### PR TITLE
feat: adds example structure for api intergration departure

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@types/node": "20.6.2",
     "@types/react": "18.2.21",
     "@types/react-dom": "18.2.7",
+    "bunyan": "^1.8.15",
     "cookies-next": "^4.0.0",
     "date-fns": "^2.30.0",
     "detect-nearest-browser-locale": "^19.0.0",
@@ -25,7 +26,9 @@
     "next": "13.4.19",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "typescript": "5.2.2"
+    "typescript": "5.2.2",
+    "uuid": "^9.0.1",
+    "zod": "^3.22.2"
   },
   "devDependencies": {
     "@atb-as/generate-assets": "^9.0.0",
@@ -33,6 +36,8 @@
     "eslint": "8.49.0",
     "eslint-config-next": "13.5.1",
     "prettier": "^3.0.3",
-    "rimraf": "^5.0.1"
+    "rimraf": "^5.0.1",
+    "@types/bunyan": "^1.8.9",
+    "@types/uuid": "^9.0.4"
   }
 }

--- a/src/layouts/global-data/index.ts
+++ b/src/layouts/global-data/index.ts
@@ -1,22 +1,10 @@
-import { GlobalCookiesData, getGlobalCookies } from '@atb/modules/cookies';
-import { IncomingHttpHeaders } from 'http';
-import { GetServerSidePropsContext, GetServerSidePropsResult } from 'next';
-import { NextApiRequestCookies } from 'next/dist/server/api-utils';
+import { type GlobalCookiesData, getGlobalCookies } from '@atb/modules/cookies';
+import type { GetServerSideProps } from 'next';
+import type { GetServerSidePropsContext, GetServerSidePropsResult } from 'next';
 
 export type AllData = GlobalCookiesData;
 
 export type WithGlobalData<T> = T & AllData;
-
-async function getGlobalData(req: {
-  cookies: NextApiRequestCookies;
-  headers: IncomingHttpHeaders;
-}): Promise<AllData> {
-  return getGlobalCookies(req);
-}
-
-export type GlobalPropGetter<P extends {} = {}> = (
-  context: GetServerSidePropsContext,
-) => Promise<GetServerSidePropsResult<P>>;
 
 /**
  * Higher order function to wrap default getServerSideProps to provide default
@@ -25,12 +13,12 @@ export type GlobalPropGetter<P extends {} = {}> = (
  * Used in relation with ./layouts/default to provide with global data,
  **/
 export function withGlobalData<P extends {} = {}>(
-  propGetter?: GlobalPropGetter<P>,
+  propGetter?: GetServerSideProps<P>,
 ) {
   return async function inside(
     ctx: GetServerSidePropsContext,
   ): Promise<GetServerSidePropsResult<WithGlobalData<P>>> {
-    const initialData = await getGlobalData(ctx.req);
+    const initialData = getGlobalCookies(ctx.req);
 
     const composedProps: GetServerSidePropsResult<P> | undefined =
       await propGetter?.({

--- a/src/modules/api-client/index.ts
+++ b/src/modules/api-client/index.ts
@@ -1,0 +1,57 @@
+import type { GetServerSidePropsContext, GetServerSidePropsResult } from "next";
+import { createRequester, HttpEndpoints, type Requester } from "./utils";
+export {
+  ApplicationError,
+  logApplicationError,
+  logError,
+  genericError,
+} from "./utils";
+
+export type { Requester };
+
+export type HttpClient<U extends HttpEndpoints, T> = T & {
+  request: Requester<U>;
+};
+
+type HttpPropGetter<U extends HttpEndpoints, T, P extends {} = {}> = (
+  context: GetServerSidePropsContext & { client: HttpClient<U, T> }
+) => Promise<GetServerSidePropsResult<P>>;
+
+export function createHttpClient<T, U extends HttpEndpoints>(
+  baseUrlType: U,
+  apiFn: (request: Requester<U>) => T
+): HttpClient<U, T> {
+  const request = createRequester(baseUrlType, undefined);
+
+  return {
+    ...apiFn(request),
+    request,
+  };
+}
+
+export function createWithHttpClientDecorator<U extends HttpEndpoints, T>(
+  client: HttpClient<U, T>
+) {
+  return function handler<P extends {} = {}>(
+    propGetter: HttpPropGetter<U, T, P>
+  ) {
+    return async function inside(
+      ctx: GetServerSidePropsContext
+    ): Promise<GetServerSidePropsResult<P>> {
+      return propGetter({
+        ...ctx,
+        client,
+      });
+    };
+  };
+}
+
+// const externalGraphqlUrls = {
+//   entur: "https://api.entur.io/journey-planner/v3/graphql/",
+// } as const;
+
+// export function createGraphqlClient(
+//   baseUrlType: keyof typeof externalGraphqlUrls
+// ) {
+//   const baseUrl = externalHttpUrls[baseUrlType];
+// }

--- a/src/modules/api-client/index.ts
+++ b/src/modules/api-client/index.ts
@@ -1,11 +1,11 @@
-import type { GetServerSidePropsContext, GetServerSidePropsResult } from "next";
-import { createRequester, HttpEndpoints, type Requester } from "./utils";
+import type { GetServerSidePropsContext, GetServerSidePropsResult } from 'next';
+import { createRequester, HttpEndpoints, type Requester } from './utils';
 export {
   ApplicationError,
   logApplicationError,
   logError,
   genericError,
-} from "./utils";
+} from './utils';
 
 export type { Requester };
 
@@ -14,12 +14,12 @@ export type HttpClient<U extends HttpEndpoints, T> = T & {
 };
 
 type HttpPropGetter<U extends HttpEndpoints, T, P extends {} = {}> = (
-  context: GetServerSidePropsContext & { client: HttpClient<U, T> }
+  context: GetServerSidePropsContext & { client: HttpClient<U, T> },
 ) => Promise<GetServerSidePropsResult<P>>;
 
 export function createHttpClient<T, U extends HttpEndpoints>(
   baseUrlType: U,
-  apiFn: (request: Requester<U>) => T
+  apiFn: (request: Requester<U>) => T,
 ): HttpClient<U, T> {
   const request = createRequester(baseUrlType, undefined);
 
@@ -30,13 +30,13 @@ export function createHttpClient<T, U extends HttpEndpoints>(
 }
 
 export function createWithHttpClientDecorator<U extends HttpEndpoints, T>(
-  client: HttpClient<U, T>
+  client: HttpClient<U, T>,
 ) {
   return function handler<P extends {} = {}>(
-    propGetter: HttpPropGetter<U, T, P>
+    propGetter: HttpPropGetter<U, T, P>,
   ) {
     return async function inside(
-      ctx: GetServerSidePropsContext
+      ctx: GetServerSidePropsContext,
     ): Promise<GetServerSidePropsResult<P>> {
       return propGetter({
         ...ctx,

--- a/src/modules/api-client/utils.ts
+++ b/src/modules/api-client/utils.ts
@@ -111,7 +111,7 @@ export function resT(
 export function resD(
   res: NextApiResponse,
   code: number,
-  data: ServerErrormessage
+  data: ServerErrorMessage
 ) {
   return res.status(code).json(data);
 }
@@ -181,7 +181,7 @@ export async function throwErrorFromResponse(result: Response) {
   }
 }
 
-function mapServerToMessage(e: any): ServerErrormessage {
+function mapServerToMessage(e: any): ServerErrorMessage {
   if (typeof e === "string") {
     return { message: translation(e, e, e) };
   }
@@ -240,12 +240,12 @@ function isInternalUpstreamServerError(
 }
 
 export class ApplicationError extends Error {
-  data!: ServerErrormessage;
+  data!: ServerErrorMessage;
   status: number;
   upstreamResponse?: Response | NextApiResponse<any>;
 
   constructor(
-    error: ServerErrormessage,
+    error: ServerErrorMessage,
     status: number = 500,
     upstreamResponse?: Response | NextApiResponse<any>
   ) {

--- a/src/modules/api-client/utils.ts
+++ b/src/modules/api-client/utils.ts
@@ -116,7 +116,7 @@ export function resD(
   return res.status(code).json(data);
 }
 
-export type ServerErrormessage = {
+export type ServerErrorMessage = {
   message: TranslatedString;
 };
 

--- a/src/modules/api-client/utils.ts
+++ b/src/modules/api-client/utils.ts
@@ -2,6 +2,7 @@ import { ServerText, TranslatedString, translation } from '@atb/translations';
 import bunyan from 'bunyan';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { v4 as uuidv4 } from 'uuid';
+import { currentOrg } from '../org-data';
 
 export const logger = bunyan.createLogger({
   name: 'planner-web',
@@ -79,12 +80,14 @@ export function createRequester<T extends HttpEndpoints>(
     const baseUrl = externalHttpUrls[baseUrlKey];
     const actualUrl = `${baseUrl}${url}`;
 
+    const orgId = currentOrg;
+
     try {
       const data = await fetch(actualUrl, {
         ...init,
         headers: {
           ...init?.headers,
-          'ET-Client-Name': 'FOO',
+          'ET-Client-Name': `${orgId}-planner-web`,
           'X-Correlation-Id': correlationId ?? uuidv4(),
           Accept: 'application/json',
           'Content-Type': 'application/json',

--- a/src/modules/api-client/utils.ts
+++ b/src/modules/api-client/utils.ts
@@ -1,11 +1,11 @@
-import { ServerText, TranslatedString, translation } from "@atb/translations";
-import { NextApiRequest, NextApiResponse } from "next";
-import bunyan from "bunyan";
-import { v4 as uuidv4 } from "uuid";
+import { ServerText, TranslatedString, translation } from '@atb/translations';
+import { NextApiRequest, NextApiResponse } from 'next';
+import bunyan from 'bunyan';
+import { v4 as uuidv4 } from 'uuid';
 
 export const logger = bunyan.createLogger({
-  name: "planner-web",
-  streams: [{ stream: process.stdout, level: "info" }],
+  name: 'planner-web',
+  streams: [{ stream: process.stdout, level: 'info' }],
   serializers: {
     req: (req: Request) => {
       return {
@@ -30,7 +30,7 @@ export const logger = bunyan.createLogger({
 });
 
 export function logError(e: any) {
-  if (process.env.NODE_ENV === "development") {
+  if (process.env.NODE_ENV === 'development') {
     console.error(e);
   } else {
     logger.error(e);
@@ -40,9 +40,9 @@ export function logError(e: any) {
 export function logApplicationError(
   e: ApplicationError,
   req: Request | NextApiRequest,
-  res: Response | NextApiResponse<any>
+  res: Response | NextApiResponse<any>,
 ) {
-  if (process.env.NODE_ENV === "development") {
+  if (process.env.NODE_ENV === 'development') {
     console.error(e);
   } else {
     logger.error(
@@ -52,29 +52,29 @@ export function logApplicationError(
         req,
         err: e,
       },
-      e.message
+      e.message,
     );
   }
 }
 
 const externalHttpUrls = {
-  entur: "https://api.entur.io",
+  entur: 'https://api.entur.io',
 } as const;
 
 export type HttpEndpoints = keyof typeof externalHttpUrls;
 
 export type Requester<T extends HttpEndpoints> = (
   url: `/${string}`,
-  init?: RequestInit | undefined
+  init?: RequestInit | undefined,
 ) => Promise<Response>;
 
 export function createRequester<T extends HttpEndpoints>(
   baseUrlKey: T,
-  correlationId: string | undefined
+  correlationId: string | undefined,
 ): Requester<T> {
   return async function request(
     url: `/${string}`,
-    init?: RequestInit | undefined
+    init?: RequestInit | undefined,
   ) {
     const baseUrl = externalHttpUrls[baseUrlKey];
     const actualUrl = `${baseUrl}${url}`;
@@ -84,10 +84,10 @@ export function createRequester<T extends HttpEndpoints>(
         ...init,
         headers: {
           ...init?.headers,
-          "ET-Client-Name": "FOO",
-          "X-Correlation-Id": correlationId ?? uuidv4(),
-          Accept: "application/json",
-          "Content-Type": "application/json",
+          'ET-Client-Name': 'FOO',
+          'X-Correlation-Id': correlationId ?? uuidv4(),
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
         },
       });
 
@@ -101,7 +101,7 @@ export function createRequester<T extends HttpEndpoints>(
 export function resT(
   res: NextApiResponse,
   code: number,
-  text: TranslatedString
+  text: TranslatedString,
 ) {
   return res.status(code).json({
     message: text,
@@ -111,7 +111,7 @@ export function resT(
 export function resD(
   res: NextApiResponse,
   code: number,
-  data: ServerErrorMessage
+  data: ServerErrorMessage,
 ) {
   return res.status(code).json(data);
 }
@@ -140,7 +140,7 @@ export async function tryResult(
   req: NextApiRequest,
   res: NextApiResponse<any>,
   fn: () => Promise<void>,
-  errorMapper?: (e: ApplicationError) => ApplicationError
+  errorMapper?: (e: ApplicationError) => ApplicationError,
 ) {
   try {
     return await fn();
@@ -157,14 +157,14 @@ export async function tryResult(
 }
 
 export async function throwErrorFromResponse(result: Response) {
-  if (result.headers.get("content-type")?.includes("application/json")) {
+  if (result.headers.get('content-type')?.includes('application/json')) {
     const data = await result.json();
     throw new ApplicationError(mapServerToMessage(data), result.status, result);
-  } else if (result.headers.get("content-type")?.includes("text/html")) {
+  } else if (result.headers.get('content-type')?.includes('text/html')) {
     throw new ApplicationError(
       mapServerToMessage(result.statusText),
       result.status,
-      result
+      result,
     );
   } else {
     const data = await result.text();
@@ -174,7 +174,7 @@ export async function throwErrorFromResponse(result: Response) {
           message: ServerText.Endpoints.accessError,
         },
         result.status,
-        result
+        result,
       );
     }
     throw new ApplicationError(mapServerToMessage(data), result.status, result);
@@ -182,7 +182,7 @@ export async function throwErrorFromResponse(result: Response) {
 }
 
 function mapServerToMessage(e: any): ServerErrorMessage {
-  if (typeof e === "string") {
+  if (typeof e === 'string') {
     return { message: translation(e, e, e) };
   }
   if (!isInternalServerError(e)) {
@@ -207,7 +207,7 @@ function mapServerToMessage(e: any): ServerErrorMessage {
       message: translation(
         upstreamError.shortNorwegian,
         upstreamError.shortEnglish,
-        upstreamError.shortNorwegian
+        upstreamError.shortNorwegian,
       ),
     };
   } catch (_err) {
@@ -220,23 +220,23 @@ export function genericError() {
 }
 
 function isMessagedError(e: any): e is MessagedServerError {
-  return "message" in e;
+  return 'message' in e;
 }
 
 function isInternalServerError(e: any): e is InternalServerError {
-  return "error" in e;
+  return 'error' in e;
 }
 
 function isInternalServerErrorWithUpstream(
-  e: any
+  e: any,
 ): e is InternalServerErrorWithUpstream {
-  return "upstreamError" in e;
+  return 'upstreamError' in e;
 }
 
 function isInternalUpstreamServerError(
-  e: any
+  e: any,
 ): e is InternalUpstreamServerError {
-  return "errorCode" in e && "shortNorwegian" in e;
+  return 'errorCode' in e && 'shortNorwegian' in e;
 }
 
 export class ApplicationError extends Error {
@@ -247,7 +247,7 @@ export class ApplicationError extends Error {
   constructor(
     error: ServerErrorMessage,
     status: number = 500,
-    upstreamResponse?: Response | NextApiResponse<any>
+    upstreamResponse?: Response | NextApiResponse<any>,
   ) {
     super();
     this.data = error;

--- a/src/modules/api-client/utils.ts
+++ b/src/modules/api-client/utils.ts
@@ -1,6 +1,6 @@
 import { ServerText, TranslatedString, translation } from '@atb/translations';
-import { NextApiRequest, NextApiResponse } from 'next';
 import bunyan from 'bunyan';
+import { NextApiRequest, NextApiResponse } from 'next';
 import { v4 as uuidv4 } from 'uuid';
 
 export const logger = bunyan.createLogger({
@@ -240,7 +240,7 @@ function isInternalUpstreamServerError(
 }
 
 export class ApplicationError extends Error {
-  data!: ServerErrorMessage;
+  data: ServerErrorMessage;
   status: number;
   upstreamResponse?: Response | NextApiResponse<any>;
 

--- a/src/modules/api-client/utils.ts
+++ b/src/modules/api-client/utils.ts
@@ -1,0 +1,257 @@
+import { ServerText, TranslatedString, translation } from "@atb/translations";
+import { NextApiRequest, NextApiResponse } from "next";
+import bunyan from "bunyan";
+import { v4 as uuidv4 } from "uuid";
+
+export const logger = bunyan.createLogger({
+  name: "planner-web",
+  streams: [{ stream: process.stdout, level: "info" }],
+  serializers: {
+    req: (req: Request) => {
+      return {
+        method: req.method,
+        url: req.url,
+        headers: {
+          ...req.headers,
+          cookie: null,
+        },
+      };
+    },
+    res: bunyan.stdSerializers.res,
+    upstream: (up: Response) => {
+      return {
+        statusCode: up.status,
+        url: up.url,
+        statusText: up.statusText,
+      };
+    },
+    err: bunyan.stdSerializers.err,
+  },
+});
+
+export function logError(e: any) {
+  if (process.env.NODE_ENV === "development") {
+    console.error(e);
+  } else {
+    logger.error(e);
+  }
+}
+
+export function logApplicationError(
+  e: ApplicationError,
+  req: Request | NextApiRequest,
+  res: Response | NextApiResponse<any>
+) {
+  if (process.env.NODE_ENV === "development") {
+    console.error(e);
+  } else {
+    logger.error(
+      {
+        upstream: e.upstreamResponse,
+        res,
+        req,
+        err: e,
+      },
+      e.message
+    );
+  }
+}
+
+const externalHttpUrls = {
+  entur: "https://api.entur.io",
+} as const;
+
+export type HttpEndpoints = keyof typeof externalHttpUrls;
+
+export type Requester<T extends HttpEndpoints> = (
+  url: `/${string}`,
+  init?: RequestInit | undefined
+) => Promise<Response>;
+
+export function createRequester<T extends HttpEndpoints>(
+  baseUrlKey: T,
+  correlationId: string | undefined
+): Requester<T> {
+  return async function request(
+    url: `/${string}`,
+    init?: RequestInit | undefined
+  ) {
+    const baseUrl = externalHttpUrls[baseUrlKey];
+    const actualUrl = `${baseUrl}${url}`;
+
+    try {
+      const data = await fetch(actualUrl, {
+        ...init,
+        headers: {
+          ...init?.headers,
+          "ET-Client-Name": "FOO",
+          "X-Correlation-Id": correlationId ?? uuidv4(),
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+      });
+
+      return data;
+    } catch (e) {
+      throw new ApplicationError(mapServerToMessage(e), 500);
+    }
+  };
+}
+
+export function resT(
+  res: NextApiResponse,
+  code: number,
+  text: TranslatedString
+) {
+  return res.status(code).json({
+    message: text,
+  });
+}
+
+export function resD(
+  res: NextApiResponse,
+  code: number,
+  data: ServerErrormessage
+) {
+  return res.status(code).json(data);
+}
+
+export type ServerErrormessage = {
+  message: TranslatedString;
+};
+
+type InternalServerError = {
+  error: string;
+};
+type MessagedServerError = {
+  message: string;
+};
+type InternalServerErrorWithUpstream = InternalServerError & {
+  upstreamError: string;
+};
+
+type InternalUpstreamServerError = {
+  errorCode: 602;
+  shortNorwegian: string;
+  shortEnglish: string;
+};
+
+export async function tryResult(
+  req: NextApiRequest,
+  res: NextApiResponse<any>,
+  fn: () => Promise<void>,
+  errorMapper?: (e: ApplicationError) => ApplicationError
+) {
+  try {
+    return await fn();
+  } catch (e) {
+    if (e instanceof ApplicationError) {
+      const properError = errorMapper?.(e) ?? e;
+      logApplicationError(properError, req, res);
+      return resD(res, properError.status, properError.data);
+    } else {
+      logError(e);
+      return resT(res, 500, ServerText.Endpoints.serverError);
+    }
+  }
+}
+
+export async function throwErrorFromResponse(result: Response) {
+  if (result.headers.get("content-type")?.includes("application/json")) {
+    const data = await result.json();
+    throw new ApplicationError(mapServerToMessage(data), result.status, result);
+  } else if (result.headers.get("content-type")?.includes("text/html")) {
+    throw new ApplicationError(
+      mapServerToMessage(result.statusText),
+      result.status,
+      result
+    );
+  } else {
+    const data = await result.text();
+    if (result.status === 401) {
+      throw new ApplicationError(
+        {
+          message: ServerText.Endpoints.accessError,
+        },
+        result.status,
+        result
+      );
+    }
+    throw new ApplicationError(mapServerToMessage(data), result.status, result);
+  }
+}
+
+function mapServerToMessage(e: any): ServerErrormessage {
+  if (typeof e === "string") {
+    return { message: translation(e, e, e) };
+  }
+  if (!isInternalServerError(e)) {
+    return { message: ServerText.Endpoints.serverError };
+  }
+  if (isMessagedError(e)) {
+    return { message: translation(e.message, e.message, e.message) };
+  }
+
+  const defaultError = { message: translation(e.error, e.error, e.error) };
+  if (!isInternalServerErrorWithUpstream(e)) {
+    return defaultError;
+  }
+
+  try {
+    const upstreamError = JSON.parse(e.upstreamError);
+    if (!isInternalUpstreamServerError(upstreamError)) {
+      return defaultError;
+    }
+
+    return {
+      message: translation(
+        upstreamError.shortNorwegian,
+        upstreamError.shortEnglish,
+        upstreamError.shortNorwegian
+      ),
+    };
+  } catch (_err) {
+    return defaultError;
+  }
+}
+
+export function genericError() {
+  return new ApplicationError({ message: ServerText.Endpoints.serverError });
+}
+
+function isMessagedError(e: any): e is MessagedServerError {
+  return "message" in e;
+}
+
+function isInternalServerError(e: any): e is InternalServerError {
+  return "error" in e;
+}
+
+function isInternalServerErrorWithUpstream(
+  e: any
+): e is InternalServerErrorWithUpstream {
+  return "upstreamError" in e;
+}
+
+function isInternalUpstreamServerError(
+  e: any
+): e is InternalUpstreamServerError {
+  return "errorCode" in e && "shortNorwegian" in e;
+}
+
+export class ApplicationError extends Error {
+  data!: ServerErrormessage;
+  status: number;
+  upstreamResponse?: Response | NextApiResponse<any>;
+
+  constructor(
+    error: ServerErrormessage,
+    status: number = 500,
+    upstreamResponse?: Response | NextApiResponse<any>
+  ) {
+    super();
+    this.data = error;
+    this.status = status;
+    this.upstreamResponse = upstreamResponse;
+  }
+}

--- a/src/page-modules/departures/api/autocomplete/encoders.ts
+++ b/src/page-modules/departures/api/autocomplete/encoders.ts
@@ -1,0 +1,75 @@
+import { z } from "zod";
+
+export const langSchema = z.object({
+  name: z.string(),
+  iso6391: z.string(),
+  iso6393: z.string(),
+  defaulted: z.boolean(),
+});
+
+export const engineSchema = z.object({
+  name: z.string(),
+  author: z.string(),
+  version: z.string(),
+});
+
+export const geometrySchema = z.object({
+  type: z.string(),
+  coordinates: z.array(z.number()),
+});
+
+export const propertiesSchema = z.object({
+  id: z.string(),
+  gid: z.string(),
+  layer: z.string(),
+  source: z.string(),
+  source_id: z.string(),
+  name: z.string(),
+  street: z.string().optional(),
+  accuracy: z.string(),
+  country_a: z.string(),
+  county: z.string(),
+  county_gid: z.string(),
+  locality: z.string(),
+  locality_gid: z.string(),
+  borough: z.string().optional(),
+  borough_gid: z.string().optional(),
+  label: z.string(),
+  category: z.array(z.string()),
+  tariff_zones: z.array(z.string()).optional(),
+});
+
+export const querySchema = z.object({
+  text: z.string(),
+  parser: z.string(),
+  tokens: z.array(z.string()),
+  size: z.number(),
+  layers: z.array(z.string()),
+  sources: z.array(z.string()),
+  private: z.boolean(),
+  lang: langSchema,
+  querySize: z.number(),
+});
+
+export const featureSchema = z.object({
+  type: z.string(),
+  geometry: geometrySchema,
+  properties: propertiesSchema,
+});
+
+export const geocodingSchema = z.object({
+  version: z.string(),
+  attribution: z.string(),
+  query: querySchema,
+  engine: engineSchema,
+  timestamp: z.number(),
+});
+
+export const autocompleteRootSchema = z.object({
+  geocoding: geocodingSchema,
+  type: z.string(),
+  features: z.array(featureSchema),
+  bbox: z.array(z.number()),
+});
+
+export type AutocompleteRoot = z.infer<typeof autocompleteRootSchema>;

--- a/src/page-modules/departures/api/autocomplete/encoders.ts
+++ b/src/page-modules/departures/api/autocomplete/encoders.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from 'zod';
 
 export const langSchema = z.object({
   name: z.string(),

--- a/src/page-modules/departures/api/autocomplete/index.ts
+++ b/src/page-modules/departures/api/autocomplete/index.ts
@@ -1,0 +1,34 @@
+import { type Requester, genericError } from "@atb/modules/api-client";
+import { autocompleteRootSchema } from "./encoders";
+
+export type AutocompleteFeature = {
+  name: string;
+};
+
+export type AutocompleteApi = {
+  autocomplete(query: string): Promise<AutocompleteFeature[]>;
+};
+
+export function createAutocompleteApi(
+  request: Requester<"entur">
+): AutocompleteApi {
+  const client: AutocompleteApi = {
+    async autocomplete(query) {
+      const result = await request(
+        `/geocoder/v1/autocomplete?text=${query}&size=20&lang=no`
+      );
+
+      const parsed = autocompleteRootSchema.safeParse(await result.json());
+
+      if (!parsed.success) {
+        throw genericError();
+      }
+
+      return parsed.data.features.map((f) => ({
+        name: f.properties.name,
+      }));
+    },
+  };
+
+  return client;
+}

--- a/src/page-modules/departures/api/autocomplete/index.ts
+++ b/src/page-modules/departures/api/autocomplete/index.ts
@@ -1,5 +1,5 @@
-import { type Requester, genericError } from "@atb/modules/api-client";
-import { autocompleteRootSchema } from "./encoders";
+import { type Requester, genericError } from '@atb/modules/api-client';
+import { autocompleteRootSchema } from './encoders';
 
 export type AutocompleteFeature = {
   name: string;
@@ -10,12 +10,12 @@ export type AutocompleteApi = {
 };
 
 export function createAutocompleteApi(
-  request: Requester<"entur">
+  request: Requester<'entur'>,
 ): AutocompleteApi {
   const client: AutocompleteApi = {
     async autocomplete(query) {
       const result = await request(
-        `/geocoder/v1/autocomplete?text=${query}&size=20&lang=no`
+        `/geocoder/v1/autocomplete?text=${query}&size=20&lang=no`,
       );
 
       const parsed = autocompleteRootSchema.safeParse(await result.json());

--- a/src/page-modules/departures/api/index.ts
+++ b/src/page-modules/departures/api/index.ts
@@ -1,12 +1,12 @@
 import {
   createHttpClient,
   createWithHttpClientDecorator,
-} from "@atb/modules/api-client";
-import { createAutocompleteApi } from "./autocomplete";
+} from '@atb/modules/api-client';
+import { createAutocompleteApi } from './autocomplete';
 
-export type { AutocompleteFeature } from "./autocomplete";
+export type { AutocompleteFeature } from './autocomplete';
 
-export const departureClient = createHttpClient("entur", createAutocompleteApi);
+export const departureClient = createHttpClient('entur', createAutocompleteApi);
 
 export const withDepartureClient =
   createWithHttpClientDecorator(departureClient);

--- a/src/page-modules/departures/api/index.ts
+++ b/src/page-modules/departures/api/index.ts
@@ -5,6 +5,7 @@ import {
 import { createAutocompleteApi } from "./autocomplete";
 
 export type { AutocompleteFeature } from "./autocomplete";
+
 export const departureClient = createHttpClient("entur", createAutocompleteApi);
 
 export const withDepartureClient =

--- a/src/page-modules/departures/api/index.ts
+++ b/src/page-modules/departures/api/index.ts
@@ -1,0 +1,11 @@
+import {
+  createHttpClient,
+  createWithHttpClientDecorator,
+} from "@atb/modules/api-client";
+import { createAutocompleteApi } from "./autocomplete";
+
+export type { AutocompleteFeature } from "./autocomplete";
+export const departureClient = createHttpClient("entur", createAutocompleteApi);
+
+export const withDepartureClient =
+  createWithHttpClientDecorator(departureClient);

--- a/src/page-modules/departures/index.ts
+++ b/src/page-modules/departures/index.ts
@@ -1,0 +1,2 @@
+export { withDepartureClient } from "./api";
+export type { AutocompleteFeature } from "./api";

--- a/src/page-modules/departures/index.ts
+++ b/src/page-modules/departures/index.ts
@@ -1,2 +1,2 @@
-export { withDepartureClient } from "./api";
-export type { AutocompleteFeature } from "./api";
+export { withDepartureClient } from './api';
+export type { AutocompleteFeature } from './api';

--- a/src/pages/departures.tsx
+++ b/src/pages/departures.tsx
@@ -1,0 +1,47 @@
+import DefaultLayout from "@atb/layouts/default";
+import { withGlobalData } from "@atb/layouts/global-data";
+import { withDepartureClient } from "@atb/page-modules/departures";
+import { CommonText, useTranslation } from "@atb/translations";
+import type { WithGlobalData } from "@atb/layouts/global-data";
+import type { AutocompleteFeature } from "@atb/page-modules/departures";
+import type { NextPage } from "next";
+
+type DeparturesContentProps = {
+  autocompleteFeatures: AutocompleteFeature[];
+};
+
+function DeparturesContent({ autocompleteFeatures }: DeparturesContentProps) {
+  const { t } = useTranslation();
+  return (
+    <div>
+      <h1>{t(CommonText.Titles.siteTitle)}</h1>
+
+      {autocompleteFeatures.map((f) => (
+        <div>{f.name}</div>
+      ))}
+    </div>
+  );
+}
+
+type DeparturesProps = WithGlobalData<DeparturesContentProps>;
+const Departures: NextPage<DeparturesProps> = (props) => {
+  return (
+    <DefaultLayout {...props}>
+      <DeparturesContent {...props} />
+    </DefaultLayout>
+  );
+};
+
+export default Departures;
+
+export const getServerSideProps = withGlobalData<DeparturesContentProps>(
+  withDepartureClient(async function ({ client }) {
+    const result = await client.autocomplete("Kongens gate");
+
+    return {
+      props: {
+        autocompleteFeatures: result,
+      },
+    };
+  })
+);

--- a/src/pages/departures.tsx
+++ b/src/pages/departures.tsx
@@ -1,10 +1,10 @@
-import DefaultLayout from "@atb/layouts/default";
-import { withGlobalData } from "@atb/layouts/global-data";
-import { withDepartureClient } from "@atb/page-modules/departures";
-import { CommonText, useTranslation } from "@atb/translations";
-import type { WithGlobalData } from "@atb/layouts/global-data";
-import type { AutocompleteFeature } from "@atb/page-modules/departures";
-import type { NextPage } from "next";
+import DefaultLayout from '@atb/layouts/default';
+import { withGlobalData } from '@atb/layouts/global-data';
+import { withDepartureClient } from '@atb/page-modules/departures';
+import { CommonText, useTranslation } from '@atb/translations';
+import type { WithGlobalData } from '@atb/layouts/global-data';
+import type { AutocompleteFeature } from '@atb/page-modules/departures';
+import type { NextPage } from 'next';
 
 type DeparturesContentProps = {
   autocompleteFeatures: AutocompleteFeature[];
@@ -36,12 +36,12 @@ export default Departures;
 
 export const getServerSideProps = withGlobalData<DeparturesContentProps>(
   withDepartureClient(async function ({ client }) {
-    const result = await client.autocomplete("Kongens gate");
+    const result = await client.autocomplete('Kongens gate');
 
     return {
       props: {
         autocompleteFeatures: result,
       },
     };
-  })
+  }),
 );

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -14,3 +14,4 @@ export {
 } from './language-context';
 
 export * as CommonText from './common';
+export * as ServerText from './server';

--- a/src/translations/server/endpoints.ts
+++ b/src/translations/server/endpoints.ts
@@ -1,0 +1,290 @@
+import {translation as _} from '@atb/translations/commons';
+import {orgSpecificTranslations} from '../utils';
+
+const EndpointsInternal = {
+  empty: _('', '', ''),
+
+  rateLimit: _(
+    'For mange forsøk. Prøv igjen senere.',
+    'Rate limit exceeded.',
+    'For mange forsøk. Prøv igjen seinare.',
+  ),
+  serverError: _(
+    'Ukjent feil med tjenesten.',
+    'Internal server error.',
+    'Ukjend feil med tenesta.',
+  ),
+  serverErrorGeneric: (err: string) => _(err, err, err),
+  accessError: _(
+    'Du har ikke tilgang. Prøv å logge inn på nytt.',
+    "You don't have the necessary access. Try logging in again",
+    'Du har ikkje tilgang. Prøv å logge inn på nytt.',
+  ),
+  invalidMethod: _(
+    'Ugyldig forespørsel.',
+    'Invalid method.',
+    'Ugyldig førespurnad.',
+  ),
+  invalidData: _('Ugyldig data.', 'Invalid data.', 'Ugyldig data.'),
+  decodeError: _(
+    'Kunne ikke hente ut data.',
+    'Could not decode received data.',
+    'Kunne ikkje hente ut data.',
+  ),
+  recurringPayment: {
+    missingId: _(
+      'Mangler betalingsid.',
+      'Missing payment id.',
+      'Manglar betalingsid.',
+    ),
+  },
+  behalfOfOthers: {
+    register: {
+      missingAlias: _('Mangler navn.', 'Missing alias.', 'Manglar namn.'),
+      success: (alias: string) =>
+        _(
+          `${alias} ble opprettet.`,
+          `${alias} was created.`,
+          `${alias} blei oppretta.`,
+        ),
+    },
+    updatedAlias: _(
+      'Kallenavn oppdatert.',
+      'Nickname updated.',
+      'Kallenavn oppdatert.',
+    ),
+    deletedAccount: _('Person slettet.', 'Person deleted.', 'Person sletta.'),
+    missingId: _(
+      'Mangler bruker id.',
+      'Missing user id.',
+      'Manglar id for brukar.',
+    ),
+    missingAccount: _('Feil konto.', 'Wrong account.', 'Feil konto.'),
+
+    serverErrors: {
+      aliasExists: _(
+        'Du har alt en person med det kallenavnet.',
+        'Person with the alias already exists',
+        'Du har allereie ein person med det kallenamnet.',
+      ),
+      travelCardExists: _(
+        't:kortet er registert hos noen andre.',
+        't:card is already registered to another account.',
+        't:kortet er registert hos nokon andre.',
+      ),
+    },
+  },
+  serverErrors: {
+    travelCardExists: _(
+      't:kortet er registert hos noen andre.',
+      't:card is already registered to another account.',
+      't:kortet er registert hos nokon andre.',
+    ),
+  },
+  travelCard: {
+    missingId: _(
+      'Mangler t:kort nummer.',
+      'Missing t:card number.',
+      'Manglar t:kort nummer.',
+    ),
+    successAdd: _('Lagt til t:kort.', 't:card added.', 'Lagt til t:kort.'),
+    successRemove: _(
+      'Fjernet t:kort.',
+      't:card successfully removed.',
+      'Fjerna t:kort.',
+    ),
+    blocked: _(
+      'Reisekort er blokkert.',
+      'Travelcard is blocked.',
+      'Reisekort er blokkert.',
+    ),
+    notExist: _(
+      'Reisekort finnes ikke.',
+      'Travelcard does not exist.',
+      'Reisekort finst ikkje.',
+    ),
+    couldNotValidate: _(
+      'Kunne ikke validere reisekort.',
+      'Could not validate travelcard.',
+      'Kunne ikkje validere reisekort.',
+    ),
+  },
+  consents: {
+    missingConsent: _(
+      'Ugyldig forespørsel, ikke sendt med samtykke.',
+      'Not a valid request, missing consent.',
+      'Ugyldig førespurnad, ikkje sendt med samtykke.',
+    ),
+    missingEmail: _(
+      'Du har ikke satt en e-post på profilen din.',
+      'You need to specify e-mail in profile settings.',
+      'Du har ikkje sett ein e-post på profilen din.',
+    ),
+    success: _(
+      'Oppdatert samtykker.',
+      'Consents updated.',
+      'Oppdaterte samtykker.',
+    ),
+  },
+  searchOffer: {
+    missingData: _(
+      'Mangler informasjon i forespørselen.',
+      'Missing information in request.',
+      'Manglar informasjon i førespurnaden.',
+    ),
+    missingStopPlaces: _(
+      'Du må velge fra- og til-holdeplass.',
+      'You have to select a from stop and a to stop.',
+      'Du må velje frå- og til-holdeplass.',
+    ),
+    missingFromStopPlaces: _(
+      'Du må velge fra-holdeplass.',
+      'You have to select a from stop.',
+      'Du må velje frå-holdeplass.',
+    ),
+    missingToStopPlace: _(
+      'Du må velge til-holdeplass.',
+      'You have to select a to stop.',
+      'Du må velje til-holdeplass.',
+    ),
+    travelDateIsNotNextMorning: (timestamp: string) =>
+      _(
+        `Starttidspunkt kan tidligst være klokken ${timestamp} neste dag.`,
+        `Validity start cannot be earlier than ${timestamp} AM the following day.`,
+        `Starttidspunkt kan tidlegast vere klokka ${timestamp} neste dag.`,
+      ),
+  },
+  reserve: {
+    missingData: _(
+      'Mangler informasjon i forespørselen.',
+      'Missing information in request.',
+      'Manglar informasjon i førespurnaden.',
+    ),
+  },
+  sendReceipt: {
+    missingEmail: _(
+      'Du har ikke satt en e-post på profilen din.',
+      'You need to specify e-mail in profile settings.',
+      'Du har ikkje sett ein e-post på profilen din.',
+    ),
+    missingOrderData: _(
+      'Fant ikke billett du spør etter.',
+      'Could not find ticket.',
+      'Fann ikkje billett du spør etter.',
+    ),
+    success: _(
+      'Kvittering sendt til din e-post.',
+      'Receipt sent to your e-mail.',
+      'Kvittering sendt til din e-post.',
+    ),
+  },
+  updateProfile: {
+    missingProfileData: _(
+      'Mangelfull data sendt til oppdatering.',
+      'Invalid profile data.',
+      'Mangelfull data sendt til oppdatering.',
+    ),
+    success: _('Oppdatert profil.', 'Updated profile.', 'Oppdatert profil.'),
+  },
+  registerProfile: {
+    success: _('Opprettet profil.', 'Created profile.', 'Oppretta profil.'),
+  },
+};
+
+export const Endpoints = orgSpecificTranslations(EndpointsInternal, {
+  nfk: {
+    serverErrors: {
+      travelCardExists: _(
+        'Reisekortet er registert hos noen andre.',
+        'Travelcard is already registered to another account.',
+        'Reisekortet er registrert hos nokon andre.',
+      ),
+    },
+    behalfOfOthers: {
+      serverErrors: {
+        travelCardExists: _(
+          'Reisekortet er registert hos noen andre.',
+          'Travelcard is already registered to another account.',
+          'Reisekortet er registrert hos nokon andre.',
+        ),
+      },
+    },
+    travelCard: {
+      missingId: _(
+        'Mangler reisekort nummer.',
+        'Missing travelcard number.',
+        'Manglar reisekortnummer.',
+      ),
+      successAdd: _(
+        'Lagt til reisekort.',
+        'Travelcard added.',
+        'Reisekort lagt til.',
+      ),
+      successRemove: _(
+        'Fjernet reisekort.',
+        'Travelcard successfully removed.',
+        'Fjerna reisekort.',
+      ),
+    },
+  },
+  fram: {
+    serverErrors: {
+      travelCardExists: _(
+        'Reisekortet er registert hos noen andre.',
+        'Travelcard is already registered to another account.',
+        'Reisekortet er registrert hos nokon andre.',
+      ),
+    },
+    behalfOfOthers: {
+      serverErrors: {
+        travelCardExists: _(
+          'Reisekortet er registert hos noen andre.',
+          'Travelcard is already registered to another account.',
+          'Reisekortet er registrert hos nokon andre.',
+        ),
+      },
+    },
+    travelCard: {
+      missingId: _(
+        'Mangler reisekort nummer.',
+        'Missing travelcard number.',
+        'Manglar reisekortnummer.',
+      ),
+      successAdd: _(
+        'Lagt til reisekort.',
+        'Travelcard added.',
+        'Reisekort lagt til.',
+      ),
+      successRemove: _(
+        'Fjernet reisekort.',
+        'Travelcard successfully removed.',
+        'Fjerna reisekort.',
+      ),
+    },
+    consents: {
+      missingEmail: _(
+        'Du har ikke satt en e-post på brukeren din.',
+        'You need to specify e-mail in user settings.',
+        'Du har ikkje sett ein e-post på brukaren din.',
+      ),
+    },
+    updateProfile: {
+      missingProfileData: _(
+        'Mangelfull data sendt til oppdatering.',
+        'Invalid user data.',
+        'Mangelfull data sendt til oppdatering.',
+      ),
+      success: _('Oppdatert bruker.', 'Updated user.', 'Oppdatert brukar.'),
+    },
+    sendReceipt: {
+      missingEmail: _(
+        'Du har ikke satt en e-post på brukeren din.',
+        'You need to specify e-mail in user settings.',
+        'Du har ikkje sett ein e-post på brukaren din.',
+      ),
+    },
+    registerProfile: {
+      success: _('Opprettet bruker.', 'Created user.', 'Oppretta brukar.'),
+    },
+  },
+});

--- a/src/translations/server/endpoints.ts
+++ b/src/translations/server/endpoints.ts
@@ -1,5 +1,5 @@
-import {translation as _} from '@atb/translations/commons';
-import {orgSpecificTranslations} from '../utils';
+import { translation as _ } from '@atb/translations/commons';
+import { orgSpecificTranslations } from '../utils';
 
 const EndpointsInternal = {
   empty: _('', '', ''),

--- a/src/translations/server/index.ts
+++ b/src/translations/server/index.ts
@@ -1,0 +1,1 @@
+export {Endpoints} from './endpoints';

--- a/src/translations/server/index.ts
+++ b/src/translations/server/index.ts
@@ -1,1 +1,1 @@
-export {Endpoints} from './endpoints';
+export { Endpoints } from './endpoints';

--- a/yarn.lock
+++ b/yarn.lock
@@ -197,6 +197,13 @@
   dependencies:
     tslib "^2.4.0"
 
+"@types/bunyan@^1.8.9":
+  version "1.8.9"
+  resolved "https://registry.yarnpkg.com/@types/bunyan/-/bunyan-1.8.9.tgz#22d4517f3217b7c8f5a69bbc8c9f6df79779dcb5"
+  integrity sha512-ZqS9JGpBxVOvsawzmVt30sP++gSQMTejCkIAQ3VdadOcRE8izTyW66hufvwLeH+YEGP6Js2AW7Gz+RMyvrEbmw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/cookie@^0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
@@ -211,6 +218,11 @@
   version "4.14.198"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.198.tgz#4d27465257011aedc741a809f1269941fa2c5d4c"
   integrity sha512-trNJ/vtMZYMLhfN45uLq4ShQSw0/S7xCTLLVM+WM1rmFpba/VS42jVUgaO3w/NOLiWR/09lnYk0yMaA/atdIsg==
+
+"@types/node@*":
+  version "20.6.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.6.3.tgz#5b763b321cd3b80f6b8dde7a37e1a77ff9358dd9"
+  integrity sha512-HksnYH4Ljr4VQgEy2lTStbCKv/P590tmPe5HqOnv9Gprffgv5WXAY+Y5Gqniu0GGqeTCUdBnzC3QSrzPkBkAMA==
 
 "@types/node@20.6.2":
   version "20.6.2"
@@ -247,6 +259,11 @@
   version "0.16.3"
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.3.tgz#cef09e3ec9af1d63d2a6cc5b383a737e24e6dcf5"
   integrity sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==
+
+"@types/uuid@^9.0.4":
+  version "9.0.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.4.tgz#e884a59338da907bda8d2ed03e01c5c49d036f1c"
+  integrity sha512-zAuJWQflfx6dYJM62vna+Sn5aeSWhh3OB+wfUEACNcqUSc0AGc5JKl+ycL1vrH7frGTXhJchYjE1Hak8L819dA==
 
 "@typescript-eslint/parser@^5.4.2 || ^6.0.0":
   version "6.7.2"
@@ -482,6 +499,16 @@ braces@^3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
+bunyan@^1.8.15:
+  version "1.8.15"
+  resolved "https://registry.yarnpkg.com/bunyan/-/bunyan-1.8.15.tgz#8ce34ca908a17d0776576ca1b2f6cbd916e93b46"
+  integrity sha512-0tECWShh6wUysgucJcBAoYegf3JJoZWibxdqhTm7OHPeT42qdjkZ29QCMcKwbgU1kiH+auSIasNRXMLWXafXig==
+  optionalDependencies:
+    dtrace-provider "~0.8"
+    moment "^2.19.3"
+    mv "~2"
+    safe-json-stringify "~1"
+
 busboy@1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/busboy/-/busboy-1.6.0.tgz#966ea36a9502e43cdb9146962523b92f531f6893"
@@ -656,6 +683,13 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dtrace-provider@~0.8:
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/dtrace-provider/-/dtrace-provider-0.8.8.tgz#2996d5490c37e1347be263b423ed7b297fb0d97e"
+  integrity sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==
+  dependencies:
+    nan "^2.14.0"
 
 eastasianwidth@^0.2.0:
   version "0.2.0"
@@ -1156,6 +1190,17 @@ glob@^10.2.5:
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
     path-scurry "^1.10.1"
 
+glob@^6.0.1:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
+  integrity sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "2 || 3"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 glob@^7.1.3:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
@@ -1616,7 +1661,7 @@ micromatch@^4.0.4, micromatch@^4.0.5:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
-minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
+"minimatch@2 || 3", minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
@@ -1640,6 +1685,18 @@ minimist@^1.2.0, minimist@^1.2.6:
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.0.3.tgz#05ea638da44e475037ed94d1c7efcc76a25e1974"
   integrity sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg==
 
+mkdirp@~0.5.1:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
+  integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
+  dependencies:
+    minimist "^1.2.6"
+
+moment@^2.19.3:
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
+
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
@@ -1650,6 +1707,20 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+mv@~2:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/mv/-/mv-2.1.1.tgz#ae6ce0d6f6d5e0a4f7d893798d03c1ea9559b6a2"
+  integrity sha512-at/ZndSy3xEGJ8i0ygALh8ru9qy7gWW1cmkaqBN29JmMlIvM//MEO9y1sk/avxuwnPcfhkejkLsuPxH81BrkSg==
+  dependencies:
+    mkdirp "~0.5.1"
+    ncp "~2.0.0"
+    rimraf "~2.4.0"
+
+nan@^2.14.0:
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.18.0.tgz#26a6faae7ffbeb293a39660e88a76b82e30b7554"
+  integrity sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==
+
 nanoid@^3.3.4:
   version "3.3.6"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
@@ -1659,6 +1730,11 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
+
+ncp@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
+  integrity sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==
 
 next@13.4.19:
   version "13.4.19"
@@ -1973,6 +2049,13 @@ rimraf@^5.0.1:
   dependencies:
     glob "^10.2.5"
 
+rimraf@~2.4.0:
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.4.5.tgz#ee710ce5d93a8fdb856fb5ea8ff0e2d75934b2da"
+  integrity sha512-J5xnxTyqaiw06JjMftq7L9ouA448dw/E7dKghkP9WpKNuwmARNNg+Gk8/u5ryb9N/Yo2+z3MCwuqFK/+qPOPfQ==
+  dependencies:
+    glob "^6.0.1"
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -1989,6 +2072,11 @@ safe-array-concat@^1.0.1:
     get-intrinsic "^1.2.1"
     has-symbols "^1.0.3"
     isarray "^2.0.5"
+
+safe-json-stringify@~1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz#356e44bc98f1f93ce45df14bcd7c01cda86e0afd"
+  integrity sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==
 
 safe-regex-test@^1.0.0:
   version "1.0.0"
@@ -2293,6 +2381,11 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+uuid@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
+  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
+
 watchpack@2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.4.0.tgz#fa33032374962c78113f93c7f2fb4c54c9862a5d"
@@ -2395,3 +2488,8 @@ zod@3.21.4:
   version "3.21.4"
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.21.4.tgz#10882231d992519f0a10b5dd58a38c9dabbb64db"
   integrity sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==
+
+zod@^3.22.2:
+  version "3.22.2"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.2.tgz#3add8c682b7077c05ac6f979fea6998b573e157b"
+  integrity sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==


### PR DESCRIPTION
Adding fundamental structure for how to integrate and get server data for pages and starting to establish overall architecture for modules.

Open for feedback on this. Somethings might seem more advanced types and structure, but trying to clean up consumption API for pages

![Untitled-2023-02-06-1529](https://github.com/AtB-AS/planner-web/assets/606374/54ee3fdb-decd-4ecc-8e75-6c16723a0829)

## For later PRs

- [ ] Add documentation in text form that explains how it all is connected.
- [ ] Add example of client side APIs
