### PR TITLE
refactor: adds ability to support multiple http methods for endpoints

### DIFF
--- a/src/pages/api/departures/autocomplete.ts
+++ b/src/pages/api/departures/autocomplete.ts
@@ -5,18 +5,8 @@ import { ServerText } from '@atb/translations';
 import { constants } from 'http2';
 import { z } from 'zod';
 
-export default handlerWithDepartureClient<AutocompleteApiReturnType>(
-  async (req, res, { client, ok }) => {
-    // Only allow GET handlers
-    // @TODO extend to "modern" handler (GET function in object).
-    if (req.method !== 'GET') {
-      return errorResultAsJson(
-        res,
-        constants.HTTP_STATUS_METHOD_NOT_ALLOWED,
-        ServerText.Endpoints.invalidMethod,
-      );
-    }
-
+export default handlerWithDepartureClient<AutocompleteApiReturnType>({
+  async GET(req, res, { client, ok }) {
     // Validate input as string
     const query = z.string().safeParse(req.query.q);
     if (!query.success) {
@@ -31,4 +21,4 @@ export default handlerWithDepartureClient<AutocompleteApiReturnType>(
       return ok(await client.autocomplete(String(query.data)));
     });
   },
-);
+});


### PR DESCRIPTION
Changes to be able to use:

```ts
export default handlerWithDepartureClient<AutocompleteApiReturnType>({
  async GET(req, res, { client, ok }) { },
  async POST(req, res, { client, ok }) { },
  // ... etc
});
```

And have it automatically return invalid method if nothing is matched. Simplifies HTTP verb handling for each API endpoint.