### PR TITLE
build: add build and deployment automation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 # What ORG to activate (nfk | atb | fram)
-NEXT_PUBLIC_WEBSHOP_ORG_ID=atb
+NEXT_PUBLIC_PLANNER_ORG_ID=atb

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,7 @@ on:
   release:
     types: [published]
   push:
-    branches: ['morten/build-docker']
+    branches: ['main']
 
 jobs:
   build:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,15 @@
+name: Docker Build, Push & Deploy
+
+on:
+  release:
+    types: [published]
+  push:
+    branches: ['morten/build-docker']
+
+jobs:
+  build:
+    uses: atb-as/workflows/.github/workflows/cluster-docker-build-tag-push.yaml@v2
+    with:
+      image: gcr.io/atb-mobility-platform/planner-web
+    secrets:
+      github_pat: ${{ secrets.GH_PAT }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,5 +13,5 @@ jobs:
       - run: yarn
       - run: yarn setup
         env:
-          NEXT_PUBLIC_WEBSHOP_ORG_ID: atb
+          NEXT_PUBLIC_PLANNER_ORG_ID: atb
       - run: yarn test

--- a/.github/workflows/tsc.yml
+++ b/.github/workflows/tsc.yml
@@ -18,6 +18,6 @@ jobs:
       - run: yarn
       - run: yarn setup
         env:
-          NEXT_PUBLIC_WEBSHOP_ORG_ID: atb
+          NEXT_PUBLIC_PLANNER_ORG_ID: atb
       - run: yarn tsc
       - run: yarn lint

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 
 # production
 /build
+/dist
 
 # misc
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+# Install dependencies only when needed
+FROM node:18-alpine AS deps
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+
+COPY package.json yarn.lock* ./
+RUN yarn --frozen-lockfile
+
+# Rebuild the source code only when needed
+FROM node:18-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+ENV NEXT_TELEMETRY_DISABLED 1
+
+RUN yarn build:all
+
+# Production image, copy all the files and run next
+FROM node:18-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV production
+ENV NEXT_TELEMETRY_DISABLED 1
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+# Set the correct permission for prerender cache
+RUN mkdir dist
+RUN chown nextjs:nodejs dist
+
+COPY --from=builder --chown=nextjs:nodejs /app/dist ./dist
+COPY server.js ./
+
+USER nextjs
+
+EXPOSE 3000
+
+ENV PORT 3000
+ENV HOSTNAME "0.0.0.0"
+
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ TBA
 
 ```
 # What ORG to activate (nfk | atb | fram)
-NEXT_PUBLIC_WEBSHOP_ORG_ID=atb
+NEXT_PUBLIC_PLANNER_ORG_ID=atb
 ```

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 
-const orgId = process.env.NEXT_PUBLIC_WEBSHOP_ORG_ID;
+const orgId = process.env.NEXT_PUBLIC_PLANNER_ORG_ID;
 
 const nextConfig = {
   optimizeFonts: false,

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "next start",
     "lint": "next lint",
     "clean-assets": "rimraf ./public/assets/",
-    "setup": "generate-assets all $NEXT_PUBLIC_WEBSHOP_ORG_ID -o ./public/assets/ -ts -ts-o ./src/components/icon"
+    "setup": "generate-assets all $NEXT_PUBLIC_PLANNER_ORG_ID -o ./public/assets/ -ts -ts-o ./src/components/icon"
   },
   "dependencies": {
     "@atb-as/theme": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "vitest",
     "dev": "next dev",
     "build": "next build",
+    "build:all": "sh ./scripts/build.sh",
     "start": "next start",
     "lint": "next lint",
     "clean-assets": "rimraf ./public/assets/",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# This script prepares and organizes the application for different organizations 
+# by setting up the environment, building the application, and organizing the output 
+# into the 'dist' directory with separate subdirectories for each organization.
+
+mkdir dist
+
+for orgId in atb nfk fram; do
+  mkdir dist/$orgId
+  export NEXT_PUBLIC_PLANNER_ORG_ID=$orgId
+  echo "Running yarn setup && yarn build for $orgId"
+  yarn setup $orgId
+  yarn build
+
+  echo "Moving the output into the dist directory"
+  mv .next/standalone dist/$orgId
+  mv .next/static dist/$orgId/standalone/.next
+  cp -r public dist/$orgId/standalone
+  cp next.config.js dist/$orgId/standalone
+done

--- a/server.js
+++ b/server.js
@@ -1,0 +1,15 @@
+const orgId = process.env.NEXT_PUBLIC_PLANNER_ORG_ID || 'atb';
+
+switch (orgId) {
+  case 'atb':
+    require('./dist/atb/standalone/server.js');
+    break;
+  case 'nfk':
+    require('./dist/nfk/standalone/server.js');
+    break;
+  case 'fram':
+    require('./dist/fram/standalone/server.js');
+    break;
+  default:
+    throw new Error('Invalid org ID provided.');
+}

--- a/src/modules/org-data/index.tsx
+++ b/src/modules/org-data/index.tsx
@@ -2,7 +2,7 @@ export type WEBSHOP_ORGS = 'nfk' | 'atb' | 'fram';
 export const currentOrg = getCurrentOrg();
 
 function getCurrentOrg(): WEBSHOP_ORGS {
-  const orgId = process.env.NEXT_PUBLIC_WEBSHOP_ORG_ID;
+  const orgId = process.env.NEXT_PUBLIC_PLANNER_ORG_ID;
   switch (orgId) {
     case 'atb':
       return 'atb';
@@ -12,5 +12,5 @@ function getCurrentOrg(): WEBSHOP_ORGS {
       return 'fram';
   }
 
-  throw new Error('NEXT_PUBLIC_WEBSHOP_ORG_ID required but missing');
+  throw new Error('NEXT_PUBLIC_PLANNER_ORG_ID required but missing');
 }

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -1,0 +1,3 @@
+export default function ErrorPage() {
+  return <h1>Something went wrong...</h1>;
+}


### PR DESCRIPTION
- Temporary Error Page: 
I've added a temporary error page so that the application can be built without errors
- Rename env variable: 
I've renamed the environment variable from `NEXT_PUBLIC_WEBSHOP_ORG_ID` to `NEXT_PUBLIC_PLANNER_ORG_ID`
- Build: 
New script in the package.json file: build:all. This runs the new build.sh script that creates a standalone build for all organizations and stores it in the dist directory.
- Docker Image: 
I've added a Dockerfile that creates a single image that can be used to serve all organizations. The new server.js file now determines the decision on which organization to run.

Note: I've tested that each organization handles the assets correctly. However, the theme is not functioning as expected. It's worth noting that this issue persists even when using `yarn dev`, suggesting that the current setup is not the root cause. Please let me know if you see what is missing/wrong about the theme setup so that I can test that as well 👍 