### PR TITLE
build: specify overlays for each org

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,9 +7,30 @@ on:
     branches: ['main']
 
 jobs:
-  build:
+  build-atb:
     uses: atb-as/workflows/.github/workflows/cluster-docker-build-tag-push.yaml@v2
     with:
       image: gcr.io/atb-mobility-platform/planner-web
+      push_overlay: atb-staging-c420
+      release_overlay: atb-prod-2e7e
+      overlays_base: manifests/amp/overlays
+    secrets:
+      github_pat: ${{ secrets.GH_PAT }}
+  build-nfk:
+    uses: atb-as/workflows/.github/workflows/cluster-docker-build-tag-push.yaml@v2
+    with:
+      image: gcr.io/atb-mobility-platform/planner-web
+      push_overlay: nfk-staging-dac7
+      release_overlay: nfk-prod-ce66
+      overlays_base: manifests/amp/overlays
+    secrets:
+      github_pat: ${{ secrets.GH_PAT }}
+  build-fram:
+    uses: atb-as/workflows/.github/workflows/cluster-docker-build-tag-push.yaml@v2
+    with:
+      image: gcr.io/atb-mobility-platform/planner-web
+      push_overlay: fram-staging-dc00
+      release_overlay: fram-prod-019b
+      overlays_base: manifests/amp/overlays
     secrets:
       github_pat: ${{ secrets.GH_PAT }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,30 +7,24 @@ on:
     branches: ['main']
 
 jobs:
-  build-atb:
-    uses: atb-as/workflows/.github/workflows/cluster-docker-build-tag-push.yaml@v2
-    with:
-      image: gcr.io/atb-mobility-platform/planner-web
-      push_overlay: atb-staging-c420
-      release_overlay: atb-prod-2e7e
-      overlays_base: manifests/amp/overlays
-    secrets:
-      github_pat: ${{ secrets.GH_PAT }}
-  build-nfk:
-    uses: atb-as/workflows/.github/workflows/cluster-docker-build-tag-push.yaml@v2
-    with:
-      image: gcr.io/atb-mobility-platform/planner-web
-      push_overlay: nfk-staging-dac7
-      release_overlay: nfk-prod-ce66
-      overlays_base: manifests/amp/overlays
-    secrets:
-      github_pat: ${{ secrets.GH_PAT }}
-  build-fram:
-    uses: atb-as/workflows/.github/workflows/cluster-docker-build-tag-push.yaml@v2
-    with:
-      image: gcr.io/atb-mobility-platform/planner-web
-      push_overlay: fram-staging-dc00
-      release_overlay: fram-prod-019b
-      overlays_base: manifests/amp/overlays
-    secrets:
-      github_pat: ${{ secrets.GH_PAT }}
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - push_overlay: 'atb-staging-c420'
+            release_overlay: 'atb-prod-2e7e'
+          - push_overlay: 'nfk-staging-dac7'
+            release_overlay: 'nfk-prod-ce66'
+          - push_overlay: 'fram-staging-dc00'
+            release_overlay: 'fram-prod-019b'
+    steps:
+      - name: Build, Push and Deploy
+        uses: atb-as/workflows/.github/workflows/cluster-docker-build-tag-push.yaml@v2
+        with:
+          image: gcr.io/atb-mobility-platform/planner-web
+          push_overlay: ${{ matrix.push_overlay }}
+          release_overlay: ${{ matrix.release_overlay }}
+          overlays_base: manifests/amp/overlays
+        secrets:
+          github_pat: ${{ secrets.GH_PAT }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
@@ -18,13 +17,11 @@ jobs:
             release_overlay: 'nfk-prod-ce66'
           - push_overlay: 'fram-staging-dc00'
             release_overlay: 'fram-prod-019b'
-    steps:
-      - name: Build, Push and Deploy
-        uses: atb-as/workflows/.github/workflows/cluster-docker-build-tag-push.yaml@v2
-        with:
-          image: gcr.io/atb-mobility-platform/planner-web
-          push_overlay: ${{ matrix.push_overlay }}
-          release_overlay: ${{ matrix.release_overlay }}
-          overlays_base: manifests/amp/overlays
-        secrets:
-          github_pat: ${{ secrets.GH_PAT }}
+    uses: atb-as/workflows/.github/workflows/cluster-docker-build-tag-push.yaml@v2
+    with:
+      image: gcr.io/atb-mobility-platform/planner-web
+      push_overlay: ${{ matrix.push_overlay }}
+      release_overlay: ${{ matrix.release_overlay }}
+      overlays_base: manifests/amp/overlays
+    secrets:
+      github_pat: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
We need to specify which overlays we push to, to ensure that the system will pick up new versions. 
Ref: https://github.com/AtB-AS/gcp-infra/pull/415#pullrequestreview-1643544450
