### PR TITLE
Revert "build: specify overlays for each org (#13)"

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,20 +8,8 @@ on:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        include:
-          - push_overlay: 'atb-staging-c420'
-            release_overlay: 'atb-prod-2e7e'
-          - push_overlay: 'nfk-staging-dac7'
-            release_overlay: 'nfk-prod-ce66'
-          - push_overlay: 'fram-staging-dc00'
-            release_overlay: 'fram-prod-019b'
     uses: atb-as/workflows/.github/workflows/cluster-docker-build-tag-push.yaml@v2
     with:
       image: gcr.io/atb-mobility-platform/planner-web
-      push_overlay: ${{ matrix.push_overlay }}
-      release_overlay: ${{ matrix.release_overlay }}
-      overlays_base: manifests/amp/overlays
     secrets:
       github_pat: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
This reverts commit 17323c644475568f091d04472b0f25d61dc8ac2c. As we are pushing for all tenants at the same time I am in the process of moving the kustomization to base and we won't need to specify overlays (https://github.com/AtB-AS/gcp-infra/pull/419). 

For future references, it's not necessary to use a matrix to specify the push and release overlays. It can be done so:
```yaml
with:
      image: gcr.io/atb-mobility-platform/planner-web
      push_overlay: atb-staging-c420 nfk-staging-dac7 fram-staging-dc00
      release_overlay: atb-prod-2e7e nfk-prod-ce66 fram-prod-019b
      overlays_base: manifests/amp/overlays

```

