### PR TITLE
feat: add departure date selector

### DIFF
--- a/src/components/departure-date-selector/__tests__/departure-date-selector.test.tsx
+++ b/src/components/departure-date-selector/__tests__/departure-date-selector.test.tsx
@@ -12,13 +12,7 @@ afterEach(function () {
 
 describe('departure date selector', function () {
   it('should default to "Now"', async () => {
-    const output = render(
-      <DepartureDateSelector
-        onStateChange={() => {}}
-        onDateChange={() => {}}
-        onTimeChange={() => {}}
-      />,
-    );
+    const output = render(<DepartureDateSelector onChange={() => {}} />);
 
     expect(
       output.getByRole('radio', {
@@ -28,13 +22,7 @@ describe('departure date selector', function () {
   });
 
   it('should not show date and time selector when "Now" is selected', async () => {
-    const output = render(
-      <DepartureDateSelector
-        onStateChange={() => {}}
-        onDateChange={() => {}}
-        onTimeChange={() => {}}
-      />,
-    );
+    const output = render(<DepartureDateSelector onChange={() => {}} />);
 
     expect(output.queryByText('Dato')).not.toBeInTheDocument();
     expect(output.queryByText('Tid')).not.toBeInTheDocument();
@@ -43,10 +31,8 @@ describe('departure date selector', function () {
   it('should use initialState for default selected', async () => {
     const output = render(
       <DepartureDateSelector
-        initialState={DepartureDateState.Arrival}
-        onStateChange={() => {}}
-        onDateChange={() => {}}
-        onTimeChange={() => {}}
+        initialState={{ type: DepartureDateState.Arrival, dateTime: 0 }}
+        onChange={() => {}}
       />,
     );
 
@@ -58,10 +44,8 @@ describe('departure date selector', function () {
   it('should show date and time selector when "Arrival" is selected', async () => {
     const output = render(
       <DepartureDateSelector
-        initialState={DepartureDateState.Arrival}
-        onStateChange={() => {}}
-        onDateChange={() => {}}
-        onTimeChange={() => {}}
+        initialState={{ type: DepartureDateState.Arrival, dateTime: 0 }}
+        onChange={() => {}}
       />,
     );
 
@@ -72,10 +56,8 @@ describe('departure date selector', function () {
   it('should show date and time selector when "Departure" is selected', async () => {
     const output = render(
       <DepartureDateSelector
-        initialState={DepartureDateState.Departure}
-        onStateChange={() => {}}
-        onDateChange={() => {}}
-        onTimeChange={() => {}}
+        initialState={{ type: DepartureDateState.Departure, dateTime: 0 }}
+        onChange={() => {}}
       />,
     );
 
@@ -84,13 +66,7 @@ describe('departure date selector', function () {
   });
 
   it('should change selection with keyboard', async () => {
-    const output = render(
-      <DepartureDateSelector
-        onStateChange={() => {}}
-        onDateChange={() => {}}
-        onTimeChange={() => {}}
-      />,
-    );
+    const output = render(<DepartureDateSelector onChange={() => {}} />);
 
     const radio = output.getByRole('radio', { name: 'Nå' });
     radio.focus();
@@ -107,13 +83,7 @@ describe('departure date selector', function () {
   });
 
   it('should change selection when clicked', async () => {
-    const output = render(
-      <DepartureDateSelector
-        onStateChange={() => {}}
-        onDateChange={() => {}}
-        onTimeChange={() => {}}
-      />,
-    );
+    const output = render(<DepartureDateSelector onChange={() => {}} />);
 
     const radio = output.getByRole('radio', {
       name: 'Ankomst',
@@ -128,27 +98,19 @@ describe('departure date selector', function () {
 
   it('should call onStateChange', async () => {
     const onStateChange = vi.fn();
-    const output = render(
-      <DepartureDateSelector
-        onStateChange={onStateChange}
-        onDateChange={() => {}}
-        onTimeChange={() => {}}
-      />,
-    );
+    const output = render(<DepartureDateSelector onChange={onStateChange} />);
 
     output.getByRole('radio', { name: 'Ankomst' }).click();
 
-    expect(onStateChange).toHaveBeenCalledWith(DepartureDateState.Arrival);
+    expect(onStateChange).toHaveBeenCalled();
   });
 
   it('should call onDateChange', async () => {
-    const onDateChange = vi.fn();
+    const onChange = vi.fn();
     const output = render(
       <DepartureDateSelector
-        initialState={DepartureDateState.Arrival}
-        onStateChange={() => {}}
-        onDateChange={onDateChange}
-        onTimeChange={() => {}}
+        initialState={{ type: DepartureDateState.Arrival, dateTime: 0 }}
+        onChange={onChange}
       />,
     );
 
@@ -156,17 +118,15 @@ describe('departure date selector', function () {
 
     fireEvent.change(date, { target: { value: '2100-01-01' } });
 
-    expect(onDateChange).toHaveBeenCalledWith(new Date('2100-01-01'));
+    expect(onChange).toHaveBeenCalled();
   });
 
   it('should call onTimeChange', async () => {
-    const onTimeChange = vi.fn();
+    const onChange = vi.fn();
     const output = render(
       <DepartureDateSelector
-        initialState={DepartureDateState.Arrival}
-        onStateChange={() => {}}
-        onDateChange={() => {}}
-        onTimeChange={onTimeChange}
+        initialState={{ type: DepartureDateState.Arrival, dateTime: 0 }}
+        onChange={onChange}
       />,
     );
 
@@ -174,6 +134,6 @@ describe('departure date selector', function () {
 
     fireEvent.change(time, { target: { value: '00:00' } });
 
-    expect(onTimeChange).toHaveBeenCalledWith('00:00');
+    expect(onChange).toHaveBeenCalled();
   });
 });

--- a/src/components/departure-date-selector/__tests__/departure-date-selector.test.tsx
+++ b/src/components/departure-date-selector/__tests__/departure-date-selector.test.tsx
@@ -1,0 +1,179 @@
+import { cleanup, render, fireEvent } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import DepartureDateSelector, {
+  DepartureDateState,
+} from '@atb/components/departure-date-selector';
+import userEvent from '@testing-library/user-event';
+
+afterEach(function () {
+  cleanup();
+});
+
+describe('departure date selector', function () {
+  it('should default to "Now"', async () => {
+    const output = render(
+      <DepartureDateSelector
+        onStateChange={() => {}}
+        onDateChange={() => {}}
+        onTimeChange={() => {}}
+      />,
+    );
+
+    expect(
+      output.getByRole('radio', {
+        name: 'Nå',
+      }),
+    ).toBeChecked();
+  });
+
+  it('should not show date and time selector when "Now" is selected', async () => {
+    const output = render(
+      <DepartureDateSelector
+        onStateChange={() => {}}
+        onDateChange={() => {}}
+        onTimeChange={() => {}}
+      />,
+    );
+
+    expect(output.queryByText('Dato')).not.toBeInTheDocument();
+    expect(output.queryByText('Tid')).not.toBeInTheDocument();
+  });
+
+  it('should use initialState for default selected', async () => {
+    const output = render(
+      <DepartureDateSelector
+        initialState={DepartureDateState.Arrival}
+        onStateChange={() => {}}
+        onDateChange={() => {}}
+        onTimeChange={() => {}}
+      />,
+    );
+
+    output.getByRole('radio', {
+      name: 'Ankomst',
+    });
+  });
+
+  it('should show date and time selector when "Arrival" is selected', async () => {
+    const output = render(
+      <DepartureDateSelector
+        initialState={DepartureDateState.Arrival}
+        onStateChange={() => {}}
+        onDateChange={() => {}}
+        onTimeChange={() => {}}
+      />,
+    );
+
+    expect(output.queryByText('Dato')).toBeInTheDocument();
+    expect(output.queryByText('Tid')).toBeInTheDocument();
+  });
+
+  it('should show date and time selector when "Departure" is selected', async () => {
+    const output = render(
+      <DepartureDateSelector
+        initialState={DepartureDateState.Departure}
+        onStateChange={() => {}}
+        onDateChange={() => {}}
+        onTimeChange={() => {}}
+      />,
+    );
+
+    expect(output.queryByText('Dato')).toBeInTheDocument();
+    expect(output.queryByText('Tid')).toBeInTheDocument();
+  });
+
+  it('should change selection with keyboard', async () => {
+    const output = render(
+      <DepartureDateSelector
+        onStateChange={() => {}}
+        onDateChange={() => {}}
+        onTimeChange={() => {}}
+      />,
+    );
+
+    const radio = output.getByRole('radio', { name: 'Nå' });
+    radio.focus();
+    expect(radio).toHaveFocus();
+
+    // {ArrowRight} does not work
+    await userEvent.type(radio, '{ArrowDown}');
+
+    expect(
+      output.getByRole('radio', {
+        name: 'Ankomst',
+      }),
+    ).toBeChecked();
+  });
+
+  it('should change selection when clicked', async () => {
+    const output = render(
+      <DepartureDateSelector
+        onStateChange={() => {}}
+        onDateChange={() => {}}
+        onTimeChange={() => {}}
+      />,
+    );
+
+    const radio = output.getByRole('radio', {
+      name: 'Ankomst',
+    });
+
+    expect(radio).not.toBeChecked();
+
+    await userEvent.click(radio);
+
+    expect(radio).toBeChecked();
+  });
+
+  it('should call onStateChange', async () => {
+    const onStateChange = vi.fn();
+    const output = render(
+      <DepartureDateSelector
+        onStateChange={onStateChange}
+        onDateChange={() => {}}
+        onTimeChange={() => {}}
+      />,
+    );
+
+    output.getByRole('radio', { name: 'Ankomst' }).click();
+
+    expect(onStateChange).toHaveBeenCalledWith(DepartureDateState.Arrival);
+  });
+
+  it('should call onDateChange', async () => {
+    const onDateChange = vi.fn();
+    const output = render(
+      <DepartureDateSelector
+        initialState={DepartureDateState.Arrival}
+        onStateChange={() => {}}
+        onDateChange={onDateChange}
+        onTimeChange={() => {}}
+      />,
+    );
+
+    const date = output.getByLabelText('Dato');
+
+    fireEvent.change(date, { target: { value: '2100-01-01' } });
+
+    expect(onDateChange).toHaveBeenCalledWith(new Date('2100-01-01'));
+  });
+
+  it('should call onTimeChange', async () => {
+    const onTimeChange = vi.fn();
+    const output = render(
+      <DepartureDateSelector
+        initialState={DepartureDateState.Arrival}
+        onStateChange={() => {}}
+        onDateChange={() => {}}
+        onTimeChange={onTimeChange}
+      />,
+    );
+
+    const time = output.getByLabelText('Tid');
+
+    fireEvent.change(time, { target: { value: '00:00' } });
+
+    expect(onTimeChange).toHaveBeenCalledWith('00:00');
+  });
+});

--- a/src/components/departure-date-selector/departure-date-selector.module.css
+++ b/src/components/departure-date-selector/departure-date-selector.module.css
@@ -1,0 +1,113 @@
+.departureDateSelector {
+  display: flex;
+  flex-direction: column;
+  /* TODO: Spacing not in variables. Use variable instead? */
+  gap: .375rem;
+}
+
+.options {
+  --container-height: 2.75rem;
+  --option-height: 2.25rem;
+  --container-border-radius: 0.75rem;
+  --option-border-radius: var(--border-radius-regular);
+
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  padding: var(--spacings-xSmall);
+  background: var(--static-background-background_0-background);
+  width: fit-content;
+  border-radius: var(--container-border-radius);
+  height: var(--container-height);
+  align-items: center;
+}
+
+.options:focus-within {
+  border-radius: var(--border-radius-regular);
+  outline: 0;
+  box-shadow: inset 0 0 0 var(--border-width-medium) var(--interactive-interactive_2-outline-background);
+}
+
+.option label span {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: var(--spacings-small);
+  border-radius: var(--option-border-radius);
+  height: var(--option-height);
+}
+
+.option input {
+  clip: rect(0 0 0 0);
+  clip-path: inset(100%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+  display: block;
+}
+
+.option label input:checked + span {
+  background: var(--interactive-interactive_1-default-background);
+  color: var(--interactive-interactive_1-default-text);
+}
+
+
+.dateAndTimeSelectors {
+  display: flex;
+  gap: var(--spacings-medium);
+}
+
+.dateSelector, .timeSelector {
+  --height: 2.75rem;
+  border-radius: 0.75rem;
+  overflow: hidden;
+  background-color: var(--static-background-background_0-background);
+  display: flex;
+}
+
+.dateSelector label,
+.timeSelector label {
+  padding: var(--spacings-medium);
+  padding-right: 0;
+  min-width: 3rem;
+}
+
+.dateSelector input[type="date"],
+.timeSelector input[type="time"] {
+  height: var(--height);
+  padding: var(--spacings-medium);
+  border: none;
+  background-color: transparent;
+  color: var(--static-background-background_0-text);
+  flex: 1;
+  border-top-right-radius: 0.75rem;
+  border-bottom-right-radius: 0.75rem;
+}
+
+.dateSelector input[type="date"]:focus,
+.timeSelector input[type="time"]:focus {
+  outline: 0;
+}
+
+.dateSelector:focus-within,
+.timeSelector:focus-within {
+  box-shadow: inset 0 0 0 var(--border-width-medium) var(--interactive-interactive_2-outline-background);
+}
+
+:global(.dark) .dateSelector input[type="date"]::-webkit-calendar-picker-indicator,
+:global(.dark) .timeSelector input[type="time"]::-webkit-calendar-picker-indicator {
+  filter: invert(1);
+}
+
+@media (max-width: 650px) {
+  .dateAndTimeSelectors {
+    flex-direction: column;
+    gap: .375rem;
+  }
+
+  .options {
+    width: 100%;
+  }
+}

--- a/src/components/departure-date-selector/index.tsx
+++ b/src/components/departure-date-selector/index.tsx
@@ -11,13 +11,14 @@ export enum DepartureDateState {
 
 type DepartureDateSelectorProps = {
   initialState?: DepartureDateState;
-  onStateChange?: (state: DepartureDateState) => void;
+  onStateChange: (state: DepartureDateState) => void;
   onDateChange: (date: Date) => void;
   onTimeChange: (time: string) => void;
 };
 
 export default function DepartureDateSelector({
   initialState = DepartureDateState.Now,
+  onStateChange,
   onDateChange,
   onTimeChange,
 }: DepartureDateSelectorProps) {
@@ -33,6 +34,10 @@ export default function DepartureDateSelector({
     return `${hours}:${minutes}`;
   });
 
+  const internalOnStateChange = (state: DepartureDateState) => {
+    setSelectedOption(state);
+    onStateChange(state);
+  };
   const internalOnDateChange = (event: ChangeEvent<HTMLInputElement>) => {
     setSelectedDate(new Date(event.target.value));
     onDateChange(new Date(event.target.value));
@@ -54,7 +59,7 @@ export default function DepartureDateSelector({
                 name="departureDateSelector"
                 value={state}
                 checked={selectedOption === state}
-                onChange={() => setSelectedOption(state)}
+                onChange={() => internalOnStateChange(state)}
                 aria-label={stateToLabel(state, t)}
               />
               <span aria-hidden>{stateToLabel(state, t)}</span>

--- a/src/components/departure-date-selector/index.tsx
+++ b/src/components/departure-date-selector/index.tsx
@@ -94,7 +94,6 @@ export default function DepartureDateSelector({
   );
 }
 
-// TODO: Add translations.
 function stateToLabel(
   state: DepartureDateState,
   t: TFunc<typeof Language>,

--- a/src/components/departure-date-selector/index.tsx
+++ b/src/components/departure-date-selector/index.tsx
@@ -1,0 +1,110 @@
+import { ChangeEvent, useState } from 'react';
+import style from './departure-date-selector.module.css';
+import { ComponentText, Language, useTranslation } from '@atb/translations';
+import { TFunc } from '@leile/lobo-t';
+
+export enum DepartureDateState {
+  Now = 'now',
+  Arrival = 'arrival',
+  Departure = 'departure',
+}
+
+type DepartureDateSelectorProps = {
+  initialState?: DepartureDateState;
+  onStateChange?: (state: DepartureDateState) => void;
+  onDateChange: (date: Date) => void;
+  onTimeChange: (time: string) => void;
+};
+
+export default function DepartureDateSelector({
+  initialState = DepartureDateState.Now,
+  onDateChange,
+  onTimeChange,
+}: DepartureDateSelectorProps) {
+  const { t } = useTranslation();
+  const [selectedOption, setSelectedOption] =
+    useState<DepartureDateState>(initialState);
+  const [selectedDate, setSelectedDate] = useState(new Date());
+  const [selectedTime, setSelectedTime] = useState(() => {
+    const now = new Date();
+    const hours = now.getHours().toString().padStart(2, '0');
+    const minutes = now.getMinutes().toString().padStart(2, '0');
+
+    return `${hours}:${minutes}`;
+  });
+
+  const internalOnDateChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setSelectedDate(new Date(event.target.value));
+    onDateChange(new Date(event.target.value));
+  };
+
+  const internalOnTimeChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setSelectedTime(event.target.value);
+    onTimeChange(event.target.value);
+  };
+
+  return (
+    <div className={style.departureDateSelector}>
+      <div className={style.options}>
+        {Object.values(DepartureDateState).map((state) => (
+          <div key={state} className={style.option}>
+            <label>
+              <input
+                type="radio"
+                name="departureDateSelector"
+                value={state}
+                checked={selectedOption === state}
+                onChange={() => setSelectedOption(state)}
+                aria-label={stateToLabel(state, t)}
+              />
+              <span aria-hidden>{stateToLabel(state, t)}</span>
+            </label>
+          </div>
+        ))}
+      </div>
+
+      {selectedOption !== DepartureDateState.Now && (
+        <div className={style.dateAndTimeSelectors}>
+          <div className={style.dateSelector}>
+            <label htmlFor="departureDateSelector">
+              {t(ComponentText.DepartureDateSelector.date)}
+            </label>
+            <input
+              type="date"
+              id="departureDateSelector"
+              value={selectedDate.toISOString().slice(0, 10)}
+              onChange={internalOnDateChange}
+            />
+          </div>
+          <div className={style.timeSelector}>
+            <label htmlFor="departureTimeSelector">
+              {t(ComponentText.DepartureDateSelector.time)}
+            </label>
+
+            <input
+              type="time"
+              id="departureTimeSelector"
+              value={selectedTime}
+              onChange={internalOnTimeChange}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// TODO: Add translations.
+function stateToLabel(
+  state: DepartureDateState,
+  t: TFunc<typeof Language>,
+): string {
+  switch (state) {
+    case DepartureDateState.Now:
+      return t(ComponentText.DepartureDateSelector.now);
+    case DepartureDateState.Arrival:
+      return t(ComponentText.DepartureDateSelector.arrival);
+    case DepartureDateState.Departure:
+      return t(ComponentText.DepartureDateSelector.departure);
+  }
+}

--- a/src/page-modules/departures/departures.module.css
+++ b/src/page-modules/departures/departures.module.css
@@ -10,6 +10,9 @@
   position: relative;
   padding: var(--spacings-xLarge);
   padding-bottom: 5.25rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-gap: var(--spacings-xLarge);
 }
 
 .searchButton {
@@ -27,5 +30,9 @@
 @media (max-width: 650px) {
   .searchWrapper {
     padding: 0;
+  }
+
+  .searchContainer {
+    grid-template-columns: 1fr;
   }
 }

--- a/src/page-modules/departures/layout.tsx
+++ b/src/page-modules/departures/layout.tsx
@@ -1,31 +1,40 @@
-import type { WithGlobalData } from '@atb/layouts/global-data';
-import type { GeocoderFeature } from '@atb/page-modules/departures';
-import { PageText, useTranslation } from '@atb/translations';
-import { FormEventHandler, PropsWithChildren, useState } from 'react';
-import Search from '@atb/components/search';
-import { Button } from '@atb/components/button';
-import style from './departures.module.css';
-import { useRouter } from 'next/router';
+import type { WithGlobalData } from "@atb/layouts/global-data";
+import type { GeocoderFeature } from "@atb/page-modules/departures";
+import { PageText, useTranslation } from "@atb/translations";
+import { PropsWithChildren, useState } from "react";
+import Search from "@atb/components/search";
+import { Button } from "@atb/components/button";
+import style from "./departures.module.css";
+import { useRouter } from "next/router";
+import DepartureDateSelector, {
+  DepartureDateState,
+} from '@atb/components/departure-date-selector';
 
 export type DeparturesLayoutProps = PropsWithChildren<WithGlobalData<{}>>;
+
 function DeparturesLayout({ children }: DeparturesLayoutProps) {
   const { t } = useTranslation();
   const router = useRouter();
 
   const [selectedFeature, setSelectedFeature] = useState<GeocoderFeature>();
+  const [departureDateState, setDepartureDateState] = useState(
+    DepartureDateState.Now,
+  );
+  const [_departureDate, setDepartureDate] = useState<Date>();
+  const [_departureTime, setDepartureTime] = useState<string>();
 
   const onSubmitHandler: FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
-    if (selectedFeature?.layer == 'venue') {
+    if (selectedFeature?.layer == "venue") {
       router.push(`/departures/${selectedFeature.id}`);
-    } else if (selectedFeature?.layer == 'address') {
+    } else if (selectedFeature?.layer == "address") {
       const [lon, lat] = selectedFeature.geometry.coordinates;
       router.push({
-        href: '/departures',
+        href: "/departures",
         query: {
           lon,
-          lat,
-        },
+          lat
+        }
       });
     }
   };
@@ -34,21 +43,36 @@ function DeparturesLayout({ children }: DeparturesLayoutProps) {
     <div className={style.departuresPage}>
       <div className={style.searchWrapper}>
         <form className={style.searchContainer} onSubmit={onSubmitHandler}>
-          <p className={style.searchInputLabel}>
-            {t(PageText.Departures.search.input.label)}
-          </p>
+          <div className={style.searchInput}>
+            <p className={style.searchInputLabel}>
+              {t(PageText.Departures.search.input.label)}
+            </p>
 
-          <Search
-            label={t(PageText.Departures.search.input.from)}
-            onChange={setSelectedFeature}
-          />
+            <Search
+              label={t(PageText.Departures.search.input.from)}
+              onChange={setSelectedFeature}
+            />
+          </div>
+
+          <div className={style.searchDate}>
+            <p className={style.searchInputLabel}>
+              {t(PageText.Departures.search.date.label)}
+            </p>
+
+            <DepartureDateSelector
+              initialState={departureDateState}
+              onStateChange={setDepartureDateState}
+              onDateChange={setDepartureDate}
+              onTimeChange={setDepartureTime}
+            />
+          </div>
 
           <Button
             title={t(PageText.Departures.search.button.title)}
             className={style.searchButton}
             mode="interactive_0"
             disabled={!selectedFeature}
-            buttonProps={{ type: 'submit' }}
+            buttonProps={{ type: "submit" }}
           />
         </form>
       </div>

--- a/src/page-modules/departures/layout.tsx
+++ b/src/page-modules/departures/layout.tsx
@@ -1,12 +1,13 @@
 import type { WithGlobalData } from "@atb/layouts/global-data";
 import type { GeocoderFeature } from "@atb/page-modules/departures";
 import { PageText, useTranslation } from "@atb/translations";
-import { PropsWithChildren, useState } from "react";
+import { FormEventHandler, PropsWithChildren, useState } from "react";
 import Search from "@atb/components/search";
 import { Button } from "@atb/components/button";
 import style from "./departures.module.css";
 import { useRouter } from "next/router";
 import DepartureDateSelector, {
+  DepartureDate,
   DepartureDateState,
 } from '@atb/components/departure-date-selector';
 
@@ -17,11 +18,9 @@ function DeparturesLayout({ children }: DeparturesLayoutProps) {
   const router = useRouter();
 
   const [selectedFeature, setSelectedFeature] = useState<GeocoderFeature>();
-  const [departureDateState, setDepartureDateState] = useState(
-    DepartureDateState.Now,
-  );
-  const [_departureDate, setDepartureDate] = useState<Date>();
-  const [_departureTime, setDepartureTime] = useState<string>();
+  const [departureDate, setDepartureDate] = useState<DepartureDate>({
+    type: DepartureDateState.Now,
+  });
 
   const onSubmitHandler: FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
@@ -60,10 +59,8 @@ function DeparturesLayout({ children }: DeparturesLayoutProps) {
             </p>
 
             <DepartureDateSelector
-              initialState={departureDateState}
-              onStateChange={setDepartureDateState}
-              onDateChange={setDepartureDate}
-              onTimeChange={setDepartureTime}
+              initialState={departureDate}
+              onChange={setDepartureDate}
             />
           </div>
 

--- a/src/translations/components/departure-date-selector.ts
+++ b/src/translations/components/departure-date-selector.ts
@@ -1,0 +1,9 @@
+import { translation as _ } from '@atb/translations/commons';
+
+export const DepartureDateSelector = {
+  now: _('Nå', 'Now', 'No'),
+  arrival: _('Ankomst', 'Arrival', 'Framkomst'),
+  departure: _('Avgang', 'Departure', 'Avgang'),
+  date: _('Dato', 'Date', 'Dato'),
+  time: _('Tid', 'Time', 'Tid'),
+};

--- a/src/translations/components/index.ts
+++ b/src/translations/components/index.ts
@@ -1,4 +1,5 @@
 export { VenueIcon } from './venue-icon';
 export { Loading } from './loading';
 export { GeolocationButton } from './geolocation-button';
+export { DepartureDateSelector } from './departure-date-selector';
 export { Map } from './map';

--- a/src/translations/pages/departures.ts
+++ b/src/translations/pages/departures.ts
@@ -12,6 +12,13 @@ export const Departures = {
       ),
       from: _('Fra', 'From', 'Frå'),
     },
+    date: {
+      label: _(
+        'Når vil du reise?',
+        'When do you want to travel?',
+        'Når vil du reise?',
+      ),
+    },
     button: {
       title: _('Finn avganger', 'Find departures', 'Finn avganger'),
     },


### PR DESCRIPTION
Added options for when to travel, based on the current time, the arrival time or the departure time.


<details><summary>Screenshots</summary>

### Light mode
![image](https://github.com/AtB-AS/planner-web/assets/14045515/d324ed7f-ad3f-4a36-9ad1-b240d42f5a95)
![image](https://github.com/AtB-AS/planner-web/assets/14045515/1e3c5439-47eb-4cec-b0cf-cb63980af345)

### Light mode mobile
![image](https://github.com/AtB-AS/planner-web/assets/14045515/a6ec1d59-c4b4-44f3-8dd1-3eb905e98ae1)
![image](https://github.com/AtB-AS/planner-web/assets/14045515/db06da2b-f72f-4c19-940f-b4d8a6637841)

### Date and time picker mobile
![image](https://github.com/AtB-AS/planner-web/assets/14045515/644900a8-4a72-45d6-9a4f-71d58e42c483)
![image](https://github.com/AtB-AS/planner-web/assets/14045515/9e106cb9-27de-4919-9e23-b1069ec9032d)

### Dark mode
![image](https://github.com/AtB-AS/planner-web/assets/14045515/f4da1601-88e6-4dd7-8c97-58aa3c9015ea)
![image](https://github.com/AtB-AS/planner-web/assets/14045515/a3f56527-9bc8-4840-8be5-a6ae2d66aa0e)

### Dark mode mobile
![image](https://github.com/AtB-AS/planner-web/assets/14045515/f9251c3b-74e6-482a-ab63-2a3671a4fc74)
![image](https://github.com/AtB-AS/planner-web/assets/14045515/aa21a495-b32d-4437-b1f1-6e84e6518016)


</details> 

Fixes https://github.com/AtB-AS/kundevendt/issues/9144 (parts of it)

## TODO

- [x] Add component tests
- [x] Clean up based on review