### PR TITLE
fix: map container max height on departures page

### DIFF
--- a/src/page-modules/departures/nearest-stop-places/nearest-stop-places.module.css
+++ b/src/page-modules/departures/nearest-stop-places/nearest-stop-places.module.css
@@ -9,6 +9,7 @@
 }
 .mapContainer {
   grid-area: map;
+  max-height: 37.5rem;
 }
 .stopPlacesList {
   grid-area: stop-places;


### PR DESCRIPTION
This makes it so that the map container is max 600px. 

<img width="1704" alt="image" src="https://github.com/AtB-AS/planner-web/assets/43166974/acf0bba7-c2eb-4079-8212-f8a44f8422a6">
