### PR TITLE
feat: assistant page header

### DIFF
--- a/src/components/search/__tests__/search.test.tsx
+++ b/src/components/search/__tests__/search.test.tsx
@@ -19,6 +19,8 @@ import {
 import userEvent from '@testing-library/user-event';
 import { SWRConfig } from 'swr';
 import React from 'react';
+import SwapButton from '../swap-button';
+import GeolocationButton from '../geolocation-button';
 
 const result = [
   {
@@ -92,7 +94,13 @@ describe('search box', () => {
   });
 
   it('should render with swap button', () => {
-    customRender(<Search label="Test" onChange={() => {}} onSwap={() => {}} />);
+    customRender(
+      <Search
+        label="Test"
+        onChange={() => {}}
+        button={<SwapButton onSwap={() => {}} />}
+      />,
+    );
 
     const swapButton = screen.getByRole('button', {
       name: 'Bytt avreisested og ankomststed',
@@ -191,7 +199,13 @@ describe('search box', () => {
   });
 
   it('should call getCurrentPosition when geolocating', async () => {
-    customRender(<Search label="Test" onChange={() => {}} />);
+    customRender(
+      <Search
+        label="Test"
+        onChange={() => {}}
+        button={<GeolocationButton onGeolocate={() => {}} />}
+      />,
+    );
 
     const geolocationButton = screen.getByRole('button', {
       name: 'Finn min posisjon',

--- a/src/components/search/__tests__/search.test.tsx
+++ b/src/components/search/__tests__/search.test.tsx
@@ -91,6 +91,16 @@ describe('search box', () => {
     expect(search).toHaveFocus();
   });
 
+  it('should render with swap button', () => {
+    customRender(<Search label="Test" onChange={() => {}} onSwap={() => {}} />);
+
+    const swapButton = screen.getByRole('button', {
+      name: 'Bytt avreisested og ankomststed',
+    });
+
+    expect(swapButton).toBeDefined();
+  });
+
   it('should focus input when clicking label', async () => {
     customRender(<Search label="Test" onChange={() => {}} />);
 

--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -11,6 +11,7 @@ type SearchProps = {
   onChange: (selection: any) => void;
   button?: ReactNode;
   initialFeature?: GeocoderFeature;
+  selectedItem?: GeocoderFeature;
 };
 
 export default function Search({
@@ -18,16 +19,17 @@ export default function Search({
   onChange,
   button,
   initialFeature,
+  selectedItem,
 }: SearchProps) {
   const [query, setQuery] = useState('');
   const { data } = useAutocomplete(query);
 
   return (
     <Downshift<GeocoderFeature>
-      initialSelectedItem={initialFeature}
       onInputValueChange={(inputValue) => setQuery(inputValue || '')}
       onChange={onChange}
       itemToString={geocoderFeatureToString}
+      selectedItem={selectedItem || initialFeature || null}
     >
       {({
         getInputProps,

--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -25,7 +25,6 @@ export default function Search({
   return (
     <Downshift<GeocoderFeature>
       initialSelectedItem={initialFeature}
-      initialInputValue={geocoderFeatureToString(initialFeature)}
       onInputValueChange={(inputValue) => setQuery(inputValue || '')}
       onChange={onChange}
       itemToString={geocoderFeatureToString}

--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -6,17 +6,20 @@ import VenueIcon from '@atb/components/venue-icon';
 import { andIf } from '@atb/utils/css';
 import GeolocationButton from '@atb/components/search/geolocation-button';
 import { GeocoderFeature } from '@atb/page-modules/departures';
+import SwapButton from '@atb/components/search//swap-button';
 
 type SearchProps = {
   label: string;
   onChange: (selection: any) => void;
   initialQuery?: string;
+  onSwap?: () => void;
 };
 
 export default function Search({
   label,
   onChange,
   initialQuery = '',
+  onSwap,
 }: SearchProps) {
   const [query, setQuery] = useState(initialQuery);
   const { data } = useAutocomplete(query);
@@ -51,10 +54,14 @@ export default function Search({
             <input className={style.input} {...getInputProps()} />
           </div>
 
-          <GeolocationButton
-            className={style.geolocationButton}
-            onGeolocate={selectItem}
-          />
+          {onSwap ? (
+            <SwapButton className={style.geolocationButton} onSwap={onSwap} />
+          ) : (
+            <GeolocationButton
+              className={style.geolocationButton}
+              onGeolocate={selectItem}
+            />
+          )}
 
           <ul className={style.menu} {...getMenuProps()}>
             {isOpen &&

--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -1,35 +1,34 @@
 import Downshift from 'downshift';
-import { useState } from 'react';
+import { ReactNode, useState } from 'react';
 import { useAutocomplete } from '@atb/page-modules/departures/client';
 import style from './search.module.css';
 import VenueIcon from '@atb/components/venue-icon';
 import { andIf } from '@atb/utils/css';
-import GeolocationButton from '@atb/components/search/geolocation-button';
 import { GeocoderFeature } from '@atb/page-modules/departures';
-import SwapButton from '@atb/components/search//swap-button';
 
 type SearchProps = {
   label: string;
   onChange: (selection: any) => void;
-  initialQuery?: string;
-  onSwap?: () => void;
+  button?: ReactNode;
+  initialFeature?: GeocoderFeature;
 };
 
 export default function Search({
   label,
   onChange,
-  initialQuery = '',
-  onSwap,
+  button,
+  initialFeature,
 }: SearchProps) {
-  const [query, setQuery] = useState(initialQuery);
+  const [query, setQuery] = useState('');
   const { data } = useAutocomplete(query);
 
   return (
     <Downshift<GeocoderFeature>
-      initialInputValue={query}
+      initialSelectedItem={initialFeature}
+      initialInputValue={geocoderFeatureToString(initialFeature)}
       onInputValueChange={(inputValue) => setQuery(inputValue || '')}
       onChange={onChange}
-      itemToString={(item) => (item ? `${item.name}, ${item.locality}` : '')}
+      itemToString={geocoderFeatureToString}
     >
       {({
         getInputProps,
@@ -40,7 +39,6 @@ export default function Search({
         inputValue,
         highlightedIndex,
         getRootProps,
-        selectItem,
       }) => (
         <div className={style.container}>
           <label className={style.label} {...getLabelProps()}>
@@ -54,14 +52,7 @@ export default function Search({
             <input className={style.input} {...getInputProps()} />
           </div>
 
-          {onSwap ? (
-            <SwapButton className={style.geolocationButton} onSwap={onSwap} />
-          ) : (
-            <GeolocationButton
-              className={style.geolocationButton}
-              onGeolocate={selectItem}
-            />
-          )}
+          {button ?? null}
 
           <ul className={style.menu} {...getMenuProps()}>
             {isOpen &&
@@ -125,4 +116,9 @@ function highlightSearchText(input: string | null, name: string) {
   } else {
     return [{ part: name, highlight: false }];
   }
+}
+function geocoderFeatureToString(
+  feature: GeocoderFeature | null | undefined,
+): string {
+  return feature ? `${feature.name}, ${feature.locality}` : '';
 }

--- a/src/components/search/search.module.css
+++ b/src/components/search/search.module.css
@@ -13,11 +13,12 @@
   composes: typo-body__secondary;
 
   height: var(--height);
+  min-width: 3rem;
   display: flex;
   align-items: center;
   background-color: var(--static-background-background_0-background);
   padding: var(--spacings-small);
-  padding-right: var(--spacings-xLarge);
+  padding-right: var(--spacings-regular);
   border-bottom-left-radius: 0.75rem;
   border-top-left-radius: 0.75rem;
 }

--- a/src/components/search/search.module.css
+++ b/src/components/search/search.module.css
@@ -35,18 +35,6 @@
   color: var(--static-background-background_0-text);
 }
 
-.geolocationButton {
-  height: var(--height);
-  background-color: var(--static-background-background_0-background);
-  border: none;
-  padding: var(--spacings-small);
-  border-bottom-right-radius: 0.75rem;
-  border-top-right-radius: 0.75rem;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-}
-
 .menu {
   width: 100%;
   background-color: var(--static-background-background_0-background);

--- a/src/components/search/swap-button/index.tsx
+++ b/src/components/search/swap-button/index.tsx
@@ -1,14 +1,24 @@
 import { MonoIcon } from '@atb/components/icon';
+import { LoadingIcon } from '@atb/components/loading';
 import { ComponentText, useTranslation } from '@atb/translations';
 
 type SwapButtonProps = {
   onSwap: () => void;
   className?: string;
+  isLoading?: boolean;
 };
-export default function SwapButton({ onSwap, className }: SwapButtonProps) {
+export default function SwapButton({
+  onSwap,
+  className,
+  isLoading,
+}: SwapButtonProps) {
   const { t } = useTranslation();
 
-  return (
+  return isLoading ? (
+    <div className={className}>
+      <LoadingIcon />
+    </div>
+  ) : (
     <button
       className={className}
       onClick={onSwap}

--- a/src/components/search/swap-button/index.tsx
+++ b/src/components/search/swap-button/index.tsx
@@ -1,0 +1,22 @@
+import { MonoIcon } from '@atb/components/icon';
+import { ComponentText, useTranslation } from '@atb/translations';
+
+type SwapButtonProps = {
+  onSwap: () => void;
+  className?: string;
+};
+export default function SwapButton({ onSwap, className }: SwapButtonProps) {
+  const { t } = useTranslation();
+
+  return (
+    <button
+      className={className}
+      onClick={onSwap}
+      title={t(ComponentText.SwapButton.alt)}
+      aria-label={t(ComponentText.SwapButton.alt)}
+      type="button"
+    >
+      <MonoIcon icon="actions/Swap" />
+    </button>
+  );
+}

--- a/src/layouts/shared/page-header.tsx
+++ b/src/layouts/shared/page-header.tsx
@@ -102,6 +102,14 @@ function Navigation({
           <li></li>
           <li>
             <HeaderLink
+              {...getActiveProps('/assistant', router.pathname)}
+              title={t(PageText.Assistant.title)}
+              tabIndex={tabIndex}
+              testID="navAssistantButton"
+            />
+          </li>
+          <li>
+            <HeaderLink
               {...getActiveProps('/departures', router.pathname)}
               title={t(PageText.Departures.title)}
               tabIndex={tabIndex}

--- a/src/page-modules/assistant/__tests__/assistant.test.tsx
+++ b/src/page-modules/assistant/__tests__/assistant.test.tsx
@@ -1,0 +1,116 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import mockRouter from 'next-router-mock';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ExternalClient } from '@atb/modules/api-server';
+import { JourneyPlannerApi } from '@atb/page-modules/assistant/server/journey-planner';
+import { TripData } from '@atb/page-modules/assistant/server/journey-planner/validators';
+import { getServerSideProps } from '@atb/pages/assistant';
+import { expectProps } from '@atb/tests/utils';
+import { createDynamicRouteParser } from 'next-router-mock/dynamic-routes';
+import { GeocoderFeature } from '@atb/page-modules/departures';
+import { FeatureCategory } from '@atb/components/venue-icon';
+import { GeocoderApi } from '@atb/page-modules/departures/server/geocoder';
+import AssistantLayout from '../layout';
+
+afterEach(function () {
+  cleanup();
+});
+
+vi.mock('next/router', () => require('next-router-mock'));
+
+mockRouter.useParser(createDynamicRouteParser(['/assistant']));
+
+describe('assistant page', function () {
+  it('should return props from getServerSideProps', async () => {
+    await mockRouter.push('/assistant');
+
+    const expectedFromFeature: GeocoderFeature = {
+      id: '638651',
+      name: 'Strindheim',
+      locality: 'Trondheim',
+      category: [FeatureCategory.BYDEL],
+      layer: 'address',
+      geometry: {
+        coordinates: [10.456038846578249, 63.42666114395819],
+      },
+    };
+
+    const expectedToFeature: GeocoderFeature = {
+      id: 'NSR:StopPlace:43984',
+      name: 'Byåsen skole',
+      locality: 'Trondheim',
+      category: [FeatureCategory.ONSTREET_BUS],
+      layer: 'venue',
+      geometry: { coordinates: [10.358037, 63.398886] },
+    };
+
+    const expectedTripResult: TripData = {
+      nextPageCursor: 'aaa',
+      tripPatterns: [],
+    };
+
+    const gqlClient: ExternalClient<
+      'graphql-journeyPlanner3' | 'http-entur',
+      GeocoderApi & JourneyPlannerApi
+    > = {
+      async trip() {
+        return expectedTripResult;
+      },
+      async autocomplete() {
+        return {} as any;
+      },
+      async reverse(lat, lon, layers) {
+        if (layers === 'address') return expectedFromFeature;
+        else return expectedToFeature;
+      },
+      client: null as any,
+    };
+
+    const context = {
+      params: {},
+      query: {
+        fromId: 638651,
+        fromName: 'Strindheim',
+        fromLon: 10.4560389,
+        fromLat: 63.4266611,
+        fromLayer: 'address',
+        toId: 'NSR:StopPlace:43984',
+        toName: 'Byåsen skole',
+        toLon: 10.358037,
+        toLat: 63.398886,
+        toLayer: 'venue',
+      },
+    };
+
+    const result = await getServerSideProps({
+      client: gqlClient,
+      ...context,
+    } as any);
+
+    (await expectProps(result)).toContain({
+      initialFromFeature: expectedFromFeature,
+      initialToFeature: expectedToFeature,
+      trip: expectedTripResult,
+    });
+  });
+
+  it('should render assistant page header', () => {
+    render(<AssistantLayout />);
+
+    expect(screen.getByText('Fra')).toBeInTheDocument();
+    expect(screen.getByText('Til')).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Bytt avreisested og ankomststed',
+      }),
+    ).toBeInTheDocument();
+
+    const submitButton = screen.getByRole('button', {
+      name: 'Finn avganger',
+    });
+
+    expect(submitButton).toBeInTheDocument();
+    expect(submitButton).toBeDisabled();
+  });
+});

--- a/src/page-modules/assistant/assistant.module.css
+++ b/src/page-modules/assistant/assistant.module.css
@@ -66,6 +66,18 @@
   z-index: 10;
 }
 
+.searchInputButton {
+  height: var(--height);
+  background-color: var(--static-background-background_0-background);
+  border: none;
+  padding: var(--spacings-small);
+  border-bottom-right-radius: 0.75rem;
+  border-top-right-radius: 0.75rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+}
+
 @media (max-width: 650px) {
   .container {
     grid-template-areas:

--- a/src/page-modules/assistant/assistant.module.css
+++ b/src/page-modules/assistant/assistant.module.css
@@ -26,7 +26,7 @@
 .input {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 0.375rem;
 }
 
 .button {
@@ -35,7 +35,7 @@
 
 .heading {
   color: var(--static-background-background_accent_0-text);
-  margin: 10px;
+  margin: 0.625rem;
 }
 
 .alternativesWrapper {

--- a/src/page-modules/assistant/assistant.module.css
+++ b/src/page-modules/assistant/assistant.module.css
@@ -1,0 +1,96 @@
+.wrapper {
+  background-color: var(--static-background-background_accent_0-background);
+}
+
+.container {
+  background-color: var(--static-background-background_accent_0-background);
+  height: 100%;
+  position: relative;
+  display: grid;
+  grid-template-areas:
+    'main'
+    'alternatives';
+}
+
+.main {
+  grid-area: main;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-gap: var(--spacings-xLarge);
+  width: 100%;
+  max-width: var(--maxPageWidth);
+  padding: var(--spacings-xLarge);
+  margin: 0 auto;
+}
+
+.input {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.button {
+  text-align: center;
+}
+
+.heading {
+  color: var(--static-background-background_accent_0-text);
+  margin: 10px;
+}
+
+.alternativesWrapper {
+  grid-area: alternatives;
+  width: 100%;
+  background-color: var(--static-background-background_accent_1-background);
+  padding-bottom: 5.25rem;
+}
+
+.alternatives {
+  padding: var(--spacings-xLarge);
+  width: 100%;
+  max-width: var(--maxPageWidth);
+  margin: 0 auto;
+}
+
+.buttons {
+  grid-area: alternatives;
+  align-self: end;
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacings-medium);
+  width: 100%;
+  max-width: var(--maxPageWidth);
+  margin: 0 auto;
+  padding: 0 var(--spacings-xLarge) var(--spacings-xLarge)
+    var(--spacings-xLarge);
+  z-index: 10;
+}
+
+@media (max-width: 650px) {
+  .container {
+    grid-template-areas:
+      'main'
+      'buttons'
+      'alternatives';
+  }
+
+  .main {
+    grid-template-columns: 1fr;
+  }
+
+  .buttons {
+    grid-area: buttons;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .alternativesWrapper {
+    padding-bottom: 0;
+  }
+}
+
+.contentContainer {
+  margin: 0 auto;
+  max-width: var(--maxPageWidth);
+  padding: var(--spacings-xLarge);
+}

--- a/src/page-modules/assistant/index.ts
+++ b/src/page-modules/assistant/index.ts
@@ -1,0 +1,1 @@
+export * from './types';

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -40,10 +40,10 @@ function AssistantLayout({
   const [showAlternatives, setShowAlternatives] = useState(false);
   const [selectedFromFeature, setSelectedFromFeature] = useState<
     GeocoderFeature | undefined
-  >();
+  >(initialFromFeature);
   const [selectedToFeature, setSelectedToFeature] = useState<
     GeocoderFeature | undefined
-  >();
+  >(initialToFeature);
   const [departureDate, setDepartureDate] = useState<DepartureDate>({
     type: DepartureDateState.Now,
   });

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -1,0 +1,222 @@
+import type { GeocoderFeature } from '@atb/page-modules/departures';
+import { PageText, useTranslation } from '@atb/translations';
+import { FormEventHandler, PropsWithChildren, useState } from 'react';
+import Search from '@atb/components/search';
+import { Button } from '@atb/components/button';
+import style from './assistant.module.css';
+import { useRouter } from 'next/router';
+import DepartureDateSelector, {
+  DepartureDate,
+  DepartureDateState,
+} from '@atb/components/departure-date-selector';
+import TransportModeFilter from '@atb/components/transport-mode-filter';
+import { Typo } from '@atb/components/typography';
+import {
+  filterToQueryString,
+  getInitialTransportModeFilter,
+} from '@atb/components/transport-mode-filter/utils';
+import { TransportModeFilterOption } from '@atb/components/transport-mode-filter/types';
+import { MonoIcon } from '@atb/components/icon';
+import { FocusScope } from '@react-aria/focus';
+import { featuresToFromToQuery } from './utils';
+
+export type AssistantLayoutProps = PropsWithChildren<{
+  initialFromFeature?: GeocoderFeature;
+  initialToFeature?: GeocoderFeature;
+  initialTransportModesFilter?: TransportModeFilterOption[] | null;
+}>;
+
+function AssistantLayout({
+  children,
+  initialFromFeature,
+  initialToFeature,
+  initialTransportModesFilter,
+}: AssistantLayoutProps) {
+  const { t } = useTranslation();
+  const router = useRouter();
+
+  const [showAlternatives, setShowAlternatives] = useState(false);
+  const [selectedFromFeature, setSelectedFromFeature] = useState<
+    GeocoderFeature | undefined
+  >(initialFromFeature);
+  const [selectedToFeature, setSelectedToFeature] = useState<
+    GeocoderFeature | undefined
+  >(initialToFeature);
+  const [departureDate, setDepartureDate] = useState<DepartureDate>({
+    type: DepartureDateState.Now,
+  });
+  const [transportModeFilter, setTransportModeFilter] = useState(
+    getInitialTransportModeFilter(initialTransportModesFilter),
+  );
+
+  const onSwap = () => {
+    let query = {};
+    const filter = filterToQueryString(transportModeFilter);
+
+    if (filter) {
+      query = {
+        filter,
+      };
+    }
+
+    const arriveBy = departureDate.type === DepartureDateState.Arrival;
+    if (arriveBy) {
+      query = {
+        ...query,
+        arriveBy,
+      };
+    }
+
+    const when = departureDate.type !== DepartureDateState.Now;
+    if (when) {
+      query = {
+        ...query,
+        when: departureDate.dateTime,
+      };
+    }
+    const fromToQuery = featuresToFromToQuery(
+      selectedToFeature,
+      selectedFromFeature,
+    );
+
+    router.push({
+      pathname: `/assistant`,
+      query: {
+        ...query,
+        ...fromToQuery,
+      },
+    });
+  };
+
+  const onSubmitHandler: FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault();
+
+    let query = {};
+
+    const filter = filterToQueryString(transportModeFilter);
+
+    if (filter) {
+      query = {
+        filter,
+      };
+    }
+
+    const arriveBy = departureDate.type === DepartureDateState.Arrival;
+    if (arriveBy) {
+      query = {
+        ...query,
+        arriveBy,
+      };
+    }
+
+    const when = departureDate.type !== DepartureDateState.Now;
+    if (when) {
+      query = {
+        ...query,
+        when: departureDate.dateTime,
+      };
+    }
+
+    const fromToQuery = featuresToFromToQuery(
+      selectedFromFeature,
+      selectedToFeature,
+    );
+
+    router.push({
+      pathname: `/assistant`,
+      query: {
+        ...query,
+        ...fromToQuery,
+      },
+    });
+  };
+
+  return (
+    <div>
+      <form className={style.container} onSubmit={onSubmitHandler}>
+        <div className={style.main}>
+          <div className={style.input}>
+            <Typo.p textType="body__primary--bold" className={style.heading}>
+              {t(PageText.Assistant.search.input.label)}
+            </Typo.p>
+
+            <Search
+              label={t(PageText.Assistant.search.input.from)}
+              onChange={setSelectedFromFeature}
+              initialQuery={
+                initialFromFeature?.name
+                  ? `${initialFromFeature.name}, ${initialFromFeature.locality}`
+                  : ''
+              }
+            />
+            <Search
+              label={t(PageText.Assistant.search.input.to)}
+              onChange={setSelectedToFeature}
+              initialQuery={
+                initialToFeature?.name
+                  ? `${initialToFeature.name}, ${initialToFeature.locality}`
+                  : ''
+              }
+              onSwap={onSwap}
+            />
+          </div>
+
+          <div className={style.date}>
+            <Typo.p textType="body__primary--bold" className={style.heading}>
+              {t(PageText.Assistant.search.date.label)}
+            </Typo.p>
+
+            <DepartureDateSelector
+              initialState={departureDate}
+              onChange={setDepartureDate}
+            />
+          </div>
+        </div>
+
+        {showAlternatives && (
+          <FocusScope contain={false} autoFocus={showAlternatives}>
+            <div className={style.alternativesWrapper}>
+              <div className={style.alternatives}>
+                <div>
+                  <Typo.p
+                    textType="body__primary--bold"
+                    className={style.heading}
+                  >
+                    {t(PageText.Assistant.search.filter.label)}
+                  </Typo.p>
+
+                  <TransportModeFilter
+                    filterState={transportModeFilter}
+                    onFilterChange={setTransportModeFilter}
+                  />
+                </div>
+              </div>
+            </div>
+          </FocusScope>
+        )}
+
+        <div className={style.buttons}>
+          <Button
+            title={t(PageText.Assistant.search.buttons.alternatives.title)}
+            className={style.button}
+            mode={showAlternatives ? 'interactive_3' : 'interactive_2'}
+            onClick={() => setShowAlternatives(!showAlternatives)}
+            icon={{ right: <MonoIcon icon="actions/Adjust" /> }}
+          />
+
+          <Button
+            title={t(PageText.Assistant.search.buttons.find.title)}
+            className={style.button}
+            mode="interactive_0"
+            disabled={!selectedFromFeature || !selectedToFeature}
+            buttonProps={{ type: 'submit' }}
+          />
+        </div>
+      </form>
+
+      <section className={style.contentContainer}>{children}</section>
+    </div>
+  );
+}
+
+export default AssistantLayout;

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -50,14 +50,18 @@ function AssistantLayout({
   const [transportModeFilter, setTransportModeFilter] = useState(
     getInitialTransportModeFilter(initialTransportModesFilter),
   );
+  const [isSwapping, setIsSwapping] = useState(false);
 
   const onSwap = () => {
     if (!selectedToFeature || !selectedFromFeature) return;
+    setIsSwapping(true);
     const query = createQuery(selectedToFeature, selectedFromFeature);
     const temp = selectedFromFeature;
     setSelectedFromFeature(selectedToFeature);
     setSelectedToFeature(temp);
-    router.push({ pathname: '/assistant', query });
+    router
+      .push({ pathname: '/assistant', query })
+      .then(() => setIsSwapping(false));
   };
 
   const onGeolocate = (geolocationFeature: GeocoderFeature) => {
@@ -106,6 +110,7 @@ function AssistantLayout({
               label={t(PageText.Assistant.search.input.from)}
               onChange={setSelectedFromFeature}
               initialFeature={initialFromFeature}
+              selectedItem={selectedFromFeature}
               button={
                 <GeolocationButton
                   className={style.searchInputButton}
@@ -117,10 +122,12 @@ function AssistantLayout({
               label={t(PageText.Assistant.search.input.to)}
               onChange={setSelectedToFeature}
               initialFeature={initialToFeature}
+              selectedItem={selectedToFeature}
               button={
                 <SwapButton
                   className={style.searchInputButton}
                   onSwap={onSwap}
+                  isLoading={isSwapping}
                 />
               }
             />

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -71,37 +71,18 @@ function AssistantLayout({
     fromFeature: GeocoderFeature,
     toFeature: GeocoderFeature,
   ) => {
-    let query = {};
-
     const filter = filterToQueryString(transportModeFilter);
-
-    if (filter) {
-      query = {
-        filter,
-      };
-    }
-
     const arriveBy = departureDate.type === DepartureDateState.Arrival;
-    if (arriveBy) {
-      query = {
-        ...query,
-        arriveBy,
-      };
-    }
-
-    const when = departureDate.type !== DepartureDateState.Now;
-    if (when) {
-      query = {
-        ...query,
-        when: departureDate.dateTime,
-      };
-    }
-
+    const departBy = departureDate.type === DepartureDateState.Departure;
     const fromToQuery = featuresToFromToQuery(fromFeature, toFeature);
-    query = {
-      ...query,
+
+    const query = {
+      ...(filter ? { filter } : {}),
+      ...(arriveBy ? { arriveBy: departureDate.dateTime } : {}),
+      ...(departBy ? { departBy: departureDate.dateTime } : {}),
       ...fromToQuery,
     };
+
     return query;
   };
 

--- a/src/page-modules/assistant/server/index.ts
+++ b/src/page-modules/assistant/server/index.ts
@@ -1,0 +1,21 @@
+import {
+  composeClientFactories,
+  createExternalClient,
+  createWithExternalClientDecorator,
+} from '@atb/modules/api-server';
+import { createJourneyApi } from './journey-planner';
+import { createGeocoderApi } from '@atb/page-modules/departures/server/geocoder';
+
+export const geocoderClient = createExternalClient(
+  'http-entur',
+  createGeocoderApi,
+);
+
+export const journeyClient = createExternalClient(
+  'graphql-journeyPlanner3',
+  createJourneyApi,
+);
+
+export const withAssistantClient = createWithExternalClientDecorator(
+  composeClientFactories(journeyClient, geocoderClient),
+);

--- a/src/page-modules/assistant/server/journey-planner/index.ts
+++ b/src/page-modules/assistant/server/journey-planner/index.ts
@@ -1,0 +1,265 @@
+import { GraphQlRequester } from '@atb/modules/api-server';
+import {
+  TripsDocument,
+  TripsQuery,
+  TripsQueryVariables,
+} from '@atb/page-modules/assistant/server/journey-planner/journey-gql/trip.generated';
+import {
+  Notice,
+  Situation,
+  TripData,
+  tripSchema,
+} from '@atb/page-modules/assistant/server/journey-planner/validators';
+import {
+  getTransportModesEnums,
+  isTransportModeType,
+  isTransportSubmodeType,
+} from '@atb/page-modules/departures/server/journey-planner';
+import { TripInput } from '@atb/page-modules/assistant';
+
+export type JourneyPlannerApi = {
+  trip(input: TripInput): Promise<TripData>;
+};
+
+export function createJourneyApi(
+  client: GraphQlRequester<'graphql-journeyPlanner3'>,
+): JourneyPlannerApi {
+  const api: JourneyPlannerApi = {
+    async trip(input) {
+      const modes = input.transportModes
+        ? {
+            transportModes: getTransportModesEnums(input.transportModes)?.map(
+              (mode) => ({
+                transportMode: mode,
+              }),
+            ),
+          }
+        : undefined;
+
+      const from = {
+        place: input.from.id,
+        coordinates: {
+          latitude: input.from.geometry.coordinates[1],
+          longitude: input.from.geometry.coordinates[0],
+        },
+        name: input.from.name,
+      };
+      const to = {
+        place: input.to.id,
+        coordinates: {
+          latitude: input.to.geometry.coordinates[1],
+          longitude: input.to.geometry.coordinates[0],
+        },
+        name: input.to.name,
+      };
+
+      const result = await client.query<TripsQuery, TripsQueryVariables>({
+        query: TripsDocument,
+        variables: {
+          from,
+          to,
+          arriveBy: input.arriveBy,
+          when: input.when,
+          numTripPatterns: 10,
+          modes,
+        },
+      });
+
+      if (result.error) {
+        throw result.error;
+      }
+
+      const data: RecursivePartial<TripData> = {
+        nextPageCursor: result.data.trip.nextPageCursor ?? null,
+        tripPatterns: result.data.trip.tripPatterns.map((tripPattern) => ({
+          expectedStartTime: tripPattern.expectedStartTime,
+          expectedEndTime: tripPattern.expectedEndTime,
+          duration: tripPattern.duration || 0,
+          walkDistance: tripPattern.walkDistance || 0,
+          legs: tripPattern.legs.map((leg) => ({
+            mode: isTransportModeType(leg.mode) ? leg.mode : null,
+            distance: leg.distance,
+            duration: leg.duration,
+            aimedStartTime: leg.aimedStartTime,
+            aimedEndTime: leg.aimedEndTime,
+            expectedEndTime: leg.expectedEndTime,
+            expectedStartTime: leg.expectedStartTime,
+            realtime: leg.realtime,
+            transportSubmode: isTransportSubmodeType(leg.transportSubmode)
+              ? leg.transportSubmode
+              : null,
+            line: leg.line
+              ? {
+                  id: leg.line.id,
+                  name: leg.line.name ?? null,
+                  transportSubmode: isTransportSubmodeType(
+                    leg.line.transportSubmode,
+                  )
+                    ? leg.line.transportSubmode
+                    : null,
+                  publicCode: leg.line.publicCode ?? null,
+                  flexibleLineType: leg.line.flexibleLineType ?? null,
+                  notices: mapNotices(leg.line.notices),
+                }
+              : null,
+            fromEstimatedCall: leg.fromEstimatedCall
+              ? {
+                  aimedDepartureTime: leg.fromEstimatedCall.aimedDepartureTime,
+                  expectedDepartureTime:
+                    leg.fromEstimatedCall.expectedDepartureTime,
+                  destinationDisplay: leg.fromEstimatedCall.destinationDisplay
+                    ? {
+                        frontText:
+                          leg.fromEstimatedCall.destinationDisplay.frontText ??
+                          null,
+                      }
+                    : null,
+                  quay: {
+                    publicCode: leg.fromEstimatedCall.quay.publicCode ?? null,
+                    name: leg.fromEstimatedCall.quay.name,
+                  },
+                  notices: mapNotices(leg.fromEstimatedCall.notices),
+                }
+              : null,
+            situations: mapSituations(leg.situations),
+            fromPlace: {
+              name: leg.fromPlace.name ?? null,
+              longitude: leg.fromPlace.longitude,
+              latitude: leg.fromPlace.latitude,
+              quay: leg.fromPlace.quay
+                ? {
+                    publicCode: leg.fromPlace.quay.publicCode ?? null,
+                    name: leg.fromPlace.quay.name,
+                    id: leg.fromPlace.quay.id,
+                    situations: mapSituations(leg.fromPlace.quay.situations),
+                  }
+                : null,
+            },
+            toPlace: {
+              name: leg.toPlace.name ?? null,
+              longitude: leg.toPlace.longitude,
+              latitude: leg.toPlace.latitude,
+              quay: leg.toPlace.quay
+                ? {
+                    publicCode: leg.toPlace.quay.publicCode ?? null,
+                    name: leg.toPlace.quay.name,
+                    id: leg.toPlace.quay.id,
+                    situations: mapSituations(leg.toPlace.quay.situations),
+                  }
+                : null,
+            },
+            serviceJourney: leg.serviceJourney
+              ? {
+                  id: leg.serviceJourney.id,
+                  notices: mapNotices(leg.serviceJourney.notices),
+                  journeyPattern: leg.serviceJourney.journeyPattern
+                    ? {
+                        notices: mapNotices(
+                          leg.serviceJourney.journeyPattern.notices,
+                        ),
+                      }
+                    : null,
+                }
+              : null,
+            interchangeTo: leg.interchangeTo
+              ? {
+                  guaranteed: leg.interchangeTo?.guaranteed ?? false,
+                  toServiceJourney: leg.interchangeTo.toServiceJourney?.id
+                    ? {
+                        id: leg.interchangeTo.toServiceJourney.id,
+                      }
+                    : null,
+                }
+              : null,
+            pointsOnLink:
+              leg.pointsOnLink?.points && leg.pointsOnLink?.length
+                ? {
+                    points: leg.pointsOnLink.points,
+                    length: leg.pointsOnLink.length,
+                  }
+                : null,
+            intermediateEstimatedCalls: leg.intermediateEstimatedCalls.map(
+              (intermediateEstimatedCall) => ({
+                date: intermediateEstimatedCall.date,
+                quay: {
+                  id: intermediateEstimatedCall.quay.id,
+                  name: intermediateEstimatedCall.quay.name,
+                },
+              }),
+            ),
+            authority: leg.authority?.id
+              ? {
+                  id: leg.authority.id,
+                }
+              : null,
+            serviceJourneyEstimatedCalls: null,
+            datedServiceJourney: null,
+          })),
+        })),
+      };
+
+      const validated = tripSchema.safeParse(data);
+      if (!validated.success) {
+        throw validated.error;
+      }
+
+      return validated.data;
+    },
+  };
+
+  return api;
+}
+
+type RecursivePartial<T> = {
+  [P in keyof T]?: T[P] extends (infer U)[]
+    ? RecursivePartial<U>[]
+    : T[P] extends object | undefined
+    ? RecursivePartial<T[P]>
+    : T[P];
+};
+
+function mapSituations(
+  situations: TripsQuery['trip']['tripPatterns'][0]['legs'][0]['situations'][0][],
+): Situation[] {
+  return situations.map((situation) => ({
+    id: situation.id,
+    situationNumber: situation.situationNumber ?? null,
+    reportType: situation.reportType ?? null,
+    summary: situation.summary.map((summary) => ({
+      language: summary.language ?? null,
+      value: summary.value,
+    })),
+    description: situation.description.map((description) => ({
+      language: description.language ?? null,
+      value: description.value,
+    })),
+    advice: situation.advice.map((advice) => ({
+      language: advice.language ?? null,
+      value: advice.value,
+    })),
+    infoLinks: situation.infoLinks
+      ? situation.infoLinks.map((infoLink) => ({
+          uri: infoLink.uri,
+          label: infoLink.label ?? null,
+        }))
+      : null,
+    validityPeriod: situation.validityPeriod
+      ? {
+          startTime: situation.validityPeriod.startTime ?? null,
+          endTime: situation.validityPeriod.endTime ?? null,
+        }
+      : null,
+  }));
+}
+
+function mapNotices(
+  notices: {
+    id: string;
+    text?: string;
+  }[],
+): Notice[] {
+  return notices.map((notice) => ({
+    id: notice.id,
+    text: notice.text ?? null,
+  }));
+}

--- a/src/page-modules/assistant/server/journey-planner/index.ts
+++ b/src/page-modules/assistant/server/journey-planner/index.ts
@@ -16,6 +16,7 @@ import {
   isTransportSubmodeType,
 } from '@atb/page-modules/departures/server/journey-planner';
 import { TripInput } from '@atb/page-modules/assistant';
+import { StreetMode } from '@atb/modules/graphql-types';
 
 export type JourneyPlannerApi = {
   trip(input: TripInput): Promise<TripData>;
@@ -26,15 +27,16 @@ export function createJourneyApi(
 ): JourneyPlannerApi {
   const api: JourneyPlannerApi = {
     async trip(input) {
-      const modes = input.transportModes
-        ? {
-            transportModes: getTransportModesEnums(input.transportModes)?.map(
-              (mode) => ({
-                transportMode: mode,
-              }),
-            ),
-          }
-        : undefined;
+      const journeyModes = {
+        accessMode: StreetMode.Foot,
+        directMode: StreetMode.Foot,
+        egressMode: StreetMode.Foot,
+        transportModes: input.transportModes
+          ? getTransportModesEnums(input.transportModes)?.map((mode) => ({
+              transportMode: mode,
+            }))
+          : undefined,
+      };
 
       const from = {
         place: input.from.id,
@@ -61,7 +63,11 @@ export function createJourneyApi(
           arriveBy: input.arriveBy,
           when: input.when,
           numTripPatterns: 10,
-          modes,
+          modes: journeyModes,
+          waitReluctance: 1.5,
+          walkReluctance: 1.5,
+          walkSpeed: 1.3,
+          transferPenalty: 10,
         },
       });
 

--- a/src/page-modules/assistant/server/journey-planner/journey-gql/trip.gql
+++ b/src/page-modules/assistant/server/journey-planner/journey-gql/trip.gql
@@ -1,0 +1,251 @@
+query Trips(
+  $from: Location!
+  $to: Location!
+  $arriveBy: Boolean!
+  $when: DateTime
+  $cursor: String
+  $transferPenalty: Int
+  $waitReluctance: Float
+  $walkReluctance: Float
+  $walkSpeed: Float
+  $modes: Modes
+  $numTripPatterns: Int
+) {
+  trip(
+    from: $from
+    to: $to
+    dateTime: $when
+    arriveBy: $arriveBy
+    pageCursor: $cursor
+    transferPenalty: $transferPenalty
+    waitReluctance: $waitReluctance
+    walkReluctance: $walkReluctance
+    walkSpeed: $walkSpeed
+    modes: $modes
+    numTripPatterns: $numTripPatterns
+  ) {
+    ...trip
+  }
+}
+
+fragment trip on Trip {
+  nextPageCursor
+  previousPageCursor
+  metadata {
+    nextDateTime
+    prevDateTime
+    searchWindowUsed
+  }
+  tripPatterns {
+    ...tripPattern
+  }
+}
+
+fragment tripPattern on TripPattern {
+  expectedStartTime
+  expectedEndTime
+  duration
+  walkDistance
+  legs {
+    mode
+    distance
+    duration
+    aimedStartTime
+    aimedEndTime
+    expectedEndTime
+    expectedStartTime
+    realtime
+    line {
+      id
+      name
+      transportSubmode
+      publicCode
+      flexibleLineType
+      notices {
+        ...notice
+      }
+    }
+    fromEstimatedCall {
+      aimedDepartureTime
+      expectedDepartureTime
+      destinationDisplay {
+        frontText
+      }
+      quay {
+        publicCode
+        name
+      }
+      notices {
+        ...notice
+      }
+    }
+    situations {
+      ...situation
+    }
+    fromPlace {
+      name
+      longitude
+      latitude
+      quay {
+        id
+        publicCode
+        name
+        longitude
+        latitude
+        stopPlace {
+          id
+          longitude
+          latitude
+          name
+        }
+        situations {
+          ...situation
+        }
+        tariffZones {
+          ...tariffZone
+        }
+      }
+    }
+    toPlace {
+      name
+      longitude
+      latitude
+      quay {
+        id
+        publicCode
+        name
+        longitude
+        latitude
+        stopPlace {
+          id
+          longitude
+          latitude
+          name
+        }
+        situations {
+          ...situation
+        }
+        tariffZones {
+          ...tariffZone
+        }
+      }
+    }
+    serviceJourney {
+      id
+      notices {
+        ...notice
+      }
+      journeyPattern {
+        notices {
+          ...notice
+        }
+      }
+    }
+    interchangeTo {
+      toServiceJourney {
+        id
+      }
+      guaranteed
+    }
+    pointsOnLink {
+      points
+      length
+    }
+    intermediateEstimatedCalls {
+      quay {
+        name
+        id
+      }
+      date
+    }
+    authority {
+      id
+    }
+    transportSubmode
+    serviceJourneyEstimatedCalls {
+      actualDepartureTime
+      realtime
+      aimedDepartureTime
+      expectedDepartureTime
+      quay {
+        name
+      }
+      predictionInaccurate
+    }
+    bookingArrangements {
+      ...bookingArrangement
+    }
+    datedServiceJourney {
+      estimatedCalls {
+        actualDepartureTime
+        quay {
+          name
+        }
+        predictionInaccurate
+      }
+    }
+    rentedBike
+  }
+}
+
+fragment notice on Notice {
+  id
+  text
+}
+
+fragment situation on PtSituationElement {
+  id
+  situationNumber
+  summary {
+    ...multilingualString
+  }
+  description {
+    ...multilingualString
+  }
+  reportType
+  advice {
+    ...multilingualString
+  }
+  infoLinks {
+    ...infoLink
+  }
+  validityPeriod {
+    ...validityPeriod
+  }
+}
+
+fragment tariffZone on TariffZone {
+  id
+  name
+}
+
+fragment bookingArrangement on BookingArrangement {
+  bookingMethods
+  latestBookingTime
+  bookingNote
+  bookWhen
+  latestBookingTime
+  minimumBookingPeriod
+  bookingContact {
+    contactPerson
+    email
+    url
+    phone
+    furtherDetails
+  }
+}
+
+fragment multilingualString on MultilingualString {
+  language
+  value
+}
+
+fragment infoLink on infoLink {
+  uri
+  label
+}
+
+fragment validityPeriod on ValidityPeriod {
+  startTime
+  endTime
+}

--- a/src/page-modules/assistant/server/journey-planner/validators.ts
+++ b/src/page-modules/assistant/server/journey-planner/validators.ts
@@ -1,0 +1,161 @@
+import { TransportModeType, TransportSubmodeType } from '@atb-as/config-specs';
+import { z } from 'zod';
+export const noticeSchema = z.object({
+  id: z.string(),
+  text: z.string().nullable(),
+});
+
+export const serviceJourneySchema = z.object({
+  id: z.string(),
+  notices: z.array(noticeSchema),
+  journeyPattern: z
+    .object({
+      notices: z.array(noticeSchema),
+    })
+    .nullable(),
+});
+export const serviceJourneyEstimatedCallSchema = z.object({
+  actualDepartureTime: z.string(),
+  realtime: z.boolean(),
+  aimedDepartureTime: z.string(),
+  expectedDepartureTime: z.string(),
+  predictionInaccurate: z.boolean(),
+  quay: z.object({
+    name: z.string(),
+  }),
+});
+export const datedServiceJourneySchema = z.object({
+  estimatedCalls: z.array(
+    z.object({
+      actualDepartureTime: z.string(),
+      predictionInaccurate: z.boolean(),
+      quay: z.object({
+        name: z.string(),
+      }),
+    }),
+  ),
+});
+export const tariffZoneSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+});
+export const languageAndTextSchema = z.object({
+  language: z.string().nullable(),
+  value: z.string(),
+});
+export const infoLinkSchema = z.object({
+  uri: z.string(),
+  label: z.string().nullable(),
+});
+
+export const situationSchema = z.object({
+  id: z.string(),
+  situationNumber: z.string().nullable(),
+  reportType: z.enum(['general', 'incident']).nullable(),
+  summary: z.array(languageAndTextSchema),
+  description: z.array(languageAndTextSchema),
+  advice: z.array(languageAndTextSchema),
+  infoLinks: z.array(infoLinkSchema).nullable(),
+  validityPeriod: z
+    .object({
+      startTime: z.string().nullable(),
+      endTime: z.string().nullable(),
+    })
+    .nullable(),
+});
+
+export const placeSchema = z.object({
+  name: z.string().nullable(),
+  longitude: z.number(),
+  latitude: z.number(),
+  quay: z
+    .object({
+      publicCode: z.string().nullable(),
+      name: z.string(),
+      id: z.string(),
+      situations: z.array(situationSchema),
+    })
+    .nullable(),
+});
+
+export const fromEstimatedCallSchema = z.object({
+  aimedDepartureTime: z.string(),
+  expectedDepartureTime: z.string(),
+  destinationDisplay: z.object({ frontText: z.string().nullable() }).nullable(),
+  quay: z.object({ publicCode: z.string().nullable(), name: z.string() }),
+  notices: z.array(noticeSchema).optional(),
+});
+
+export const lineSchema = z.object({
+  id: z.string(),
+  name: z.string().nullable(),
+  transportSubmode: TransportSubmodeType.nullable(),
+  publicCode: z.string().nullable(),
+  flexibleLineType: z.string().nullable(),
+  notices: z.array(noticeSchema),
+});
+
+export const legSchema = z.object({
+  mode: TransportModeType.nullable(),
+  distance: z.number(),
+  duration: z.number(),
+  aimedStartTime: z.string(),
+  aimedEndTime: z.string(),
+  expectedEndTime: z.string(),
+  expectedStartTime: z.string(),
+  realtime: z.boolean(),
+  transportSubmode: TransportSubmodeType.nullable(),
+  line: lineSchema.nullable(),
+  fromEstimatedCall: fromEstimatedCallSchema.nullable(),
+  situations: z.array(situationSchema),
+  fromPlace: placeSchema,
+  toPlace: placeSchema,
+  serviceJourney: serviceJourneySchema.nullable(),
+  interchangeTo: z
+    .object({
+      guaranteed: z.boolean(),
+      toServiceJourney: z
+        .object({
+          id: z.string(),
+        })
+        .nullable(),
+    })
+    .nullable(),
+  pointsOnLink: z
+    .object({
+      points: z.string(),
+      length: z.number(),
+    })
+    .nullable(),
+  intermediateEstimatedCalls: z.array(
+    z.object({
+      date: z.string(),
+      quay: z.object({
+        name: z.string(),
+        id: z.string(),
+      }),
+    }),
+  ),
+  authority: z.object({ id: z.string() }).nullable(),
+  serviceJourneyEstimatedCalls: z
+    .array(serviceJourneyEstimatedCallSchema)
+    .nullable(),
+  datedServiceJourney: datedServiceJourneySchema.nullable(),
+});
+
+export const tripPatternSchema = z.object({
+  expectedStartTime: z.string(),
+  expectedEndTime: z.string(),
+  duration: z.number(),
+  walkDistance: z.number(),
+  legs: z.array(legSchema),
+});
+
+export const tripSchema = z.object({
+  nextPageCursor: z.string().nullable(),
+  tripPatterns: z.array(tripPatternSchema),
+});
+
+export type Notice = z.infer<typeof noticeSchema>;
+export type Situation = z.infer<typeof situationSchema>;
+export type TripData = z.infer<typeof tripSchema>;

--- a/src/page-modules/assistant/types.ts
+++ b/src/page-modules/assistant/types.ts
@@ -1,0 +1,10 @@
+import { TransportModeFilterOption } from '@atb/components/transport-mode-filter/types';
+import { GeocoderFeature } from '@atb/page-modules/departures';
+
+export type TripInput = {
+  from: GeocoderFeature;
+  to: GeocoderFeature;
+  arriveBy: boolean;
+  when: Date;
+  transportModes: TransportModeFilterOption[] | null;
+};

--- a/src/page-modules/assistant/utils.ts
+++ b/src/page-modules/assistant/utils.ts
@@ -1,0 +1,38 @@
+import { GeocoderFeature } from '@atb/page-modules/departures';
+
+export type FromToQuery = {
+  fromId: string;
+  fromName: string;
+  fromLon: string;
+  fromLat: string;
+  fromLayer: string;
+  toId: string;
+  toName: string;
+  toLon: string;
+  toLat: string;
+  toLayer: string;
+};
+
+export const featuresToFromToQuery = (
+  from: GeocoderFeature | undefined,
+  to: GeocoderFeature | undefined,
+): FromToQuery | null => {
+  if (!from || !to) return null;
+  return {
+    fromId: from.id,
+    fromName: from.name,
+    fromLon: from.geometry.coordinates[0].toString(),
+    fromLat: from.geometry.coordinates[1].toString(),
+    fromLayer: from.layer,
+    toId: to.id,
+    toName: to.name,
+    toLon: to.geometry.coordinates[0].toString(),
+    toLat: to.geometry.coordinates[1].toString(),
+    toLayer: to.layer,
+  };
+};
+
+export const parseLayerQueryString = (layer: string): 'address' | 'venue' => {
+  if (layer === 'venue') return 'venue';
+  return 'address';
+};

--- a/src/page-modules/departures/departures.module.css
+++ b/src/page-modules/departures/departures.module.css
@@ -12,7 +12,6 @@
     'alternatives';
 }
 
-
 .main {
   grid-area: main;
   display: grid;
@@ -31,6 +30,18 @@
 .heading {
   color: var(--static-background-background_accent_0-text);
   margin-bottom: var(--spacings-medium);
+}
+
+.geolocationButton {
+  height: var(--height);
+  background-color: var(--static-background-background_0-background);
+  border: none;
+  padding: var(--spacings-small);
+  border-bottom-right-radius: 0.75rem;
+  border-top-right-radius: 0.75rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
 }
 
 .alternativesWrapper {
@@ -56,7 +67,8 @@
   width: 100%;
   max-width: var(--maxPageWidth);
   margin: 0 auto;
-  padding: 0 var(--spacings-xLarge) var(--spacings-xLarge) var(--spacings-xLarge);
+  padding: 0 var(--spacings-xLarge) var(--spacings-xLarge)
+    var(--spacings-xLarge);
   z-index: 10;
 }
 

--- a/src/page-modules/departures/layout.tsx
+++ b/src/page-modules/departures/layout.tsx
@@ -88,9 +88,7 @@ function DeparturesLayout({
               button={
                 <GeolocationButton
                   className={style.geolocationButton}
-                  onGeolocate={(feature: GeocoderFeature) => {
-                    setSelectedFeature(feature);
-                  }}
+                  onGeolocate={setSelectedFeature}
                 />
               }
             />

--- a/src/page-modules/departures/layout.tsx
+++ b/src/page-modules/departures/layout.tsx
@@ -19,6 +19,7 @@ import {
 import { TransportModeFilterOption } from '@atb/components/transport-mode-filter/types';
 import { MonoIcon } from '@atb/components/icon';
 import { FocusScope } from '@react-aria/focus';
+import GeolocationButton from '@atb/components/search/geolocation-button';
 
 export type DeparturesLayoutProps = PropsWithChildren<{
   initialTransportModesFilter?: TransportModeFilterOption[] | null;
@@ -84,6 +85,14 @@ function DeparturesLayout({
             <Search
               label={t(PageText.Departures.search.input.from)}
               onChange={setSelectedFeature}
+              button={
+                <GeolocationButton
+                  className={style.geolocationButton}
+                  onGeolocate={(feature: GeocoderFeature) => {
+                    setSelectedFeature(feature);
+                  }}
+                />
+              }
             />
           </div>
 

--- a/src/page-modules/departures/server/geocoder/index.ts
+++ b/src/page-modules/departures/server/geocoder/index.ts
@@ -6,7 +6,11 @@ import { first } from 'lodash';
 
 export type GeocoderApi = {
   autocomplete(query: string): Promise<GeocoderFeature[]>;
-  reverse(lat: number, lon: number): Promise<GeocoderFeature | undefined>;
+  reverse(
+    lat: number,
+    lon: number,
+    layers: 'address' | 'venue',
+  ): Promise<GeocoderFeature | undefined>;
 };
 
 export function createGeocoderApi(
@@ -27,9 +31,9 @@ export function createGeocoderApi(
       return mapGeocoderFeature(parsed.data);
     },
 
-    async reverse(lat, lon) {
+    async reverse(lat, lon, layers) {
       const result = await request(
-        `/geocoder/v1/reverse?point.lat=${lat}&point.lon=${lon}&boundary.circle.radius=1&size=1&layers=address`,
+        `/geocoder/v1/reverse?point.lat=${lat}&point.lon=${lon}&size=1&layers=${layers}&lang=no`,
       );
 
       const parsed = geocoderRootSchema.safeParse(await result.json());

--- a/src/page-modules/departures/server/journey-planner/index.ts
+++ b/src/page-modules/departures/server/journey-planner/index.ts
@@ -36,7 +36,7 @@ import {
   TransportMode,
   TransportMode as GraphqlTransportMode,
 } from '@atb/modules/graphql-types';
-import { TransportModeType } from '@atb-as/config-specs';
+import { TransportModeType, TransportSubmodeType } from '@atb-as/config-specs';
 import { TransportModeFilterOption } from '@atb/components/transport-mode-filter/types';
 import { getAllTransportModesFromFilterOptions } from '@atb/components/transport-mode-filter/utils';
 import { enumFromString } from '@atb/utils/enum-from-string';
@@ -291,11 +291,15 @@ const filterTransportModes = (
   return transportModes;
 };
 
-const isTransportModeType = (a: any): a is TransportModeType => {
+export const isTransportModeType = (a: any): a is TransportModeType => {
   return TransportModeType.safeParse(a).success;
 };
 
-const getTransportModesEnums = (
+export const isTransportSubmodeType = (a: any): a is TransportSubmodeType => {
+  return TransportSubmodeType.safeParse(a).success;
+};
+
+export const getTransportModesEnums = (
   transportModes: TransportModeFilterOption[] | null,
 ): TransportMode[] | null => {
   if (!transportModes) return null;

--- a/src/pages/api/departures/reverse.ts
+++ b/src/pages/api/departures/reverse.ts
@@ -20,7 +20,11 @@ export default handlerWithDepartureClient<ReverseApiReturnType>({
 
     return tryResult(req, res, async () => {
       return ok(
-        await client.reverse(parseFloat(lat.data), parseFloat(lon.data)),
+        await client.reverse(
+          parseFloat(lat.data),
+          parseFloat(lon.data),
+          'address',
+        ),
       );
     });
   },

--- a/src/pages/assistant/assistant.module.css
+++ b/src/pages/assistant/assistant.module.css
@@ -1,0 +1,11 @@
+.tripPattern {
+  display: flex;
+  flex-direction: column;
+  padding: var(--spacings-medium);
+  border-bottom: 1px solid black;
+}
+
+.leg {
+  display: grid;
+  grid-template-columns: 1fr 1fr 4fr 2fr;
+}

--- a/src/pages/assistant/index.tsx
+++ b/src/pages/assistant/index.tsx
@@ -89,17 +89,17 @@ export const getServerSideProps = withGlobalData(
           parseLayerQueryString(query.toLayer.toString()),
         );
       }
-
-      const arriveBy = query.arriveBy === 'true';
-      const when = query.when
-        ? new Date(Number(query.when.toString()))
-        : new Date();
+      const arriveBy =
+        query.arriveBy && new Date(Number(query.arriveBy.toString()));
+      const departBy =
+        query.departBy && new Date(Number(query.departBy.toString()));
+      const when = arriveBy || departBy || new Date();
 
       if (initialFromFeature && initialToFeature) {
         const trip = await client.trip({
           from: initialFromFeature,
           to: initialToFeature,
-          arriveBy,
+          arriveBy: Boolean(arriveBy),
           when,
           transportModes: transportModeFilter,
         });

--- a/src/pages/assistant/index.tsx
+++ b/src/pages/assistant/index.tsx
@@ -81,7 +81,7 @@ export const getServerSideProps = withGlobalData(
         initialFromFeature = await client.reverse(fromLat, fromLon, fromLayer);
       }
 
-      let initialToFeature = undefined;
+      let initialToFeature;
       if (query.toLat && query.toLon && query.toLayer) {
         initialToFeature = await client.reverse(
           parseFloat(query.toLat.toString()),

--- a/src/pages/assistant/index.tsx
+++ b/src/pages/assistant/index.tsx
@@ -72,7 +72,7 @@ export const getServerSideProps = withGlobalData(
     async function ({ client, query }) {
       const transportModeFilter = parseFilterQuery(query.filter);
 
-      let initialFromFeature = undefined;
+      let initialFromFeature;
       if (query.fromLat && query.fromLon && query.fromLayer) {
         const fromLat = parseFloat(query.fromLat.toString());
         const fromLon = parseFloat(query.fromLon.toString());

--- a/src/pages/assistant/index.tsx
+++ b/src/pages/assistant/index.tsx
@@ -1,0 +1,124 @@
+import { parseFilterQuery } from '@atb/components/transport-mode-filter/utils';
+import DefaultLayout from '@atb/layouts/default';
+import { WithGlobalData, withGlobalData } from '@atb/layouts/global-data';
+import AssistantLayout, {
+  AssistantLayoutProps,
+} from '@atb/page-modules/assistant/layout';
+import { withAssistantClient } from '@atb/page-modules/assistant/server';
+import { TripData } from '@atb/page-modules/assistant/server/journey-planner/validators';
+import { useTranslation } from '@atb/translations';
+import { formatLocaleTime } from '@atb/utils/date';
+import { NextPage } from 'next';
+import style from './assistant.module.css';
+import { parseLayerQueryString } from '@atb/page-modules/assistant/utils';
+
+type AssistantContentProps = { empty: true } | { trip: TripData };
+
+export type AssistantPageProps = WithGlobalData<
+  AssistantLayoutProps & AssistantContentProps
+>;
+
+function AssistantContent(props: AssistantContentProps) {
+  const { language } = useTranslation();
+  if (isTripDataProps(props)) {
+    return (
+      <section>
+        {props.trip.tripPatterns.map((tripPattern, i) => (
+          <div
+            key={`tripPattern-${tripPattern.expectedStartTime}-${i}`}
+            className={style.tripPattern}
+          >
+            {tripPattern.legs.map((leg, i) => (
+              <div
+                key={`leg-${leg.expectedStartTime}-${i}`}
+                className={style.leg}
+              >
+                <span>{leg.mode ? leg.mode : 'foot'}</span>
+                <span>{leg.line?.publicCode}</span>
+                <span>
+                  {leg.fromPlace.name} til {leg.toPlace.name}
+                </span>
+                <span>
+                  {formatLocaleTime(leg.aimedStartTime, language)} -{' '}
+                  {formatLocaleTime(leg.aimedEndTime, language)}
+                </span>
+              </div>
+            ))}
+          </div>
+        ))}
+      </section>
+    );
+  }
+}
+
+function isTripDataProps(a: any): a is { trip: TripData } {
+  return 'trip' in a;
+}
+
+const AssistantPage: NextPage<AssistantPageProps> = (props) => {
+  return (
+    <DefaultLayout {...props}>
+      <AssistantLayout {...props}>
+        <AssistantContent {...props} />
+      </AssistantLayout>
+    </DefaultLayout>
+  );
+};
+
+export default AssistantPage;
+
+export const getServerSideProps = withGlobalData(
+  withAssistantClient<AssistantLayoutProps & AssistantContentProps>(
+    async function ({ client, query }) {
+      const transportModeFilter = parseFilterQuery(query.filter);
+
+      let initialFromFeature = undefined;
+      if (query.fromLat && query.fromLon && query.fromLayer) {
+        const fromLat = parseFloat(query.fromLat.toString());
+        const fromLon = parseFloat(query.fromLon.toString());
+        const fromLayer = parseLayerQueryString(query.fromLayer.toString());
+
+        initialFromFeature = await client.reverse(fromLat, fromLon, fromLayer);
+      }
+
+      let initialToFeature = undefined;
+      if (query.toLat && query.toLon && query.toLayer) {
+        initialToFeature = await client.reverse(
+          parseFloat(query.toLat.toString()),
+          parseFloat(query.toLon.toString()),
+          parseLayerQueryString(query.toLayer.toString()),
+        );
+      }
+
+      const arriveBy = query.arriveBy === 'true';
+      const when = query.when
+        ? new Date(Number(query.when.toString()))
+        : new Date();
+
+      if (initialFromFeature && initialToFeature) {
+        const trip = await client.trip({
+          from: initialFromFeature,
+          to: initialToFeature,
+          arriveBy,
+          when,
+          transportModes: transportModeFilter,
+        });
+
+        return {
+          props: {
+            initialFromFeature,
+            initialToFeature,
+            initialTransportModesFilter: transportModeFilter,
+            trip,
+          },
+        };
+      }
+
+      return {
+        props: {
+          empty: true,
+        },
+      };
+    },
+  ),
+);

--- a/src/pages/departures/[[...id]].tsx
+++ b/src/pages/departures/[[...id]].tsx
@@ -86,7 +86,11 @@ export const getServerSideProps = withGlobalData(
         transportModes: transportModeFilter,
       });
 
-      const activeLocation = await client.reverse(position.lat, position.lon);
+      const activeLocation = await client.reverse(
+        position.lat,
+        position.lon,
+        'address',
+      );
 
       return {
         props: {

--- a/src/translations/components/index.ts
+++ b/src/translations/components/index.ts
@@ -5,3 +5,4 @@ export { DepartureDateSelector } from './departure-date-selector';
 export { Map } from './map';
 export { TransportMode } from './transport-mode';
 export { TransportModeFilter } from './transport-mode-filter';
+export { SwapButton } from './swap-button';

--- a/src/translations/components/swap-button.ts
+++ b/src/translations/components/swap-button.ts
@@ -1,0 +1,9 @@
+import { translation as _ } from '@atb/translations/commons';
+
+export const SwapButton = {
+  alt: _(
+    'Bytt avreisested og ankomststed',
+    'Swap place of departure/arrival',
+    'Byt avreisestad og framkomststad',
+  ),
+};

--- a/src/translations/pages/assistant.ts
+++ b/src/translations/pages/assistant.ts
@@ -1,0 +1,39 @@
+import { translation as _ } from '@atb/translations/commons';
+
+export const Assistant = {
+  title: _('Planlegg reisen', 'Plan travel', 'Planlegg reisen'),
+  shortTitle: _('Reiseplanlegger', 'Assistant', 'Reiseplanlegger'),
+  search: {
+    input: {
+      label: _(
+        'Hvor vil du reise?',
+        'Where do you want to go?',
+        'Kor vil du reise?',
+      ),
+      from: _('Fra', 'From', 'Frå'),
+      to: _('Til', 'To', 'Til'),
+    },
+    date: {
+      label: _(
+        'Når vil du reise?',
+        'When do you want to travel?',
+        'Når vil du reise?',
+      ),
+    },
+    filter: {
+      label: _(
+        'Hva vil du reise med?',
+        'How do you want to travel?',
+        'Kva vil du reise med?',
+      ),
+    },
+    buttons: {
+      find: {
+        title: _('Finn avganger', 'Find departures', 'Finn avganger'),
+      },
+      alternatives: {
+        title: _('Flere valg', 'More choices', 'Fleire val'),
+      },
+    },
+  },
+};

--- a/src/translations/pages/assistant.ts
+++ b/src/translations/pages/assistant.ts
@@ -1,8 +1,8 @@
 import { translation as _ } from '@atb/translations/commons';
 
 export const Assistant = {
-  title: _('Planlegg reisen', 'Plan travel', 'Planlegg reisen'),
-  shortTitle: _('Reiseplanlegger', 'Assistant', 'Reiseplanlegger'),
+  title: _('Planlegg reisen', 'Plan travel', 'Planlegg reisa'),
+  shortTitle: _('Reiseplanlegger', 'Assistant', 'Reiseplanleggar'),
   search: {
     input: {
       label: _(

--- a/src/translations/pages/index.ts
+++ b/src/translations/pages/index.ts
@@ -1,1 +1,2 @@
 export { Departures } from './departures';
+export { Assistant } from './assistant';


### PR DESCRIPTION
This includes the assistant page header and the required functionality to get a trip with trip patterns. We might want to fine-tune the data included in a trip, but that might be easier to do when we start to work on the assistant page content. The search is stored in the URL. 

### TODO
- [x] Update search bar text on swap
- [x] Tests

Closes https://github.com/AtB-AS/kundevendt/issues/11317

<details>
<summary>Screenshots</summary>

<img width="1089" alt="image" src="https://github.com/AtB-AS/planner-web/assets/43166974/cd178974-d1fd-48d7-93e7-ad47310727af">

<img width="1073" alt="image" src="https://github.com/AtB-AS/planner-web/assets/43166974/dcfbc46e-33b3-4d53-8158-448cb8a2274a">

<img width="1063" alt="image" src="https://github.com/AtB-AS/planner-web/assets/43166974/0b68e8cd-b20f-42f6-9c6b-71a3e8421cac">

</details>