### PR TITLE
fix: fix bug in MonoIcon dark mode

### DIFF
--- a/src/components/icon/mono-icon.tsx
+++ b/src/components/icon/mono-icon.tsx
@@ -73,9 +73,9 @@ function colorToMode(
 function useInteractiveThemeColor(
   interactiveColorName?: keyof Theme['interactive'],
   interactiveState?: keyof InteractiveColor,
-): MonoIconProps['overrideMode'] | undefined {
+): MonoIconProps['overrideMode'] {
   const { interactive } = useTheme();
-  if (!interactiveColorName) return undefined;
+  if (!interactiveColorName) return 'none';
   const interactiveColor = interactive[interactiveColorName];
 
   if (!interactiveState)

--- a/src/page-modules/assistant/trip-pattern/index.tsx
+++ b/src/page-modules/assistant/trip-pattern/index.tsx
@@ -60,7 +60,7 @@ export function TripPattern({ tripPattern, index }: TripPatternProps) {
             </div>
 
             <Typo.span textType="body__tertiary">
-              {formatLocaleTime(tripPattern.expectedEndTime, language)}
+              {formatLocaleTime(leg.aimedStartTime, language)}
             </Typo.span>
           </div>
         ))}


### PR DESCRIPTION
There was a bug in setting the `darkModeString` for `MonoIcon`. The hook `useInteractiveThemeColor` returned `undefined` instead of `none`, which caused issues.