### PR TITLE
feat: adds non-transit data to trip patterns.

### DIFF
--- a/src/components/button/button.module.css
+++ b/src/components/button/button.module.css
@@ -218,6 +218,9 @@
 .button--size_compact {
   padding: 0;
 }
+.button--size_pill {
+  padding: var(--spacings-xSmall) var(--spacings-medium);
+}
 
 .button--radius_top-bottom {
   border-radius: var(--border-radius-regular);

--- a/src/components/button/utils.tsx
+++ b/src/components/button/utils.tsx
@@ -36,7 +36,7 @@ export type ButtonBaseProps = {
    * Button padding size
    * @default 'small'
    */
-  size?: 'medium' | 'small' | 'compact';
+  size?: 'medium' | 'small' | 'pill' | 'compact';
 
   /**
    * Set button state

--- a/src/components/map/map-header.tsx
+++ b/src/components/map/map-header.tsx
@@ -6,7 +6,7 @@ import { and } from '@atb/utils/css';
 import { MonoIcon } from '@atb/components/icon';
 import { transportModeToTranslatedString } from '@atb/components/transport-mode';
 import { getTransportModeIcon } from '@atb/components/transport-mode/transport-icon';
-import { TransportModeType } from '@atb-as/config-specs';
+import { TransportModeType } from '@atb/components/transport-mode/types';
 
 export type MapHeaderProps = {
   id: string;

--- a/src/components/transport-mode/index.ts
+++ b/src/components/transport-mode/index.ts
@@ -1,4 +1,8 @@
-export { TransportIcons, TransportIcon } from './transport-icon';
+export {
+  TransportIcons,
+  TransportIcon,
+  TransportMonoIcon,
+} from './transport-icon';
 export type { TransportIconsProps, TransportIconProps } from './transport-icon';
 
 export {

--- a/src/components/transport-mode/transport-icon/index.tsx
+++ b/src/components/transport-mode/transport-icon/index.tsx
@@ -1,4 +1,4 @@
-import { TransportModeGroup } from '../types';
+import { TransportModeGroup, TransportSubmodeType } from '../types';
 
 import { ContrastColor, Theme } from '@atb-as/theme';
 import MonoIcon, { MonoIconProps } from '@atb/components/icon/mono-icon';
@@ -8,7 +8,6 @@ import { useTranslation } from '@atb/translations';
 import { transportModeToTranslatedString } from '../utils';
 import style from './transport-icon.module.css';
 import { colorToOverrideMode } from '@atb/utils/color';
-import { TransportSubmodeType } from '@atb-as/config-specs';
 
 export type TransportIconsProps = {
   modes: TransportModeGroup[];
@@ -39,6 +38,16 @@ export function TransportIcon({ mode }: TransportIconProps) {
         overrideMode={overrideMode}
       />
     </span>
+  );
+}
+export function TransportMonoIcon({ mode }: TransportIconProps) {
+  const { t } = useTranslation();
+  return (
+    <MonoIcon
+      icon={getTransportModeIcon(mode)}
+      role="img"
+      alt={t(transportModeToTranslatedString(mode))}
+    />
   );
 }
 
@@ -112,6 +121,9 @@ function modeToColor(
     case 'tram':
       return transport.transport_city.primary;
 
+    case 'bicycle':
+      return transport.transport_bike.primary;
+
     case 'water':
       return transport.transport_boat.primary;
 
@@ -137,6 +149,10 @@ export function getTransportModeIcon(
       return 'transportation/Tram';
     case 'rail':
       return 'transportation/Train';
+    case 'foot':
+      return 'transportation/Walk';
+    case 'bicycle':
+      return 'transportation-entur/Bicycle';
     case 'air':
       return 'transportation-entur/Plane';
     case 'water':

--- a/src/components/transport-mode/types.ts
+++ b/src/components/transport-mode/types.ts
@@ -1,4 +1,27 @@
-import { TransportModeType, TransportSubmodeType } from '@atb-as/config-specs';
+import { TransportSubmodeType } from '@atb-as/config-specs';
+import { z } from 'zod';
+
+export const TransportModeType = z.union([
+  z.literal('air'),
+  z.literal('bus'),
+  z.literal('foot'),
+  z.literal('bicycle'),
+  z.literal('cableway'),
+  z.literal('coach'),
+  z.literal('funicular'),
+  z.literal('lift'),
+  z.literal('metro'),
+  z.literal('monorail'),
+  z.literal('rail'),
+  z.literal('taxi'),
+  z.literal('tram'),
+  z.literal('trolleybus'),
+  z.literal('unknown'),
+  z.literal('water'),
+]);
+export type TransportModeType = z.infer<typeof TransportModeType>;
+
+export { TransportSubmodeType };
 
 export type TransportModeGroup = {
   mode: TransportModeType;

--- a/src/page-modules/assistant/__tests__/assistant.test.tsx
+++ b/src/page-modules/assistant/__tests__/assistant.test.tsx
@@ -11,6 +11,7 @@ import { GeocoderFeature } from '@atb/page-modules/departures';
 import { FeatureCategory } from '@atb/components/venue-icon';
 import { GeocoderApi } from '@atb/page-modules/departures/server/geocoder';
 import AssistantLayout from '../layout';
+import { NonTransitTripData } from '..';
 
 afterEach(function () {
   cleanup();
@@ -48,6 +49,12 @@ describe('assistant page', function () {
       nextPageCursor: 'aaa',
       tripPatterns: [],
     };
+    const expectedNonTransitTripResult: NonTransitTripData = {
+      footTrip: {
+        nextPageCursor: 'bbb',
+        tripPatterns: [],
+      },
+    };
 
     const gqlClient: ExternalClient<
       'graphql-journeyPlanner3' | 'http-entur',
@@ -57,7 +64,7 @@ describe('assistant page', function () {
         return expectedTripResult;
       },
       async nonTransitTrips() {
-        return {};
+        return expectedNonTransitTripResult;
       },
       async autocomplete() {
         return {} as any;
@@ -94,6 +101,7 @@ describe('assistant page', function () {
       initialFromFeature: expectedFromFeature,
       initialToFeature: expectedToFeature,
       trip: expectedTripResult,
+      nonTransitTrips: expectedNonTransitTripResult,
     });
   });
 

--- a/src/page-modules/assistant/__tests__/assistant.test.tsx
+++ b/src/page-modules/assistant/__tests__/assistant.test.tsx
@@ -56,6 +56,9 @@ describe('assistant page', function () {
       async trip() {
         return expectedTripResult;
       },
+      async nonTransitTrips() {
+        return {};
+      },
       async autocomplete() {
         return {} as any;
       },

--- a/src/page-modules/assistant/assistant.module.css
+++ b/src/page-modules/assistant/assistant.module.css
@@ -65,7 +65,8 @@
   width: 100%;
   max-width: var(--maxPageWidth);
   margin: 0 auto;
-  padding: 0 var(--spacings-xLarge) var(--spacings-xLarge) var(--spacings-xLarge);
+  padding: 0 var(--spacings-xLarge) var(--spacings-xLarge)
+    var(--spacings-xLarge);
   z-index: 10;
   position: absolute;
   left: 0;
@@ -115,5 +116,17 @@
   padding: var(--spacings-xLarge);
   display: flex;
   flex-direction: column;
+  gap: var(--spacings-medium);
+}
+
+.tripResults {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacings-medium);
+}
+
+.nonTransitResult {
+  display: flex;
+  flex-wrap: wrap;
   gap: var(--spacings-medium);
 }

--- a/src/page-modules/assistant/assistant.module.css
+++ b/src/page-modules/assistant/assistant.module.css
@@ -122,7 +122,7 @@
 .tripResults {
   display: flex;
   flex-direction: column;
-  gap: var(--spacings-medium);
+  gap: var(--spacings-large);
 }
 
 .nonTransitResult {

--- a/src/page-modules/assistant/index.ts
+++ b/src/page-modules/assistant/index.ts
@@ -1,1 +1,5 @@
 export * from './types';
+export { TripPattern } from './trip-pattern';
+export { parseLayerQueryString } from './utils';
+export type { AssistantLayoutProps } from './layout';
+export { default as AssistantLayout } from './layout';

--- a/src/page-modules/assistant/non-transit-pill/index.tsx
+++ b/src/page-modules/assistant/non-transit-pill/index.tsx
@@ -1,4 +1,3 @@
-import { TransportModeType } from '@atb-as/config-specs';
 import { ButtonLink } from '@atb/components/button';
 import { MonoIcon } from '@atb/components/icon';
 import { TransportMonoIcon } from '@atb/components/transport-mode';
@@ -6,6 +5,7 @@ import { type TripPattern } from '@atb/page-modules/assistant/server/journey-pla
 import { PageText, TranslateFunction, useTranslation } from '@atb/translations';
 import { secondsToDurationShort } from '@atb/utils/date';
 import { NonTransitTripData } from '..';
+import { TransportModeType } from '@atb/components/transport-mode/types';
 
 type NonTransitTripProps = {
   tripPattern: TripPattern;

--- a/src/page-modules/assistant/non-transit-pill/index.tsx
+++ b/src/page-modules/assistant/non-transit-pill/index.tsx
@@ -43,15 +43,15 @@ const getMode = (
   tp: TripPattern,
   t: TranslateFunction,
 ): { mode: TransportModeType; modeText: string } => {
-  let mode = tp.legs[0].mode ?? 'unknown';
+  let mode = tp.legs[0]?.mode ?? 'unknown';
   let text = t(PageText.Assistant.nonTransit.unknown);
 
   if (tp.legs.some((leg) => leg.rentedBike)) {
     mode = 'bicycle';
     text = t(PageText.Assistant.nonTransit.bikeRental);
-  } else if (tp.legs[0].mode === 'foot') {
+  } else if (mode === 'foot') {
     text = t(PageText.Assistant.nonTransit.foot);
-  } else if (tp.legs[0].mode === 'bicycle') {
+  } else if (mode === 'bicycle') {
     text = t(PageText.Assistant.nonTransit.bicycle);
   }
 

--- a/src/page-modules/assistant/non-transit-pill/index.tsx
+++ b/src/page-modules/assistant/non-transit-pill/index.tsx
@@ -1,0 +1,59 @@
+import { TransportModeType } from '@atb-as/config-specs';
+import { ButtonLink } from '@atb/components/button';
+import { MonoIcon } from '@atb/components/icon';
+import { TransportMonoIcon } from '@atb/components/transport-mode';
+import { type TripPattern } from '@atb/page-modules/assistant/server/journey-planner/validators';
+import { PageText, TranslateFunction, useTranslation } from '@atb/translations';
+import { secondsToDurationShort } from '@atb/utils/date';
+import { NonTransitTripData } from '..';
+
+type NonTransitTripProps = {
+  tripPattern: TripPattern;
+  nonTransitType: keyof NonTransitTripData;
+};
+export function NonTransitTrip({
+  tripPattern,
+  nonTransitType,
+}: NonTransitTripProps) {
+  const { t, language } = useTranslation();
+
+  if (!tripPattern) {
+    return null;
+  }
+
+  const { mode, modeText } = getMode(tripPattern, t);
+
+  const durationShort = secondsToDurationShort(tripPattern.duration, language);
+
+  return (
+    <ButtonLink
+      radiusSize="circular"
+      size="pill"
+      href="/assistant"
+      title={`${modeText} ${durationShort}`}
+      icon={{
+        left: <TransportMonoIcon mode={{ mode }} />,
+        right: <MonoIcon icon="navigation/ArrowRight" />,
+      }}
+    />
+  );
+}
+
+const getMode = (
+  tp: TripPattern,
+  t: TranslateFunction,
+): { mode: TransportModeType; modeText: string } => {
+  let mode = tp.legs[0].mode ?? 'unknown';
+  let text = t(PageText.Assistant.nonTransit.unknown);
+
+  if (tp.legs.some((leg) => leg.rentedBike)) {
+    mode = 'bicycle';
+    text = t(PageText.Assistant.nonTransit.bikeRental);
+  } else if (tp.legs[0].mode === 'foot') {
+    text = t(PageText.Assistant.nonTransit.foot);
+  } else if (tp.legs[0].mode === 'bicycle') {
+    text = t(PageText.Assistant.nonTransit.bicycle);
+  }
+
+  return { mode, modeText: text };
+};

--- a/src/page-modules/assistant/server/journey-planner/journey-gql/trip.gql
+++ b/src/page-modules/assistant/server/journey-planner/journey-gql/trip.gql
@@ -28,6 +28,48 @@ query Trips(
   }
 }
 
+query TripsNonTransit(
+  $from: Location!
+  $to: Location!
+  $arriveBy: Boolean!
+  $when: DateTime
+  $walkSpeed: Float
+  $includeFoot: Boolean!
+  $includeBicycle: Boolean!
+  $includeBikeRental: Boolean!
+) {
+  footTrip: trip(
+    from: $from
+    to: $to
+    dateTime: $when
+    arriveBy: $arriveBy
+    walkSpeed: $walkSpeed
+    modes: { directMode: foot, transportModes: [] }
+  ) @include(if: $includeFoot) {
+    ...trip
+  }
+  bikeRentalTrip: trip(
+    from: $from
+    to: $to
+    dateTime: $when
+    arriveBy: $arriveBy
+    walkSpeed: $walkSpeed
+    modes: { directMode: bike_rental, transportModes: [] }
+  ) @include(if: $includeBikeRental) {
+    ...trip
+  }
+  bicycleTrip: trip(
+    from: $from
+    to: $to
+    dateTime: $when
+    arriveBy: $arriveBy
+    walkSpeed: $walkSpeed
+    modes: { directMode: bicycle, transportModes: [] }
+  ) @include(if: $includeBicycle) {
+    ...trip
+  }
+}
+
 fragment trip on Trip {
   nextPageCursor
   previousPageCursor

--- a/src/page-modules/assistant/server/journey-planner/validators.ts
+++ b/src/page-modules/assistant/server/journey-planner/validators.ts
@@ -1,4 +1,7 @@
-import { TransportModeType, TransportSubmodeType } from '@atb-as/config-specs';
+import {
+  TransportModeType,
+  TransportSubmodeType,
+} from '@atb/components/transport-mode/types';
 import { z } from 'zod';
 export const noticeSchema = z.object({
   id: z.string(),
@@ -111,6 +114,7 @@ export const legSchema = z.object({
   fromPlace: placeSchema,
   toPlace: placeSchema,
   serviceJourney: serviceJourneySchema.nullable(),
+  rentedBike: z.boolean().nullable(),
   interchangeTo: z
     .object({
       guaranteed: z.boolean(),

--- a/src/page-modules/assistant/types.ts
+++ b/src/page-modules/assistant/types.ts
@@ -1,5 +1,6 @@
-import { TransportModeFilterOption } from '@atb/components/transport-mode-filter/types';
-import { GeocoderFeature } from '@atb/page-modules/departures';
+import type { TripData } from './server/journey-planner/validators';
+import type { TransportModeFilterOption } from '@atb/components/transport-mode-filter/types';
+import type { GeocoderFeature } from '@atb/page-modules/departures';
 
 export type TripInput = {
   from: GeocoderFeature;
@@ -7,4 +8,40 @@ export type TripInput = {
   arriveBy: boolean;
   when: Date;
   transportModes: TransportModeFilterOption[] | null;
+};
+
+export enum StreetMode {
+  /** Bike only. This can be used as access/egress, but transfers will still be walk only. */
+  Bicycle = 'bicycle',
+  /** Bike to a bike parking area, then walk the rest of the way. Direct mode and access mode only. */
+  BikePark = 'bike_park',
+  /** Walk to a bike rental point, bike to a bike rental drop-off point, and walk the rest of the way. This can include bike rental at fixed locations or free-floating services. */
+  BikeRental = 'bike_rental',
+  /** Car only. Direct mode only. */
+  Car = 'car',
+  /** Start in the car, drive to a parking area, and walk the rest of the way. Direct mode and access mode only. */
+  CarPark = 'car_park',
+  /** Walk to a pickup point along the road, drive to a drop-off point along the road, and walk the rest of the way. This can include various taxi-services or kiss & ride. */
+  CarPickup = 'car_pickup',
+  /** Walk to an eligible pickup area for flexible transportation, ride to an eligible drop-off area and then walk the rest of the way. */
+  Flexible = 'flexible',
+  /** Walk only */
+  Foot = 'foot',
+  /** Walk to a scooter rental point, ride a scooter to a scooter rental drop-off point, and walk the rest of the way. This can include scooter rental at fixed locations or free-floating services. */
+  ScooterRental = 'scooter_rental',
+}
+
+export type NonTransitTripInput = {
+  from: GeocoderFeature;
+  to: GeocoderFeature;
+  arriveBy: boolean;
+  when: Date;
+  directModes: StreetMode[];
+};
+
+export type { TripData };
+export type NonTransitTripData = {
+  cycleTrip?: TripData;
+  footTrip?: TripData;
+  bikeRentalTrip?: TripData;
 };

--- a/src/page-modules/departures/server/journey-planner/index.ts
+++ b/src/page-modules/departures/server/journey-planner/index.ts
@@ -36,10 +36,13 @@ import {
   TransportMode,
   TransportMode as GraphqlTransportMode,
 } from '@atb/modules/graphql-types';
-import { TransportModeType, TransportSubmodeType } from '@atb-as/config-specs';
 import { TransportModeFilterOption } from '@atb/components/transport-mode-filter/types';
 import { getAllTransportModesFromFilterOptions } from '@atb/components/transport-mode-filter/utils';
 import { enumFromString } from '@atb/utils/enum-from-string';
+import {
+  TransportModeType,
+  TransportSubmodeType,
+} from '@atb/components/transport-mode/types';
 
 export type DepartureInput = {
   id: string;

--- a/src/page-modules/departures/server/journey-planner/validators.ts
+++ b/src/page-modules/departures/server/journey-planner/validators.ts
@@ -1,5 +1,8 @@
+import {
+  TransportModeType,
+  TransportSubmodeType,
+} from '@atb/components/transport-mode/types';
 import { z } from 'zod';
-import { TransportModeType, TransportSubmodeType } from '@atb-as/config-specs';
 
 export const locationSchema = z.object({
   lat: z.number(),

--- a/src/pages/assistant/index.tsx
+++ b/src/pages/assistant/index.tsx
@@ -11,6 +11,9 @@ import {
   AssistantLayoutProps,
 } from '@atb/page-modules/assistant';
 import type { NextPage } from 'next';
+import { NonTransitTrip } from '@atb/page-modules/assistant/non-transit-pill';
+
+import style from '@atb/page-modules/assistant/assistant.module.css';
 
 type AssistantContentProps =
   | { empty: true }
@@ -22,13 +25,29 @@ export type AssistantPageProps = WithGlobalData<
 
 function AssistantContent(props: AssistantContentProps) {
   if (isTripDataProps(props)) {
-    return props.trip.tripPatterns.map((tripPattern, i) => (
-      <TripPattern
-        key={`tripPattern-${tripPattern.expectedStartTime}-${i}`}
-        tripPattern={tripPattern}
-        index={i}
-      />
-    ));
+    const nonTransits = Object.entries(props.nonTransitTrips);
+    return (
+      <div className={style.tripResults}>
+        {nonTransits.length > 0 && (
+          <div className={style.nonTransitResult}>
+            {Object.entries(props.nonTransitTrips).map(([legType, trip]) => (
+              <NonTransitTrip
+                key={legType}
+                tripPattern={trip.tripPatterns[0]}
+                nonTransitType={legType as keyof NonTransitTripData}
+              />
+            ))}
+          </div>
+        )}
+        {props.trip.tripPatterns.map((tripPattern, i) => (
+          <TripPattern
+            key={`tripPattern-${tripPattern.expectedStartTime}-${i}`}
+            tripPattern={tripPattern}
+            index={i}
+          />
+        ))}
+      </div>
+    );
   }
 }
 

--- a/src/pages/assistant/index.tsx
+++ b/src/pages/assistant/index.tsx
@@ -1,16 +1,20 @@
 import { parseFilterQuery } from '@atb/components/transport-mode-filter/utils';
 import DefaultLayout from '@atb/layouts/default';
-import { WithGlobalData, withGlobalData } from '@atb/layouts/global-data';
-import AssistantLayout, {
-  AssistantLayoutProps,
-} from '@atb/page-modules/assistant/layout';
+import { type WithGlobalData, withGlobalData } from '@atb/layouts/global-data';
 import { withAssistantClient } from '@atb/page-modules/assistant/server';
-import { TripData } from '@atb/page-modules/assistant/server/journey-planner/validators';
-import { NextPage } from 'next';
-import { parseLayerQueryString } from '@atb/page-modules/assistant/utils';
-import { TripPattern } from '@atb/page-modules/assistant/trip-pattern';
+import type { TripData, NonTransitTripData } from '@atb/page-modules/assistant';
+import {
+  StreetMode,
+  TripPattern,
+  parseLayerQueryString,
+  AssistantLayout,
+  AssistantLayoutProps,
+} from '@atb/page-modules/assistant';
+import type { NextPage } from 'next';
 
-type AssistantContentProps = { empty: true } | { trip: TripData };
+type AssistantContentProps =
+  | { empty: true }
+  | { trip: TripData; nonTransitTrips: NonTransitTripData };
 
 export type AssistantPageProps = WithGlobalData<
   AssistantLayoutProps & AssistantContentProps
@@ -81,12 +85,21 @@ export const getServerSideProps = withGlobalData(
           transportModes: transportModeFilter,
         });
 
+        const nonTransitTrips = await client.nonTransitTrips({
+          from: initialFromFeature,
+          to: initialToFeature,
+          arriveBy: Boolean(arriveBy),
+          when,
+          directModes: [StreetMode.Foot, StreetMode.Bicycle],
+        });
+
         return {
           props: {
             initialFromFeature,
             initialToFeature,
             initialTransportModesFilter: transportModeFilter,
             trip,
+            nonTransitTrips,
           },
         };
       }

--- a/src/translations/pages/assistant.ts
+++ b/src/translations/pages/assistant.ts
@@ -40,4 +40,11 @@ export const Assistant = {
     busFrom: _('Buss fra', 'Bus from', 'Buss frå'),
     details: _('Detaljer', 'Details', 'Detaljar'),
   },
+
+  nonTransit: {
+    foot: _('Gå', 'Walk', 'Gå'),
+    bicycle: _('Sykkel', 'Bike', 'Sykkel'),
+    bikeRental: _('Bysykkel', 'City bike', 'Bysykkel'),
+    unknown: _('Ukjent', 'Unknown', 'Ukjent'),
+  },
 };

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -48,6 +48,17 @@ export function formatToAlwaysLongDateTime(
   return format(parsed, 'PPp', { locale: languageToLocale(language) });
 }
 
+export function secondsToDurationShort(
+  seconds: number,
+  language: Language,
+): string {
+  return getShortHumanizer(seconds * 1000, language, {
+    units: ['d', 'h', 'm'],
+    round: true,
+    conjunction: ' ',
+  });
+}
+
 export function formatToShortDateWithYear(
   date: Date | string,
   language: Language,


### PR DESCRIPTION
Adds non-transit search results and removes walking from original trip result.

## Notes

Not happy about `TransportModeType`, `TransportSubmodeType` usage inside components. Want to refactor, but seeing if that could be separate PR.

Assistant page should be handled better but see that that work is done in #45 , so leaving as is for now.

Fixes https://github.com/AtB-AS/kundevendt/issues/11320

<details><summary>Screenshot</summary>
<p>

<img width="1005" alt="Screenshot 2023-10-31 at 08 42 05" src="https://github.com/AtB-AS/planner-web/assets/606374/fd94a5ec-b89e-44c7-996e-e84619923572">


</p>
</details> 


