### PR TITLE
feat: base trip pattern header text on mode of first leg

### DIFF
--- a/src/page-modules/assistant/__tests__/assistant.test.tsx
+++ b/src/page-modules/assistant/__tests__/assistant.test.tsx
@@ -11,8 +11,7 @@ import { GeocoderFeature } from '@atb/page-modules/departures';
 import { FeatureCategory } from '@atb/components/venue-icon';
 import { GeocoderApi } from '@atb/page-modules/departures/server/geocoder';
 import AssistantLayout from '../layout';
-import { getQuayName, getStartModeAndPlace, NonTransitTripData } from '..';
-import { mockTrip } from './test-data';
+import { NonTransitTripData } from '@atb/page-modules/assistant';
 
 afterEach(function () {
   cleanup();
@@ -126,40 +125,5 @@ describe('assistant page', function () {
 
     expect(submitButton).toBeInTheDocument();
     expect(submitButton).toBeDisabled();
-  });
-
-  it('should get quay name from quay', () => {
-    const quayName = getQuayName({
-      publicCode: '',
-      name: 'Quay',
-      id: 'NSR:Quay:1',
-      situations: [],
-    });
-
-    expect(quayName).toBe('Quay');
-  });
-
-  it('should get quay name with public code from quay', () => {
-    const quayName = getQuayName({
-      publicCode: '1',
-      name: 'Quay',
-      id: 'NSR:Quay:1',
-      situations: [],
-    });
-
-    expect(quayName).toBe('Quay 1');
-  });
-
-  it('should get quay name from trip', () => {
-    const quayName = getQuayName(mockTrip.legs[0].fromPlace.quay);
-
-    expect(quayName).toBe('From 1');
-  });
-
-  it('should get start mode and start place from trip', () => {
-    const { startMode, startPlace } = getStartModeAndPlace(mockTrip);
-
-    expect(startMode).toBe('bus');
-    expect(startPlace).toBe('From 1');
   });
 });

--- a/src/page-modules/assistant/__tests__/assistant.test.tsx
+++ b/src/page-modules/assistant/__tests__/assistant.test.tsx
@@ -11,7 +11,8 @@ import { GeocoderFeature } from '@atb/page-modules/departures';
 import { FeatureCategory } from '@atb/components/venue-icon';
 import { GeocoderApi } from '@atb/page-modules/departures/server/geocoder';
 import AssistantLayout from '../layout';
-import { NonTransitTripData } from '..';
+import { getQuayName, getStartModeAndPlace, NonTransitTripData } from '..';
+import { mockTrip } from './test-data';
 
 afterEach(function () {
   cleanup();
@@ -125,5 +126,40 @@ describe('assistant page', function () {
 
     expect(submitButton).toBeInTheDocument();
     expect(submitButton).toBeDisabled();
+  });
+
+  it('should get quay name from quay', () => {
+    const quayName = getQuayName({
+      publicCode: '',
+      name: 'Quay',
+      id: 'NSR:Quay:1',
+      situations: [],
+    });
+
+    expect(quayName).toBe('Quay');
+  });
+
+  it('should get quay name with public code from quay', () => {
+    const quayName = getQuayName({
+      publicCode: '1',
+      name: 'Quay',
+      id: 'NSR:Quay:1',
+      situations: [],
+    });
+
+    expect(quayName).toBe('Quay 1');
+  });
+
+  it('should get quay name from trip', () => {
+    const quayName = getQuayName(mockTrip.legs[0].fromPlace.quay);
+
+    expect(quayName).toBe('From 1');
+  });
+
+  it('should get start mode and start place from trip', () => {
+    const { startMode, startPlace } = getStartModeAndPlace(mockTrip);
+
+    expect(startMode).toBe('bus');
+    expect(startPlace).toBe('From 1');
   });
 });

--- a/src/page-modules/assistant/__tests__/test-data.ts
+++ b/src/page-modules/assistant/__tests__/test-data.ts
@@ -1,0 +1,84 @@
+import { TripPattern } from '../server/journey-planner/validators';
+
+export const mockTrip: TripPattern = {
+  expectedStartTime: '2023-01-01T00:00:00+01:00',
+  expectedEndTime: '2023-01-01T01:00:00+01:00',
+  duration: 3600,
+  walkDistance: 0,
+  legs: [
+    {
+      mode: 'bus',
+      distance: 1,
+      duration: 1,
+      aimedStartTime: '2023-01-01T00:00:00+01:00',
+      aimedEndTime: '2023-01-01T01:00:00+01:00',
+      expectedEndTime: '2023-01-01T01:00:00+01:00',
+      expectedStartTime: '2023-01-01T00:00:00+01:00',
+      realtime: false,
+      transportSubmode: 'regionalBus',
+      line: {
+        id: 'ATB:Line:1',
+        name: 'Line',
+        transportSubmode: 'regionalBus',
+        publicCode: '1',
+        flexibleLineType: null,
+        notices: [],
+      },
+      fromEstimatedCall: {
+        aimedDepartureTime: '2023-01-01T00:00:00+01:00',
+        expectedDepartureTime: '2023-01-01T01:00:00+01:00',
+        destinationDisplay: {
+          frontText: 'Destination',
+        },
+        quay: {
+          publicCode: '',
+          name: 'Quay',
+        },
+        notices: [],
+      },
+      situations: [],
+      fromPlace: {
+        name: 'From',
+        longitude: 0,
+        latitude: 0,
+        quay: {
+          publicCode: '1',
+          name: 'From',
+          id: 'NSR:Quay:1',
+          situations: [],
+        },
+      },
+      toPlace: {
+        name: '2',
+        longitude: 0,
+        latitude: 0,
+        quay: {
+          publicCode: '2',
+          name: '2',
+          id: 'NSR:Quay:2',
+          situations: [],
+        },
+      },
+      serviceJourney: {
+        id: 'ATB:ServiceJourney:1',
+        notices: [],
+        journeyPattern: {
+          notices: [],
+        },
+      },
+      rentedBike: null,
+      interchangeTo: null,
+      pointsOnLink: {
+        points:
+          'yscbKgbqfAaJzl@oEx^??oAdKi@zDc@hBaAjC_@t@aA`BeUn]kApBg@pAo@jCa@bCWlCEt@e@tJ??sBpe@WlEQ|Bs@bGq@vD??_DpMsAhF{@dCy@dBgDtG??gA`Cw@rBc@jB[vBQvBEpB@~Bp@nM??LjEL`P\\da@J|EThGlAfV??TdFH`D?fC_Av_@CzB??AnCJhe@??@|RG`ZBtFP`Ij@bM??DfC?zBGxCUdD_@dDm@jDa@|Ai@`B}ArDw@`Ce@xBKt@oAhLiAjIUhECtCF~BTjD^pCPz@bBxGJb@FET\\??U]GDj@xDThCFlBD~C?xFCzAKjBOnAMx@cAtEiBxK]zAcB`G]bBs@fFY`C??y@bIc@nFMnCa@xLQdDIdAS~AQfASx@sAtEkAtEgArDwF~Qg@vA{@zAeE|FgFjGwA~Bk@lAa@`Aa@lAa@|Am@bDe@hD_@jF_AtNM|AOtA_@vBWjAaBbG??gFfRk@dC_@~BKrAGhBAnCD`BPbCx@dFTjBThCH`BD|BBxMRlOA~BIbC_@fFq@vGo@fEgChOk@zCu@xCeDfL{Ir_@k@pCm@vB}A`Hq@|DUjBMjBKdDA`CJvLHlGFpBHjBv@hLF~ABxB?vAGrCY~FW|CeB|PWvCOzDQ~MS|FYlE}@dJQ~CGnEBhLCtEe@z\\KxEKtCYnEa@`EYbC_@tBoAfF{@pEKI??nl@t~KCA]xEWtFG|BI|G@rKD`GH~BPjBnAzHRrBd@`HVxBPfAXjA|AtFd@hBPhARbBLzBFvC?`AEtAMrAS`A[|@_IzQc@pAw@fDoGdZeAzF[jCQxBO~BIlCoAns@??CzCBvCNbFJpBpArPHdBFhB@tBElAq@tLObEaAhl@D@JTFV@\\A^??Mp@SGKxFCnDFvDFnAj@pIF~C?x@ElBKpBMlA{CfWWpCEz@MCONCPE|@???lA\\F?|@HvDZzFHdA^~Bt@nDtAtH~@~FtA~JLrALrBHhD@vBh@rmBEjGu@|i@C|B@`CN`FLrCZvGV|D`@fFtF~n@P`CHnBJfDDfC@vCEfCEvAOdCQjBw@~F??sDxWs@zGMfBI~BEfFHzG??h@zPH~ALlAT`BVfA^rA`BdEp@pBxCdLf@~Az@vBpDjHd@v@j@t@nDhD|AjBvAxBvDtG~FvI|@z@x@d@|HbDvA~@v@t@t@`AbCbEdAvB`A`CbAnCfBzFjAjEh@~B`AfFbA|G]d@Lt@??PfAHHRMl@jG^pFjEbq@TlDL`D??ZpJD`EAlE}@nlCEjBGzAQnBUpB[lB[xA[`AGQwgBx{DJHePvaB{@nJyAlRW[EU??DTVZcEhi@??Q~B]xGOdEc@rQc@rTO~OAtCDhIx@`a@??P~YF~DJjE~@zY`@pKd@dKx@lMbDj`@J`BRGFFB\\@tBA?aOrgCLHM`DGlCCbFDjDHbCJrB`@`F\\zCbAnGr@hFp@xG`@hFLhCJbDFrD@~B?~BEdCeBb_@QdE[fR??C`BA|FFjL?dBGfESbE_@zDsBjN[nDQvDGbE]BIzA??BbAd@S@n@^vJn@jLl@rH~@jI|ArKzA`IR|@v@|CrB|F^vA^bCNzBFnBDpD`@x]I?jStnC??yTngEEFEWMYqBzNyApLsB`RcBvPsAtOqIpkAk@rJUpFMzEIdEErICh@?v@RfJ@nBM^Aj@@PLb@DFFrBA|D@p@Dv@~@pMHjADJn@hH`@pFJzCFjEOdLIjN@rBCrIBdLIlCCFq@LaDG??kKW@xH??Jhm@p@AAxCDFj@?',
+        length: 530,
+      },
+      intermediateEstimatedCalls: [],
+      authority: {
+        id: 'ATB:Authority:2',
+      },
+      serviceJourneyEstimatedCalls: null,
+      datedServiceJourney: null,
+    },
+  ],
+};

--- a/src/page-modules/assistant/server/journey-planner/validators.ts
+++ b/src/page-modules/assistant/server/journey-planner/validators.ts
@@ -67,18 +67,18 @@ export const situationSchema = z.object({
     .nullable(),
 });
 
+export const quaySchema = z.object({
+  publicCode: z.string().nullable(),
+  name: z.string(),
+  id: z.string(),
+  situations: z.array(situationSchema),
+});
+
 export const placeSchema = z.object({
   name: z.string().nullable(),
   longitude: z.number(),
   latitude: z.number(),
-  quay: z
-    .object({
-      publicCode: z.string().nullable(),
-      name: z.string(),
-      id: z.string(),
-      situations: z.array(situationSchema),
-    })
-    .nullable(),
+  quay: quaySchema.nullable(),
 });
 
 export const fromEstimatedCallSchema = z.object({
@@ -165,3 +165,4 @@ export type Notice = z.infer<typeof noticeSchema>;
 export type Situation = z.infer<typeof situationSchema>;
 export type TripData = z.infer<typeof tripSchema>;
 export type TripPattern = z.infer<typeof tripPatternSchema>;
+export type Quay = z.infer<typeof quaySchema>;

--- a/src/page-modules/assistant/trip/index.tsx
+++ b/src/page-modules/assistant/trip/index.tsx
@@ -136,6 +136,7 @@ function TripPattern({ tripPattern, delay }: TripPatternProps) {
 
   const duration = secondsToDuration(tripPattern.duration, language);
   const fromPlace = tripPattern.legs[0]?.fromPlace.name ?? '';
+  const fromMode = tripPattern.legs[0]?.mode ?? 'unknown';
 
   return (
     <motion.a
@@ -150,7 +151,9 @@ function TripPattern({ tripPattern, delay }: TripPatternProps) {
     >
       <header className={style.header}>
         <Typo.span textType="body__secondary--bold">
-          {t(PageText.Assistant.trip.tripPattern.busFrom)} {fromPlace}
+          {t(
+            PageText.Assistant.trip.tripPattern.travelFrom(fromMode, fromPlace),
+          )}
         </Typo.span>
         <Typo.span
           textType="body__secondary"

--- a/src/page-modules/assistant/trip/index.tsx
+++ b/src/page-modules/assistant/trip/index.tsx
@@ -1,6 +1,5 @@
 import { formatLocaleTime, secondsToDuration } from '@atb/utils/date';
 import {
-  Quay,
   TripData,
   type TripPattern,
 } from '@atb/page-modules/assistant/server/journey-planner/validators';
@@ -17,6 +16,7 @@ import {
   DepartureMode,
   NonTransitTripData,
   createTripQuery,
+  getStartModeAndPlace,
 } from '@atb/page-modules/assistant';
 import { useEffect, useState } from 'react';
 import { getInitialTransportModeFilter } from '@atb/components/transport-mode-filter/utils';
@@ -231,27 +231,4 @@ function getCursorByDepartureMode(
   } else {
     return trip.nextPageCursor;
   }
-}
-
-function getStartModeAndPlace(tripPattern: TripPattern) {
-  let startLeg = tripPattern.legs[0];
-  let startName = startLeg.fromPlace.name;
-
-  if (tripPattern.legs[0].mode === 'foot' && tripPattern.legs[1]) {
-    startLeg = tripPattern.legs[1];
-    startName = getQuayName(startLeg.fromPlace.quay);
-  } else if (tripPattern.legs[0].mode !== 'foot') {
-    startName = getQuayName(startLeg.fromPlace.quay);
-  }
-
-  return {
-    startMode: startLeg.mode ?? 'unknown',
-    startPlace: startName ?? '',
-  };
-}
-
-function getQuayName(quay: Quay | null): string | null {
-  if (!quay) return null;
-  if (!quay.publicCode) return quay.name;
-  return `${quay.name} ${quay.publicCode}`;
 }

--- a/src/page-modules/assistant/trip/index.tsx
+++ b/src/page-modules/assistant/trip/index.tsx
@@ -16,12 +16,12 @@ import {
   DepartureMode,
   NonTransitTripData,
   createTripQuery,
-  getStartModeAndPlace,
 } from '@atb/page-modules/assistant';
 import { useEffect, useState } from 'react';
 import { getInitialTransportModeFilter } from '@atb/components/transport-mode-filter/utils';
 import { Button } from '@atb/components/button';
 import { NonTransitTrip } from '../non-transit-pill';
+import { TripPatternHeader } from '@atb/page-modules/assistant/trip/trip-pattern-header';
 
 export type TripProps = {
   initialFromFeature: GeocoderFeature;
@@ -135,10 +135,6 @@ type TripPatternProps = {
 function TripPattern({ tripPattern, delay }: TripPatternProps) {
   const { t, language } = useTranslation();
 
-  const duration = secondsToDuration(tripPattern.duration, language);
-
-  const { startMode, startPlace } = getStartModeAndPlace(tripPattern);
-
   return (
     <motion.a
       href="/assistant" // TODO: Use correct href.
@@ -150,22 +146,7 @@ function TripPattern({ tripPattern, delay }: TripPatternProps) {
         delay, // staggerChildren on parent only works first render
       }}
     >
-      <header className={style.header}>
-        <Typo.span textType="body__secondary--bold">
-          {t(
-            PageText.Assistant.trip.tripPattern.travelFrom(
-              startMode,
-              startPlace,
-            ),
-          )}
-        </Typo.span>
-        <Typo.span
-          textType="body__secondary"
-          className={style.header__duration}
-        >
-          {duration}
-        </Typo.span>
-      </header>
+      <TripPatternHeader tripPattern={tripPattern} />
 
       <div className={style.legs}>
         {tripPattern.legs.map((leg, i) => (

--- a/src/page-modules/assistant/trip/trip-pattern-header/__tests__/trip-pattern-header.test.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern-header/__tests__/trip-pattern-header.test.tsx
@@ -1,0 +1,105 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import mockRouter from 'next-router-mock';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createDynamicRouteParser } from 'next-router-mock/dynamic-routes';
+import { getQuayName, getStartModeAndPlace, TripPatternHeader } from '..';
+import { tripFixture } from './trip.fixture';
+import {
+  AppCookiesProvider,
+  AppCookiesProviderProps,
+} from '@atb/modules/cookies/cookies-context';
+import React from 'react';
+import { AppLanguageProvider } from '@atb/translations';
+
+afterEach(function () {
+  cleanup();
+});
+
+vi.mock('next/router', () => require('next-router-mock'));
+
+mockRouter.useParser(createDynamicRouteParser(['/assistant']));
+
+type RenderProps = { providerProps: AppCookiesProviderProps };
+const customRender = (
+  ui: React.ReactNode,
+  { providerProps, ...renderOptions }: RenderProps,
+) => {
+  return render(
+    <AppCookiesProvider {...providerProps}>
+      <AppLanguageProvider serverAcceptLanguage="">{ui}</AppLanguageProvider>
+    </AppCookiesProvider>,
+    renderOptions,
+  );
+};
+
+describe('trip pattern header', function () {
+  it('should render trip pattern header', async () => {
+    render(<TripPatternHeader tripPattern={tripFixture} />);
+
+    expect(screen.getByText('Buss fra From 1')).toBeInTheDocument();
+    expect(screen.getByText('1 time')).toBeInTheDocument();
+  });
+
+  it('should render trip pattern header in english', async () => {
+    customRender(<TripPatternHeader tripPattern={tripFixture} />, {
+      providerProps: {
+        initialCookies: {
+          darkmode: true,
+          language: 'en-US',
+        },
+      },
+    });
+
+    expect(screen.getByText('Bus from From 1')).toBeInTheDocument();
+    expect(screen.getByText('1 hour')).toBeInTheDocument();
+  });
+
+  it('should render trip pattern header in nynorsk', async () => {
+    customRender(<TripPatternHeader tripPattern={tripFixture} />, {
+      providerProps: {
+        initialCookies: {
+          darkmode: true,
+          language: 'nn',
+        },
+      },
+    });
+
+    expect(screen.getByText('Buss frå From 1')).toBeInTheDocument();
+    expect(screen.getByText('1 time')).toBeInTheDocument();
+  });
+
+  it('should get quay name from quay', () => {
+    const quayName = getQuayName({
+      publicCode: '',
+      name: 'Quay',
+      id: 'NSR:Quay:1',
+      situations: [],
+    });
+
+    expect(quayName).toBe('Quay');
+  });
+
+  it('should get quay name with public code from quay', () => {
+    const quayName = getQuayName({
+      publicCode: '1',
+      name: 'Quay',
+      id: 'NSR:Quay:1',
+      situations: [],
+    });
+
+    expect(quayName).toBe('Quay 1');
+  });
+
+  it('should get quay name from trip', () => {
+    const quayName = getQuayName(tripFixture.legs[0].fromPlace.quay);
+
+    expect(quayName).toBe('From 1');
+  });
+
+  it('should get start mode and start place from trip', () => {
+    const { startMode, startPlace } = getStartModeAndPlace(tripFixture);
+
+    expect(startMode).toBe('bus');
+    expect(startPlace).toBe('From 1');
+  });
+});

--- a/src/page-modules/assistant/trip/trip-pattern-header/__tests__/trip.fixture.ts
+++ b/src/page-modules/assistant/trip/trip-pattern-header/__tests__/trip.fixture.ts
@@ -1,6 +1,6 @@
-import { TripPattern } from '../server/journey-planner/validators';
+import { TripPattern } from '../../../server/journey-planner/validators';
 
-export const mockTrip: TripPattern = {
+export const tripFixture: TripPattern = {
   expectedStartTime: '2023-01-01T00:00:00+01:00',
   expectedEndTime: '2023-01-01T01:00:00+01:00',
   duration: 3600,

--- a/src/page-modules/assistant/trip/trip-pattern-header/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern-header/index.tsx
@@ -1,0 +1,56 @@
+import {
+  TripPattern,
+  Quay,
+} from '@atb/page-modules/assistant/server/journey-planner/validators';
+import style from './trip-pattern-header.module.css';
+import { Typo } from '@atb/components/typography';
+import { useTranslation, PageText } from '@atb/translations';
+import { secondsToDuration } from '@atb/utils/date';
+
+type TripPatternHeaderProps = {
+  tripPattern: TripPattern;
+};
+
+export function TripPatternHeader({ tripPattern }: TripPatternHeaderProps) {
+  const { t, language } = useTranslation();
+
+  const duration = secondsToDuration(tripPattern.duration, language);
+
+  const { startMode, startPlace } = getStartModeAndPlace(tripPattern);
+
+  return (
+    <header className={style.header}>
+      <Typo.span textType="body__secondary--bold">
+        {t(
+          PageText.Assistant.trip.tripPattern.travelFrom(startMode, startPlace),
+        )}
+      </Typo.span>
+      <Typo.span textType="body__secondary" className={style.header__duration}>
+        {duration}
+      </Typo.span>
+    </header>
+  );
+}
+
+export function getStartModeAndPlace(tripPattern: TripPattern) {
+  let startLeg = tripPattern.legs[0];
+  let startName = startLeg.fromPlace.name;
+
+  if (tripPattern.legs[0].mode === 'foot' && tripPattern.legs[1]) {
+    startLeg = tripPattern.legs[1];
+    startName = getQuayName(startLeg.fromPlace.quay);
+  } else if (tripPattern.legs[0].mode !== 'foot') {
+    startName = getQuayName(startLeg.fromPlace.quay);
+  }
+
+  return {
+    startMode: startLeg.mode ?? 'unknown',
+    startPlace: startName ?? '',
+  };
+}
+
+export function getQuayName(quay: Quay | null): string | null {
+  if (!quay) return null;
+  if (!quay.publicCode) return quay.name;
+  return `${quay.name} ${quay.publicCode}`;
+}

--- a/src/page-modules/assistant/trip/trip-pattern-header/trip-pattern-header.module.css
+++ b/src/page-modules/assistant/trip/trip-pattern-header/trip-pattern-header.module.css
@@ -1,0 +1,9 @@
+.header {
+  display: flex;
+  justify-content: space-between;
+  padding: var(--spacings-small) var(--spacings-medium);
+}
+
+.header__duration {
+  color: var(--text-colors-secondary);
+}

--- a/src/page-modules/assistant/trip/trip.module.css
+++ b/src/page-modules/assistant/trip/trip.module.css
@@ -18,16 +18,6 @@
   gap: var(--spacings-medium);
 }
 
-.header {
-  display: flex;
-  justify-content: space-between;
-  padding: var(--spacings-small) var(--spacings-medium);
-}
-
-.header__duration {
-  color: var(--text-colors-secondary);
-}
-
 .legs {
   display: flex;
   align-items: center;

--- a/src/page-modules/assistant/utils.ts
+++ b/src/page-modules/assistant/utils.ts
@@ -10,6 +10,7 @@ import {
   TripQuery,
   TripQuerySchema,
 } from '@atb/page-modules/assistant';
+import { Quay, TripPattern } from './server/journey-planner/validators';
 
 const featuresToFromToQuery = (from: GeocoderFeature, to: GeocoderFeature) => {
   return {
@@ -79,3 +80,26 @@ export const parseTripQuery = (query: any): TripQuery | undefined => {
   }
   return parsed.data;
 };
+
+export function getStartModeAndPlace(tripPattern: TripPattern) {
+  let startLeg = tripPattern.legs[0];
+  let startName = startLeg.fromPlace.name;
+
+  if (tripPattern.legs[0].mode === 'foot' && tripPattern.legs[1]) {
+    startLeg = tripPattern.legs[1];
+    startName = getQuayName(startLeg.fromPlace.quay);
+  } else if (tripPattern.legs[0].mode !== 'foot') {
+    startName = getQuayName(startLeg.fromPlace.quay);
+  }
+
+  return {
+    startMode: startLeg.mode ?? 'unknown',
+    startPlace: startName ?? '',
+  };
+}
+
+export function getQuayName(quay: Quay | null): string | null {
+  if (!quay) return null;
+  if (!quay.publicCode) return quay.name;
+  return `${quay.name} ${quay.publicCode}`;
+}

--- a/src/page-modules/assistant/utils.ts
+++ b/src/page-modules/assistant/utils.ts
@@ -80,26 +80,3 @@ export const parseTripQuery = (query: any): TripQuery | undefined => {
   }
   return parsed.data;
 };
-
-export function getStartModeAndPlace(tripPattern: TripPattern) {
-  let startLeg = tripPattern.legs[0];
-  let startName = startLeg.fromPlace.name;
-
-  if (tripPattern.legs[0].mode === 'foot' && tripPattern.legs[1]) {
-    startLeg = tripPattern.legs[1];
-    startName = getQuayName(startLeg.fromPlace.quay);
-  } else if (tripPattern.legs[0].mode !== 'foot') {
-    startName = getQuayName(startLeg.fromPlace.quay);
-  }
-
-  return {
-    startMode: startLeg.mode ?? 'unknown',
-    startPlace: startName ?? '',
-  };
-}
-
-export function getQuayName(quay: Quay | null): string | null {
-  if (!quay) return null;
-  if (!quay.publicCode) return quay.name;
-  return `${quay.name} ${quay.publicCode}`;
-}

--- a/src/page-modules/departures/__tests__/departure-data.fixture.ts
+++ b/src/page-modules/departures/__tests__/departure-data.fixture.ts
@@ -1,6 +1,6 @@
 import { DepartureData } from '@atb/page-modules/departures/';
 
-export const departureDataMock: DepartureData = {
+export const departureDataFixture: DepartureData = {
   stopPlace: {
     id: 'NSR:StopPlace:41613',
     name: 'Prinsens gate',

--- a/src/page-modules/departures/__tests__/departure.test.tsx
+++ b/src/page-modules/departures/__tests__/departure.test.tsx
@@ -10,7 +10,7 @@ import {
 import { getServerSideProps } from '@atb/pages/departures/[[...id]]';
 import { expectProps } from '@atb/tests/utils';
 import { createDynamicRouteParser } from 'next-router-mock/dynamic-routes';
-import { departureDataMock } from './test-data';
+import { departureDataFixture } from './departure-data.fixture';
 import { StopPlace } from '../stop-place';
 import userEvent from '@testing-library/user-event';
 afterEach(function () {
@@ -83,23 +83,25 @@ describe('departure page', function () {
   });
 
   it('should render quays', () => {
-    const output = render(<StopPlace departures={departureDataMock} />);
+    const output = render(<StopPlace departures={departureDataFixture} />);
 
-    departureDataMock.quays.forEach((q) =>
+    departureDataFixture.quays.forEach((q) =>
       expect(output.getByText(q.name)).toBeInTheDocument(),
     );
   });
 
   it('should render estimated calls', () => {
-    const output = render(<StopPlace departures={departureDataMock} />);
+    const output = render(<StopPlace departures={departureDataFixture} />);
     const lists = output.getAllByRole('list');
     const { getAllByRole } = within(lists[0]);
     const items = getAllByRole('listitem');
-    expect(items.length).toBe(departureDataMock.quays[0].departures.length + 1);
+    expect(items.length).toBe(
+      departureDataFixture.quays[0].departures.length + 1,
+    );
   });
 
   it('Should collapse estimated calls list', async () => {
-    const output = render(<StopPlace departures={departureDataMock} />);
+    const output = render(<StopPlace departures={departureDataFixture} />);
     const button = screen.getAllByRole('button', {
       name: 'Aktiver for å minimere',
     });

--- a/src/translations/pages/assistant.ts
+++ b/src/translations/pages/assistant.ts
@@ -1,4 +1,5 @@
 import { translation as _ } from '@atb/translations/commons';
+import { TransportModeType } from '@atb/components/transport-mode/types';
 
 export const Assistant = {
   title: _('Planlegg reisen', 'Plan travel', 'Planlegg reisa'),
@@ -38,7 +39,61 @@ export const Assistant = {
   },
   trip: {
     tripPattern: {
-      busFrom: _('Buss fra', 'Bus from', 'Buss frå'),
+      travelFrom: (mode: TransportModeType, place: string) => {
+        switch (mode) {
+          case 'bus':
+          case 'coach':
+            return _(
+              `Buss fra ${place}`,
+              `Bus from ${place}`,
+              `Buss frå ${place}`,
+            );
+          case 'tram':
+            return _(
+              `Trikk fra ${place}`,
+              `Tram from ${place}`,
+              `Trikk frå ${place}`,
+            );
+          case 'metro':
+            return _(
+              `T-bane fra ${place}`,
+              `Metro from ${place}`,
+              `T-bane frå ${place}`,
+            );
+          case 'rail':
+            return _(
+              `Tog fra ${place}`,
+              `Train from ${place}`,
+              `Tog frå ${place}`,
+            );
+          case 'water':
+            return _(
+              `Båt fra ${place}`,
+              `Boat from ${place}`,
+              `Båt frå ${place}`,
+            );
+          case 'air':
+            return _(
+              `Fly fra ${place}`,
+              `Air from ${place}`,
+              `Fly frå ${place}`,
+            );
+          case 'bicycle':
+            return _(
+              `Sykkel fra ${place}`,
+              `Bike from ${place}`,
+              `Sykkel frå ${place}`,
+            );
+          case 'foot':
+            return _(
+              `Gå fra ${place}`,
+              `Walk from ${place}`,
+              `Gå frå ${place}`,
+            );
+          default:
+            return _(`Fra ${place}`, `From ${place}`, `Frå ${place}`);
+        }
+      },
       details: _('Detaljer', 'Details', 'Detaljar'),
     },
     fetchMore: _(


### PR DESCRIPTION
This PR introduces a valuable new feature which dynamically bases the trip pattern header text on the mode of the first leg of the journey. It seeks to enhance the user experience by providing a clearer, context-aware narrative about the upcoming trip details.

Fixes https://github.com/AtB-AS/kundevendt/issues/14917