### PR TITLE
feat: recursive trip pattern search and day label in trip pattern list

### DIFF
--- a/src/page-modules/assistant/client/journey-planner/index.ts
+++ b/src/page-modules/assistant/client/journey-planner/index.ts
@@ -5,13 +5,10 @@ export type TripApiReturnType = TripData;
 
 export async function nextTripPatterns(
   query: TripQuery,
-  cursor: string,
 ): Promise<TripApiReturnType> {
   const queryString = tripQueryToQueryString(query);
 
-  const result = await fetch(
-    `/api/assistant/trip?${queryString}&cursor=${cursor}`,
-  );
+  const result = await fetch(`/api/assistant/trip?${queryString}`);
 
   return await result.json();
 }

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -15,7 +15,10 @@ import { getInitialTransportModeFilter } from '@atb/components/transport-mode-fi
 import { TransportModeFilterOption } from '@atb/components/transport-mode-filter/types';
 import { MonoIcon } from '@atb/components/icon';
 import { FocusScope } from '@react-aria/focus';
-import { createTripQuery } from '@atb/page-modules/assistant';
+import {
+  createTripQuery,
+  departureDateStateToDepartureMode,
+} from '@atb/page-modules/assistant';
 import SwapButton from '@atb/components/search/swap-button';
 import GeolocationButton from '@atb/components/search/geolocation-button';
 import { AnimatePresence, motion } from 'framer-motion';
@@ -56,8 +59,9 @@ function AssistantLayout({
     const query = createTripQuery(
       selectedToFeature,
       selectedFromFeature,
+      departureDateStateToDepartureMode(departureDate),
+      departureDate.type !== 'now' ? departureDate.dateTime : undefined,
       transportModeFilter,
-      departureDate,
     );
     const temp = selectedFromFeature;
     setSelectedFromFeature(selectedToFeature);
@@ -72,8 +76,9 @@ function AssistantLayout({
     const query = createTripQuery(
       geolocationFeature,
       selectedToFeature,
+      departureDateStateToDepartureMode(departureDate),
+      departureDate.type !== 'now' ? departureDate.dateTime : undefined,
       transportModeFilter,
-      departureDate,
     );
     setSelectedFromFeature(geolocationFeature);
     router.push({ pathname: '/assistant', query });
@@ -85,8 +90,9 @@ function AssistantLayout({
     const query = createTripQuery(
       selectedFromFeature,
       selectedToFeature,
+      departureDateStateToDepartureMode(departureDate),
+      departureDate.type !== 'now' ? departureDate.dateTime : undefined,
       transportModeFilter,
-      departureDate,
     );
     router.push({ pathname: '/assistant', query });
   };

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -7,6 +7,7 @@ import style from './assistant.module.css';
 import { useRouter } from 'next/router';
 import DepartureDateSelector, {
   DepartureDate,
+  DepartureDateState,
 } from '@atb/components/departure-date-selector';
 import TransportModeFilter from '@atb/components/transport-mode-filter';
 import { Typo } from '@atb/components/typography';
@@ -65,7 +66,9 @@ function AssistantLayout({
       selectedToFeature,
       selectedFromFeature,
       departureDateToDepartureMode(departureDate),
-      departureDate.type !== 'now' ? departureDate.dateTime : undefined,
+      departureDate.type !== DepartureDateState.Now
+        ? departureDate.dateTime
+        : undefined,
       transportModeFilter,
     );
     const temp = selectedFromFeature;
@@ -82,7 +85,9 @@ function AssistantLayout({
       geolocationFeature,
       selectedToFeature,
       departureDateToDepartureMode(departureDate),
-      departureDate.type !== 'now' ? departureDate.dateTime : undefined,
+      departureDate.type !== DepartureDateState.Now
+        ? departureDate.dateTime
+        : undefined,
       transportModeFilter,
     );
     setSelectedFromFeature(geolocationFeature);
@@ -96,7 +101,9 @@ function AssistantLayout({
       selectedFromFeature,
       selectedToFeature,
       departureDateToDepartureMode(departureDate),
-      departureDate.type !== 'now' ? departureDate.dateTime : undefined,
+      departureDate.type !== DepartureDateState.Now
+        ? departureDate.dateTime
+        : undefined,
       transportModeFilter,
     );
     router.push({ pathname: '/assistant', query });

--- a/src/page-modules/assistant/server/journey-planner/index.ts
+++ b/src/page-modules/assistant/server/journey-planner/index.ts
@@ -26,6 +26,16 @@ import {
   isTransportSubmodeType,
 } from '@atb/page-modules/departures/server/journey-planner';
 
+const MIN_NUMBER_OF_TRIP_PATTERNS = 8;
+const MAX_NUMBER_OF_SEARCH_ATTEMPTS = 5;
+const DEFAULT_JOURNEY_CONFIG = {
+  numTripPatterns: 8, // The maximum number of trip patterns to return.
+  waitReluctance: 1.5, // Setting this to a value lower than 1 indicates that waiting is better than staying on a vehicle.
+  walkReluctance: 1.5, // This is the main parameter to use for limiting walking.
+  walkSpeed: 1.3, // The maximum walk speed along streets, in meters per second.
+  transferPenalty: 10, // An extra penalty added on transfers (i.e. all boardings except the first one)
+};
+
 export type JourneyPlannerApi = {
   trip(input: TripInput): Promise<TripData>;
   nonTransitTrips(input: NonTransitTripInput): Promise<NonTransitTripData>;
@@ -105,15 +115,8 @@ export function createJourneyApi(
         when,
         modes: journeyModes,
         cursor: input.cursor,
-        numTripPatterns: 10,
-        waitReluctance: 1.5,
-        walkReluctance: 1.5,
-        walkSpeed: 1.3,
-        transferPenalty: 10,
+        ...DEFAULT_JOURNEY_CONFIG,
       };
-
-      const MINIMUM_NUMBER_OF_TRIP_PATTERNS = 8;
-      const MAX_NUMBER_OF_TRIES = 5;
 
       let trip: TripData | undefined = undefined;
       let cursor = input.cursor;
@@ -150,8 +153,8 @@ export function createJourneyApi(
 
         searchAttempt += 1;
       } while (
-        searchAttempt <= MAX_NUMBER_OF_TRIES &&
-        trip.tripPatterns.length <= MINIMUM_NUMBER_OF_TRIP_PATTERNS
+        searchAttempt <= MAX_NUMBER_OF_SEARCH_ATTEMPTS &&
+        trip.tripPatterns.length <= MIN_NUMBER_OF_TRIP_PATTERNS
       );
 
       return trip;

--- a/src/page-modules/assistant/server/journey-planner/index.ts
+++ b/src/page-modules/assistant/server/journey-planner/index.ts
@@ -132,6 +132,10 @@ export function createJourneyApi(
           variables: { ...queryVariables, cursor },
         });
 
+        if (result.error) {
+          throw result.error;
+        }
+
         const data: RecursivePartial<TripData> = mapResultToTrips(
           result.data.trip,
         );

--- a/src/page-modules/assistant/server/journey-planner/index.ts
+++ b/src/page-modules/assistant/server/journey-planner/index.ts
@@ -14,7 +14,7 @@ import {
   TripData,
   tripSchema,
 } from '@atb/page-modules/assistant/server/journey-planner/validators';
-import {
+import type {
   NonTransitTripData,
   NonTransitTripInput,
   TripInput,
@@ -24,7 +24,10 @@ import {
   isTransportModeType,
   isTransportSubmodeType,
 } from '@atb/page-modules/departures/server/journey-planner';
-import { filterDuplicateTripPatterns, getCursorByDepartureMode } from '../..';
+import {
+  filterOutDuplicates,
+  getCursorByDepartureMode,
+} from '@atb/page-modules/assistant';
 
 const MIN_NUMBER_OF_TRIP_PATTERNS = 8;
 const MAX_NUMBER_OF_SEARCH_ATTEMPTS = 5;
@@ -150,10 +153,13 @@ export function createJourneyApi(
         } else {
           trip = {
             ...validated.data,
-            tripPatterns: filterDuplicateTripPatterns([
+            tripPatterns: [
               ...trip.tripPatterns,
-              ...validated.data.tripPatterns,
-            ]),
+              ...filterOutDuplicates(
+                validated.data.tripPatterns,
+                trip.tripPatterns,
+              ),
+            ],
           };
         }
         searchAttempt += 1;

--- a/src/page-modules/assistant/trip/index.tsx
+++ b/src/page-modules/assistant/trip/index.tsx
@@ -21,6 +21,7 @@ import {
   DepartureMode,
   NonTransitTripData,
   createTripQuery,
+  filterOutDuplicates,
   getCursorByDepartureMode,
 } from '@atb/page-modules/assistant';
 import { useEffect, useState } from 'react';
@@ -126,16 +127,13 @@ function useTripPatterns(initialTrip: TripData, departureMode: DepartureMode) {
       cursor || undefined,
     );
     const trip = await nextTripPatterns(tripQuery);
-    const filtered = trip.tripPatterns.filter(
-      (tp) =>
-        !tripPatterns.some(
-          (tp2) => tp.expectedStartTime === tp2.expectedStartTime,
-        ),
+    const newTripPatternsWithTransitionDelay = tripPatternsWithTransitionDelay(
+      filterOutDuplicates(trip.tripPatterns, tripPatterns),
     );
 
     setTripPatterns((prevTripPatterns) => [
       ...prevTripPatterns,
-      ...tripPatternsWithTransitionDelay(filtered),
+      ...newTripPatternsWithTransitionDelay,
     ]);
 
     setCursor(getCursorByDepartureMode(trip, departureMode));

--- a/src/page-modules/assistant/trip/index.tsx
+++ b/src/page-modules/assistant/trip/index.tsx
@@ -1,7 +1,7 @@
 import {
-  daysBetween,
   formatLocaleTime,
   formatToSimpleDate,
+  formatToWeekday,
   parseIfNeeded,
   secondsToDuration,
 } from '@atb/utils/date';
@@ -28,6 +28,7 @@ import { getInitialTransportModeFilter } from '@atb/components/transport-mode-fi
 import { Button } from '@atb/components/button';
 import { NonTransitTrip } from '../non-transit-pill';
 import { isSameDay } from 'date-fns';
+import { capitalize } from 'lodash';
 
 export type TripProps = {
   initialFromFeature: GeocoderFeature;
@@ -225,32 +226,22 @@ type DayLabelProps = {
   previousDepartureTime?: string;
 };
 function DayLabel({ departureTime, previousDepartureTime }: DayLabelProps) {
-  const { t, language } = useTranslation();
+  const { language } = useTranslation();
   const isFirst = !previousDepartureTime;
   const departureDate = parseIfNeeded(departureTime);
   const prevDate = !previousDepartureTime
     ? new Date()
     : parseIfNeeded(previousDepartureTime);
 
-  const dateString = formatToSimpleDate(departureDate, language);
-  const numberOfDays = daysBetween(new Date(), departureDate);
-
-  let dateLabel = dateString;
-
-  if (numberOfDays === 0) {
-    dateLabel = t(PageText.Assistant.trip.dayLabel.today);
-  }
-  if (numberOfDays == 1) {
-    dateLabel = t(PageText.Assistant.trip.dayLabel.tomorrow(dateString));
-  }
-  if (numberOfDays == 2) {
-    dateLabel = t(
-      PageText.Assistant.trip.dayLabel.dayAfterTomorrow(dateString),
-    );
-  }
+  const weekDay = capitalize(formatToWeekday(departureDate, language, 'eeee'));
+  const simpleDate = formatToSimpleDate(departureDate, language);
 
   if (isFirst || !isSameDay(prevDate, departureDate)) {
-    return <p className={style.dayLabel}>{dateLabel}</p>;
+    return (
+      <Typo.p textType="heading--medium" className={style.dayLabel}>
+        {`${weekDay} ${simpleDate}`}
+      </Typo.p>
+    );
   }
   return null;
 }

--- a/src/page-modules/assistant/trip/index.tsx
+++ b/src/page-modules/assistant/trip/index.tsx
@@ -66,17 +66,16 @@ export default function Trip({
           </div>
         )}
         {tripPatterns.map((tripPattern, i) => (
-          <>
+          <div key={`tripPattern-${tripPattern.expectedStartTime}-${i}`}>
             <DayLabel
               departureTime={tripPattern.expectedStartTime}
               previousDepartureTime={tripPatterns[i - 1]?.expectedStartTime}
             />
             <TripPattern
-              key={`tripPattern-${tripPattern.expectedStartTime}-${i}`}
               tripPattern={tripPattern}
               delay={tripPattern.transitionDelay}
             />
-          </>
+          </div>
         ))}
       </div>
 
@@ -239,7 +238,7 @@ function DayLabel({ departureTime, previousDepartureTime }: DayLabelProps) {
   let dateLabel = dateString;
 
   if (numberOfDays === 0) {
-    dateLabel = t(PageText.Assistant.trip.dayLabel.today());
+    dateLabel = t(PageText.Assistant.trip.dayLabel.today);
   }
   if (numberOfDays == 1) {
     dateLabel = t(PageText.Assistant.trip.dayLabel.tomorrow(dateString));

--- a/src/page-modules/assistant/trip/trip.module.css
+++ b/src/page-modules/assistant/trip/trip.module.css
@@ -19,7 +19,7 @@
 }
 
 .dayLabel {
-  padding: var(--spacings-small) var(--spacings-medium);
+  padding-bottom: var(--spacings-medium);
 }
 
 .header {

--- a/src/page-modules/assistant/trip/trip.module.css
+++ b/src/page-modules/assistant/trip/trip.module.css
@@ -18,6 +18,10 @@
   gap: var(--spacings-medium);
 }
 
+.dayLabel {
+  padding: var(--spacings-small) var(--spacings-medium);
+}
+
 .header {
   display: flex;
   justify-content: space-between;

--- a/src/page-modules/assistant/utils.ts
+++ b/src/page-modules/assistant/utils.ts
@@ -12,17 +12,14 @@ import {
   TripQuerySchema,
 } from '@atb/page-modules/assistant';
 
-export function filterDuplicateTripPatterns(
-  tripPatterns: TripData['tripPatterns'],
+export function filterOutDuplicates(
+  arrayToFilter: TripData['tripPatterns'],
+  referenceArray: TripData['tripPatterns'],
 ): TripData['tripPatterns'] {
-  const existing = new Map<string, TripData['tripPatterns'][0]>();
-  return tripPatterns.filter((tp) => {
-    if (existing.has(tp.expectedStartTime)) {
-      return false;
-    }
-    existing.set(tp.expectedStartTime, tp);
-    return true;
-  });
+  const existing = new Set<string>(
+    referenceArray.map((tp) => tp.expectedStartTime),
+  );
+  return arrayToFilter.filter((tp) => !existing.has(tp.expectedStartTime));
 }
 
 export function getCursorByDepartureMode(

--- a/src/translations/pages/assistant.ts
+++ b/src/translations/pages/assistant.ts
@@ -53,7 +53,7 @@ export const Assistant = {
       unknown: _('Ukjent', 'Unknown', 'Ukjent'),
     },
     dayLabel: {
-      today: () => _('I dag', 'Today', 'I dag'),
+      today: _('I dag', 'Today', 'I dag'),
       tomorrow: (date: string) =>
         _(`I morgen - ${date}`, `Tomorrow - ${date}`, `I morgon - ${date}`),
       dayAfterTomorrow: (date: string) =>

--- a/src/translations/pages/assistant.ts
+++ b/src/translations/pages/assistant.ts
@@ -52,5 +52,16 @@ export const Assistant = {
       bikeRental: _('Bysykkel', 'City bike', 'Bysykkel'),
       unknown: _('Ukjent', 'Unknown', 'Ukjent'),
     },
+    dayLabel: {
+      today: () => _('I dag', 'Today', 'I dag'),
+      tomorrow: (date: string) =>
+        _(`I morgen - ${date}`, `Tomorrow - ${date}`, `I morgon - ${date}`),
+      dayAfterTomorrow: (date: string) =>
+        _(
+          `I overmorgen - ${date}`,
+          `Day after tomorrow - ${date}`,
+          `I overmorgon - ${date}`,
+        ),
+    },
   },
 };

--- a/src/translations/pages/assistant.ts
+++ b/src/translations/pages/assistant.ts
@@ -52,16 +52,5 @@ export const Assistant = {
       bikeRental: _('Bysykkel', 'City bike', 'Bysykkel'),
       unknown: _('Ukjent', 'Unknown', 'Ukjent'),
     },
-    dayLabel: {
-      today: _('I dag', 'Today', 'I dag'),
-      tomorrow: (date: string) =>
-        _(`I morgen - ${date}`, `Tomorrow - ${date}`, `I morgon - ${date}`),
-      dayAfterTomorrow: (date: string) =>
-        _(
-          `I overmorgen - ${date}`,
-          `Day after tomorrow - ${date}`,
-          `I overmorgon - ${date}`,
-        ),
-    },
   },
 };

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -11,6 +11,7 @@ import {
   parseISO,
   setMinutes,
   differenceInSeconds,
+  differenceInCalendarDays,
 } from 'date-fns';
 import en from 'date-fns/locale/en-GB';
 import nb from 'date-fns/locale/nb';
@@ -158,6 +159,11 @@ export function formatToVerboseDateTime(
 
   return `${dateString} ${at} ${timeString}`;
 }
+export function formatToSimpleDate(date: Date | string, language: Language) {
+  return format(parseIfNeeded(date), 'do MMMM', {
+    locale: languageToLocale(language),
+  });
+}
 
 export function isInPast(date: Date | string) {
   return isPast(parseIfNeeded(date));
@@ -211,6 +217,9 @@ export function secondsBetween(
   const parsedStart = parseIfNeeded(start);
   const parsedEnd = parseIfNeeded(end);
   return differenceInSeconds(parsedEnd, parsedStart);
+}
+export function daysBetween(start: string | Date, end: string | Date) {
+  return differenceInCalendarDays(parseIfNeeded(start), parseIfNeeded(end));
 }
 /**
  * Either show clock or relative time (X min) if below threshold specified by

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -198,6 +198,15 @@ export function formatIsoDate(isoDate: string | Date) {
 export function formatSimpleTime(isoDate: string | Date) {
   return format(parseIfNeeded(isoDate), 'HH:mm');
 }
+export function formatToWeekday(
+  date: Date | string,
+  language: Language,
+  dateFormat?: string,
+) {
+  return format(parseIfNeeded(date), dateFormat ? dateFormat : 'EEEEEE', {
+    locale: languageToLocale(language),
+  });
+}
 export function daysInFuture(days: number) {
   return addDays(new Date(), days);
 }

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -219,7 +219,7 @@ export function secondsBetween(
   return differenceInSeconds(parsedEnd, parsedStart);
 }
 export function daysBetween(start: string | Date, end: string | Date) {
-  return differenceInCalendarDays(parseIfNeeded(start), parseIfNeeded(end));
+  return differenceInCalendarDays(parseIfNeeded(end), parseIfNeeded(start));
 }
 /**
  * Either show clock or relative time (X min) if below threshold specified by


### PR DESCRIPTION
With this PR we now search for trip patterns until we have found at least 5 trip patterns, with a maximum of 15 attempts. I have also added a day label to the trip patterns list so that it's easier to distinguish day of travel. 

<details>
<summary>Screenshots</summary>

<img width="1004" alt="image" src="https://github.com/AtB-AS/planner-web/assets/43166974/487a944f-72c2-4167-b17b-0dea165f5dc0">

<img width="1089" alt="image" src="https://github.com/AtB-AS/planner-web/assets/43166974/d2991074-9809-433d-a4e2-4b13b399e5b5">

<img width="1044" alt="image" src="https://github.com/AtB-AS/planner-web/assets/43166974/0242db57-d137-46a4-8ab7-caeb834931e0">


</details>

## TODO 
- [x] Verify and update the day label look when it's added to the design
- [x] Fix issue with wrong trip patterns when `departureMode` is `arriveBy`
 