### PR TITLE
feat: use initial state in departure date selector

### DIFF
--- a/src/components/departure-date-selector/index.tsx
+++ b/src/components/departure-date-selector/index.tsx
@@ -35,11 +35,12 @@ export default function DepartureDateSelector({
   const { t } = useTranslation();
   const [selectedOption, setSelectedOption] =
     useState<DepartureDate>(initialState);
-  const [selectedDate, setSelectedDate] = useState(new Date());
+  const initialDate =
+    'dateTime' in initialState ? new Date(initialState.dateTime) : new Date();
+  const [selectedDate, setSelectedDate] = useState(initialDate);
   const [selectedTime, setSelectedTime] = useState(() => {
-    const now = new Date();
-    const hours = now.getHours().toString().padStart(2, '0');
-    const minutes = now.getMinutes().toString().padStart(2, '0');
+    const hours = initialDate.getHours().toString().padStart(2, '0');
+    const minutes = initialDate.getMinutes().toString().padStart(2, '0');
 
     return `${hours}:${minutes}`;
   });

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -24,6 +24,7 @@ export type AssistantLayoutProps = PropsWithChildren<{
   initialFromFeature?: GeocoderFeature;
   initialToFeature?: GeocoderFeature;
   initialTransportModesFilter?: TransportModeFilterOption[] | null;
+  initialDepartureMode?: DepartureDate;
 }>;
 
 function AssistantLayout({
@@ -31,6 +32,7 @@ function AssistantLayout({
   initialFromFeature,
   initialToFeature,
   initialTransportModesFilter,
+  initialDepartureMode,
 }: AssistantLayoutProps) {
   const { t } = useTranslation();
   const router = useRouter();
@@ -42,9 +44,11 @@ function AssistantLayout({
   const [selectedToFeature, setSelectedToFeature] = useState<
     GeocoderFeature | undefined
   >(initialToFeature);
-  const [departureDate, setDepartureDate] = useState<DepartureDate>({
-    type: DepartureDateState.Now,
-  });
+  const [departureDate, setDepartureDate] = useState<DepartureDate>(
+    initialDepartureMode ?? {
+      type: DepartureDateState.Now,
+    },
+  );
   const [transportModeFilter, setTransportModeFilter] = useState(
     getInitialTransportModeFilter(initialTransportModesFilter),
   );

--- a/src/page-modules/assistant/types.ts
+++ b/src/page-modules/assistant/types.ts
@@ -11,7 +11,7 @@ export enum DepartureMode {
 export type TripInput = {
   from: GeocoderFeature;
   to: GeocoderFeature;
-  departureMode: DepartureMode;
+  departureMode?: DepartureMode;
   departureDate?: number;
   transportModes?: TransportModeFilterOption[];
   cursor?: string;
@@ -28,7 +28,7 @@ export const TripQuerySchema = z.object({
   toLayer: z.union([z.literal('address'), z.literal('venue')]),
   filter: z.string().optional(),
   departureDate: z.number().optional(),
-  departureMode: z.nativeEnum(DepartureMode),
+  departureMode: z.nativeEnum(DepartureMode).optional(),
   cursor: z.string().optional(),
 });
 
@@ -57,7 +57,7 @@ export enum StreetMode {
 export type NonTransitTripInput = {
   from: GeocoderFeature;
   to: GeocoderFeature;
-  departureMode: DepartureMode;
+  departureMode?: DepartureMode;
   departureDate?: number;
   directModes: StreetMode[];
 };

--- a/src/page-modules/assistant/utils.ts
+++ b/src/page-modules/assistant/utils.ts
@@ -10,7 +10,6 @@ import {
   TripQuery,
   TripQuerySchema,
 } from '@atb/page-modules/assistant';
-import { Quay, TripPattern } from './server/journey-planner/validators';
 
 const featuresToFromToQuery = (from: GeocoderFeature, to: GeocoderFeature) => {
   return {
@@ -48,13 +47,12 @@ export const createTripQuery = (
 
   const departureDateQuery =
     departureDate && departureDate.type !== DepartureDateState.Now
-      ? { departureDate: departureDate.dateTime }
+      ? { departureMode, departureDate: departureDate.dateTime }
       : {};
 
   const fromToQuery = featuresToFromToQuery(fromFeature, toFeature);
 
   return {
-    departureMode,
     ...transportModeFilterQuery,
     ...departureDateQuery,
     ...fromToQuery,
@@ -80,3 +78,16 @@ export const parseTripQuery = (query: any): TripQuery | undefined => {
   }
   return parsed.data;
 };
+
+export function departureModeToDepartureDate(
+  mode?: DepartureMode,
+  date?: number,
+): DepartureDate {
+  if (mode === 'arriveBy') {
+    return { type: DepartureDateState.Arrival, dateTime: date ?? Date.now() };
+  } else if (mode === 'departBy') {
+    return { type: DepartureDateState.Departure, dateTime: date ?? Date.now() };
+  } else {
+    return { type: DepartureDateState.Now };
+  }
+}

--- a/src/pages/assistant/index.tsx
+++ b/src/pages/assistant/index.tsx
@@ -3,12 +3,14 @@ import DefaultLayout from '@atb/layouts/default';
 import { type WithGlobalData, withGlobalData } from '@atb/layouts/global-data';
 import { withAssistantClient } from '@atb/page-modules/assistant/server';
 import Trip, { TripProps } from '@atb/page-modules/assistant/trip';
-import { parseTripQuery } from '@atb/page-modules/assistant';
 import type { TripData } from '@atb/page-modules/assistant';
 import {
-  StreetMode,
   AssistantLayout,
   AssistantLayoutProps,
+  DepartureMode,
+  departureModeToDepartureDate,
+  parseTripQuery,
+  StreetMode,
 } from '@atb/page-modules/assistant';
 import type { NextPage } from 'next';
 
@@ -80,7 +82,11 @@ export const getServerSideProps = withGlobalData(
               initialToFeature: to,
               initialTransportModesFilter: transportModeFilter,
               trip,
-              departureMode: tripQuery.departureMode,
+              departureMode: tripQuery.departureMode ?? DepartureMode.DepartBy,
+              initialDepartureMode: departureModeToDepartureDate(
+                tripQuery.departureMode,
+                tripQuery.departureDate,
+              ),
               nonTransitTrips,
             },
           };


### PR DESCRIPTION
Added the feature to get the initial state for the departure date selector from the query. This ensures that if the page is reloaded or the URL is copied and opened in a new tab etc., the departure date selector will keep the correct state. 

Fixes https://github.com/AtB-AS/kundevendt/issues/15103