### PR TITLE
feat: empty search results component

### DIFF
--- a/src/components/empty-search-results/empty-search-results.module.css
+++ b/src/components/empty-search-results/empty-search-results.module.css
@@ -1,0 +1,18 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacings-large);
+  text-align: center;
+  max-width: 22rem;
+  margin: 0 auto;
+
+  padding: var(--spacings-medium);
+}
+
+.text {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacings-xSmall);
+  color: var(--text-colors-secondary);
+}

--- a/src/components/empty-search-results/index.tsx
+++ b/src/components/empty-search-results/index.tsx
@@ -1,0 +1,25 @@
+import { Image } from '@atb/components/icon';
+import { Typo } from '@atb/components/typography';
+import style from './empty-search-results.module.css';
+
+export type EmptySearchResultsProps = {
+  title: string;
+  details: string;
+};
+
+export default function EmptySearchResults({
+  title,
+  details,
+}: EmptySearchResultsProps) {
+  return (
+    <div className={style.container}>
+      <div>
+        <Image image="OnBehalfOf" alt="" width="113" />
+      </div>
+      <div className={style.text}>
+        <Typo.h3 textType="body__primary--bold">{title}</Typo.h3>
+        <Typo.span textType="body__secondary">{details}</Typo.span>
+      </div>
+    </div>
+  );
+}

--- a/src/page-modules/assistant/__tests__/assistant-data.fixture.ts
+++ b/src/page-modules/assistant/__tests__/assistant-data.fixture.ts
@@ -1,0 +1,37 @@
+import { FeatureCategory } from '@atb/components/venue-icon';
+import { GeocoderFeature } from '@atb/page-modules/departures';
+import { NonTransitTripData, TripData } from '..';
+
+export const fromFeature: GeocoderFeature = {
+  id: '638651',
+  name: 'Strindheim',
+  locality: 'Trondheim',
+  category: [FeatureCategory.BYDEL],
+  layer: 'address',
+  geometry: {
+    coordinates: [10.456038846578249, 63.42666114395819],
+  },
+};
+
+export const toFeature: GeocoderFeature = {
+  id: 'NSR:StopPlace:43984',
+  name: 'Byåsen skole',
+  locality: 'Trondheim',
+  category: [FeatureCategory.ONSTREET_BUS],
+  layer: 'venue',
+  geometry: { coordinates: [10.358037, 63.398886] },
+};
+
+export const tripResult: TripData = {
+  nextPageCursor: 'aaa',
+  previousPageCursor: 'bbb',
+  tripPatterns: [],
+};
+
+export const nonTransitTripResult: NonTransitTripData = {
+  footTrip: {
+    nextPageCursor: 'ccc',
+    previousPageCursor: 'ddd',
+    tripPatterns: [],
+  },
+};

--- a/src/page-modules/assistant/__tests__/assistant.test.tsx
+++ b/src/page-modules/assistant/__tests__/assistant.test.tsx
@@ -98,7 +98,7 @@ describe('assistant page', function () {
     expect(submitButton).toBeDisabled();
   });
 
-  it('Should render empty search results', () => {
+  it('should render empty search results', () => {
     const output = render(
       <Trip
         initialFromFeature={fromFeature}

--- a/src/page-modules/assistant/__tests__/assistant.test.tsx
+++ b/src/page-modules/assistant/__tests__/assistant.test.tsx
@@ -3,15 +3,19 @@ import mockRouter from 'next-router-mock';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ExternalClient } from '@atb/modules/api-server';
 import { JourneyPlannerApi } from '@atb/page-modules/assistant/server/journey-planner';
-import { TripData } from '@atb/page-modules/assistant/server/journey-planner/validators';
 import { getServerSideProps } from '@atb/pages/assistant';
 import { expectProps } from '@atb/tests/utils';
 import { createDynamicRouteParser } from 'next-router-mock/dynamic-routes';
-import { GeocoderFeature } from '@atb/page-modules/departures';
-import { FeatureCategory } from '@atb/components/venue-icon';
 import { GeocoderApi } from '@atb/page-modules/departures/server/geocoder';
 import AssistantLayout from '../layout';
-import { NonTransitTripData } from '@atb/page-modules/assistant';
+import Trip from '../trip';
+import {
+  fromFeature,
+  nonTransitTripResult,
+  toFeature,
+  tripResult,
+} from './assistant-data.fixture';
+import { DepartureMode } from '..';
 
 afterEach(function () {
   cleanup();
@@ -25,55 +29,22 @@ describe('assistant page', function () {
   it('should return props from getServerSideProps', async () => {
     await mockRouter.push('/assistant');
 
-    const expectedFromFeature: GeocoderFeature = {
-      id: '638651',
-      name: 'Strindheim',
-      locality: 'Trondheim',
-      category: [FeatureCategory.BYDEL],
-      layer: 'address',
-      geometry: {
-        coordinates: [10.456038846578249, 63.42666114395819],
-      },
-    };
-
-    const expectedToFeature: GeocoderFeature = {
-      id: 'NSR:StopPlace:43984',
-      name: 'Byåsen skole',
-      locality: 'Trondheim',
-      category: [FeatureCategory.ONSTREET_BUS],
-      layer: 'venue',
-      geometry: { coordinates: [10.358037, 63.398886] },
-    };
-
-    const expectedTripResult: TripData = {
-      nextPageCursor: 'aaa',
-      previousPageCursor: 'bbb',
-      tripPatterns: [],
-    };
-    const expectedNonTransitTripResult: NonTransitTripData = {
-      footTrip: {
-        nextPageCursor: 'ccc',
-        previousPageCursor: 'ddd',
-        tripPatterns: [],
-      },
-    };
-
     const gqlClient: ExternalClient<
       'graphql-journeyPlanner3' | 'http-entur',
       GeocoderApi & JourneyPlannerApi
     > = {
       async trip() {
-        return expectedTripResult;
+        return tripResult;
       },
       async nonTransitTrips() {
-        return expectedNonTransitTripResult;
+        return nonTransitTripResult;
       },
       async autocomplete() {
         return {} as any;
       },
       async reverse(lat, lon, layers) {
-        if (layers === 'address') return expectedFromFeature;
-        else return expectedToFeature;
+        if (layers === 'address') return fromFeature;
+        else return toFeature;
       },
       client: null as any,
     };
@@ -99,11 +70,11 @@ describe('assistant page', function () {
     } as any);
 
     (await expectProps(result)).toContain({
-      initialFromFeature: expectedFromFeature,
-      initialToFeature: expectedToFeature,
-      trip: expectedTripResult,
+      initialFromFeature: fromFeature,
+      initialToFeature: toFeature,
+      trip: tripResult,
       departureMode: 'departBy',
-      nonTransitTrips: expectedNonTransitTripResult,
+      nonTransitTrips: nonTransitTripResult,
     });
   });
 
@@ -126,4 +97,43 @@ describe('assistant page', function () {
     expect(submitButton).toBeInTheDocument();
     expect(submitButton).toBeDisabled();
   });
+
+  it('Should render empty search results', () => {
+    const output = render(
+      <Trip
+        initialFromFeature={fromFeature}
+        initialToFeature={toFeature}
+        trip={{ ...tripResult, tripPatterns: [] }}
+        departureMode={DepartureMode.DepartBy}
+        nonTransitTrips={nonTransitTripResult}
+        initialTransportModesFilter={null}
+      />,
+    );
+
+    expect(
+      output.getByText('Ingen kollektivreiser passer til ditt søk'),
+    ).toBeInTheDocument();
+
+    expect(
+      output.getByText('Prøv å justere på sted eller tidspunkt.'),
+    ).toBeInTheDocument();
+  });
+
+  it('Should render empty search results with filter details'),
+    () => {
+      const output = render(
+        <Trip
+          initialFromFeature={fromFeature}
+          initialToFeature={toFeature}
+          trip={{ ...tripResult, tripPatterns: [] }}
+          departureMode={DepartureMode.DepartBy}
+          nonTransitTrips={nonTransitTripResult}
+          initialTransportModesFilter={['bus']}
+        />,
+      );
+
+      expect(
+        output.getByText('Prøv å justere på sted, filter eller tidspunkt.'),
+      ).toBeInTheDocument();
+    };
 });

--- a/src/page-modules/assistant/__tests__/assistant.test.tsx
+++ b/src/page-modules/assistant/__tests__/assistant.test.tsx
@@ -119,7 +119,7 @@ describe('assistant page', function () {
     ).toBeInTheDocument();
   });
 
-  it('Should render empty search results with filter details'),
+  it('should render empty search results with filter details'),
     () => {
       const output = render(
         <Trip

--- a/src/page-modules/assistant/trip/index.tsx
+++ b/src/page-modules/assistant/trip/index.tsx
@@ -22,6 +22,7 @@ import { getInitialTransportModeFilter } from '@atb/components/transport-mode-fi
 import { Button } from '@atb/components/button';
 import { NonTransitTrip } from '../non-transit-pill';
 import { TripPatternHeader } from '@atb/page-modules/assistant/trip/trip-pattern-header';
+import EmptySearchResults from '@atb/components/empty-search-results';
 
 export type TripProps = {
   initialFromFeature: GeocoderFeature;
@@ -45,6 +46,27 @@ export default function Trip({
     useTripPatterns(trip, departureMode);
 
   const nonTransits = Object.entries(nonTransitTrips);
+
+  if (tripPatterns.length === 0) {
+    return (
+      <EmptySearchResults
+        title={t(
+          PageText.Assistant.trip.emptySearchResults.emptySearchResultsTitle,
+        )}
+        details={
+          initialTransportModesFilter
+            ? t(
+                PageText.Assistant.trip.emptySearchResults
+                  .emptySearchResultsDetailsWithFilters,
+              )
+            : t(
+                PageText.Assistant.trip.emptySearchResults
+                  .emptySearchResultsDetails,
+              )
+        }
+      />
+    );
+  }
   return (
     <>
       <div className={style.tripResults}>

--- a/src/page-modules/departures/__tests__/departure.test.tsx
+++ b/src/page-modules/departures/__tests__/departure.test.tsx
@@ -13,6 +13,7 @@ import { createDynamicRouteParser } from 'next-router-mock/dynamic-routes';
 import { departureDataFixture } from './departure-data.fixture';
 import { StopPlace } from '../stop-place';
 import userEvent from '@testing-library/user-event';
+import { NearestStopPlaces } from '..';
 afterEach(function () {
   cleanup();
 });
@@ -110,5 +111,14 @@ describe('departure page', function () {
     await userEvent.click(button[0]);
     lists = output.getAllByRole('list');
     expect(lists.length).toBe(1);
+  });
+
+  it('Should render empty search results', () => {
+    const output = render(
+      <NearestStopPlaces activeLocation={undefined} nearestStopPlaces={[]} />,
+    );
+    expect(
+      output.getByText('Finner ingen holdeplasser i nærheten'),
+    ).toBeInTheDocument();
   });
 });

--- a/src/page-modules/departures/__tests__/departure.test.tsx
+++ b/src/page-modules/departures/__tests__/departure.test.tsx
@@ -113,7 +113,7 @@ describe('departure page', function () {
     expect(lists.length).toBe(1);
   });
 
-  it('Should render empty search results', () => {
+  it('should render empty search results', () => {
     const output = render(
       <NearestStopPlaces activeLocation={undefined} nearestStopPlaces={[]} />,
     );

--- a/src/page-modules/departures/nearest-stop-places/index.tsx
+++ b/src/page-modules/departures/nearest-stop-places/index.tsx
@@ -11,6 +11,7 @@ import { Typo } from '@atb/components/typography';
 import { useRouter } from 'next/router';
 import VenueIcon, { FeatureCategory } from '@atb/components/venue-icon';
 import { PageText, useTranslation } from '@atb/translations';
+import EmptySearchResults from '@atb/components/empty-search-results';
 
 export type NearestStopPlacesProps = {
   activeLocation: GeocoderFeature | undefined;
@@ -21,7 +22,23 @@ export function NearestStopPlaces({
   nearestStopPlaces,
   activeLocation,
 }: NearestStopPlacesProps) {
+  const { t } = useTranslation();
   const router = useRouter();
+
+  if (nearestStopPlaces.length === 0) {
+    return (
+      <EmptySearchResults
+        title={t(
+          PageText.Departures.nearest.emptySearchResults
+            .emptyNearbyLocationsTitle,
+        )}
+        details={t(
+          PageText.Departures.nearest.emptySearchResults
+            .emptyNearbyLocationsDetails,
+        )}
+      />
+    );
+  }
   return (
     <section className={style.nearestContainer}>
       <div className={style.mapContainer}>

--- a/src/translations/pages/assistant.ts
+++ b/src/translations/pages/assistant.ts
@@ -107,5 +107,22 @@ export const Assistant = {
       bikeRental: _('Bysykkel', 'City bike', 'Bysykkel'),
       unknown: _('Ukjent', 'Unknown', 'Ukjent'),
     },
+    emptySearchResults: {
+      emptySearchResultsTitle: _(
+        'Ingen kollektivreiser passer til ditt søk',
+        'No public transportation routes match your search criteria',
+        'Ingen kollektivreiser passar til søket ditt',
+      ),
+      emptySearchResultsDetails: _(
+        'Prøv å justere på sted eller tidspunkt.',
+        'Try adjusting your time or location input.',
+        'Prøv å justere på stad eller tidspunkt.',
+      ),
+      emptySearchResultsDetailsWithFilters: _(
+        'Prøv å justere på sted, filter eller tidspunkt.',
+        'Try adjusting your time, filters or location input.',
+        'Prøv å justere på stad, filter eller tidspunkt.',
+      ),
+    },
   },
 };

--- a/src/translations/pages/departures.ts
+++ b/src/translations/pages/departures.ts
@@ -89,6 +89,5 @@ export const Departures = {
         'Sjå fleire avgangar',
       ),
     },
-    noSearchResults: {},
   },
 };

--- a/src/translations/pages/departures.ts
+++ b/src/translations/pages/departures.ts
@@ -47,6 +47,18 @@ export const Departures = {
           `Holdeplass ${name}. ${distance} meter gåavstand`,
         ),
     },
+    emptySearchResults: {
+      emptyNearbyLocationsTitle: _(
+        'Finner ingen holdeplasser i nærheten',
+        'No nearby stop places found',
+        'Finn ingen haldeplassar i nærleiken',
+      ),
+      emptyNearbyLocationsDetails: _(
+        'Prøv å søke på et annet navn eller bruk et annet stoppested for å finne avganger i nærheten.',
+        'Try to search for another name or use another stop place to find departures nearby.',
+        'Prøv å søkje på eit anna namn eller bruk ein annan stoppestad for å finne avgangar i nærleiken.',
+      ),
+    },
   },
   stopPlace: {
     noDepartures: _(
@@ -77,5 +89,6 @@ export const Departures = {
         'Sjå fleire avgangar',
       ),
     },
+    noSearchResults: {},
   },
 };


### PR DESCRIPTION
This introduces a component for handling empty search results. 

Fixes sub-task "Add information on empty results" for https://github.com/AtB-AS/kundevendt/issues/11319 

<details>
<summary>Screenshots</summary>

<img width="1033" alt="image" src="https://github.com/AtB-AS/planner-web/assets/43166974/1cc75b90-b8fd-4729-87f7-0adb456e38b9">

<img width="1026" alt="image" src="https://github.com/AtB-AS/planner-web/assets/43166974/0425fa56-96a4-45b5-a599-ff723d63cf2e">

<img width="1041" alt="image" src="https://github.com/AtB-AS/planner-web/assets/43166974/6878c26b-3c66-461e-bd6f-780b9505ff76">


</details>