### PR TITLE
feat: loading indicator when searching for travels and stop places

### DIFF
--- a/src/page-modules/assistant/assistant.module.css
+++ b/src/page-modules/assistant/assistant.module.css
@@ -132,7 +132,7 @@
 }
 
 .isSearching {
-  margin: 0 auto;
   padding: 2.5rem;
+  text-align: center;
   color: var(--text-colors-secondary);
 }

--- a/src/page-modules/assistant/assistant.module.css
+++ b/src/page-modules/assistant/assistant.module.css
@@ -130,3 +130,9 @@
   flex-wrap: wrap;
   gap: var(--spacings-medium);
 }
+
+.isSearching {
+  margin: 0 auto;
+  padding: 2.5rem;
+  color: var(--text-colors-secondary);
+}

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -24,6 +24,7 @@ import {
 import SwapButton from '@atb/components/search/swap-button';
 import GeolocationButton from '@atb/components/search/geolocation-button';
 import { AnimatePresence, motion } from 'framer-motion';
+import React from 'react';
 
 export type AssistantLayoutProps = PropsWithChildren<{
   initialFromFeature?: GeocoderFeature;
@@ -60,7 +61,7 @@ function AssistantLayout({
   const [isSwapping, setIsSwapping] = useState(false);
   const [isSearching, setIsSearching] = useState(false);
 
-  const onSwap = () => {
+  const onSwap = async () => {
     if (!selectedToFeature || !selectedFromFeature) return;
     setIsSwapping(true);
     const query = createTripQuery(
@@ -75,9 +76,11 @@ function AssistantLayout({
     const temp = selectedFromFeature;
     setSelectedFromFeature(selectedToFeature);
     setSelectedToFeature(temp);
-    router
-      .push({ pathname: '/assistant', query })
-      .then(() => setIsSwapping(false));
+    setIsSwapping(false);
+
+    setIsSearching(true);
+    await router.push({ pathname: '/assistant', query });
+    setIsSearching(false);
   };
 
   const onGeolocate = (geolocationFeature: GeocoderFeature) => {
@@ -95,7 +98,7 @@ function AssistantLayout({
     router.push({ pathname: '/assistant', query });
   };
 
-  const onSubmitHandler: FormEventHandler<HTMLFormElement> = (e) => {
+  const onSubmitHandler: FormEventHandler<HTMLFormElement> = async (e) => {
     e.preventDefault();
     if (!selectedFromFeature || !selectedToFeature) return;
     setIsSearching(true);
@@ -108,10 +111,16 @@ function AssistantLayout({
         : undefined,
       transportModeFilter,
     );
-    router
-      .push({ pathname: '/assistant', query })
-      .then(() => setIsSearching(false));
+    await router.push({ pathname: '/assistant', query });
+    setIsSearching(false);
   };
+
+  const hasEmptyChild = React.Children.toArray(children).some((child) => {
+    if (React.isValidElement(child)) {
+      return 'empty' in child.props;
+    }
+    return false;
+  });
 
   return (
     <div>
@@ -223,7 +232,7 @@ function AssistantLayout({
       </form>
 
       <section className={style.contentContainer}>
-        {isSearching || isSwapping ? (
+        {isSearching && hasEmptyChild ? (
           <Typo.p textType="body__primary" className={style.isSearching}>
             {t(PageText.Assistant.search.searching)}
           </Typo.p>

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -233,9 +233,17 @@ function AssistantLayout({
 
       <section className={style.contentContainer}>
         {isSearching && hasEmptyChild ? (
-          <Typo.p textType="body__primary" className={style.isSearching}>
-            {t(PageText.Assistant.search.searching)}
-          </Typo.p>
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.3 }}
+            className={style.isSearching}
+          >
+            <Typo.p textType="body__primary">
+              {t(PageText.Assistant.search.searching)}
+            </Typo.p>
+          </motion.div>
         ) : (
           children
         )}

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -58,6 +58,7 @@ function AssistantLayout({
     getInitialTransportModeFilter(initialTransportModesFilter),
   );
   const [isSwapping, setIsSwapping] = useState(false);
+  const [isSearching, setIsSearching] = useState(false);
 
   const onSwap = () => {
     if (!selectedToFeature || !selectedFromFeature) return;
@@ -97,6 +98,7 @@ function AssistantLayout({
   const onSubmitHandler: FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
     if (!selectedFromFeature || !selectedToFeature) return;
+    setIsSearching(true);
     const query = createTripQuery(
       selectedFromFeature,
       selectedToFeature,
@@ -106,7 +108,9 @@ function AssistantLayout({
         : undefined,
       transportModeFilter,
     );
-    router.push({ pathname: '/assistant', query });
+    router
+      .push({ pathname: '/assistant', query })
+      .then(() => setIsSearching(false));
   };
 
   return (
@@ -213,11 +217,20 @@ function AssistantLayout({
             mode="interactive_0"
             disabled={!selectedFromFeature || !selectedToFeature}
             buttonProps={{ type: 'submit' }}
+            state={isSearching ? 'loading' : undefined}
           />
         </div>
       </form>
 
-      <section className={style.contentContainer}>{children}</section>
+      <section className={style.contentContainer}>
+        {isSearching || isSwapping ? (
+          <Typo.p textType="body__primary" className={style.isSearching}>
+            {t(PageText.Assistant.search.searching)}
+          </Typo.p>
+        ) : (
+          children
+        )}
+      </section>
     </div>
   );
 }

--- a/src/page-modules/departures/departures.module.css
+++ b/src/page-modules/departures/departures.module.css
@@ -75,6 +75,12 @@
   right: 0;
 }
 
+.isSearching {
+  margin: 0 auto;
+  padding: 2.5rem;
+  color: var(--text-colors-secondary);
+  text-align: center;
+}
 
 @media (max-width: 650px) {
   .container {

--- a/src/page-modules/departures/departures.module.css
+++ b/src/page-modules/departures/departures.module.css
@@ -76,10 +76,9 @@
 }
 
 .isSearching {
-  margin: 0 auto;
   padding: 2.5rem;
-  color: var(--text-colors-secondary);
   text-align: center;
+  color: var(--text-colors-secondary);
 }
 
 @media (max-width: 650px) {

--- a/src/page-modules/departures/layout.tsx
+++ b/src/page-modules/departures/layout.tsx
@@ -181,11 +181,19 @@ function DeparturesLayout({
 
       <section className={style.contentContainer}>
         {isSearching && hasEmptyChild ? (
-          <Typo.p textType="body__primary" className={style.isSearching}>
-            {selectedFeature?.layer === 'venue'
-              ? t(PageText.Departures.search.searching.stopPlace)
-              : t(PageText.Departures.search.searching.nearby)}
-          </Typo.p>
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.3 }}
+            className={style.isSearching}
+          >
+            <Typo.p textType="body__primary">
+              {selectedFeature?.layer === 'venue'
+                ? t(PageText.Departures.search.searching.stopPlace)
+                : t(PageText.Departures.search.searching.nearby)}
+            </Typo.p>
+          </motion.div>
         ) : (
           children
         )}

--- a/src/page-modules/departures/layout.tsx
+++ b/src/page-modules/departures/layout.tsx
@@ -21,6 +21,7 @@ import { MonoIcon } from '@atb/components/icon';
 import { FocusScope } from '@react-aria/focus';
 import GeolocationButton from '@atb/components/search/geolocation-button';
 import { AnimatePresence, motion } from 'framer-motion';
+import React from 'react';
 
 export type DeparturesLayoutProps = PropsWithChildren<{
   initialTransportModesFilter?: TransportModeFilterOption[] | null;
@@ -41,8 +42,9 @@ function DeparturesLayout({
   const [transportModeFilter, setTransportModeFilter] = useState(
     getInitialTransportModeFilter(initialTransportModesFilter),
   );
+  const [isSearching, setIsSearching] = useState(false);
 
-  const onSubmitHandler: FormEventHandler<HTMLFormElement> = (e) => {
+  const onSubmitHandler: FormEventHandler<HTMLFormElement> = async (e) => {
     e.preventDefault();
 
     let query = {};
@@ -56,14 +58,16 @@ function DeparturesLayout({
     }
 
     if (selectedFeature?.layer == 'venue') {
+      setIsSearching(true);
       // TODO: Using URL object encodes all query params
-      router.push({
+      await router.push({
         pathname: `/departures/[[...id]]`,
         query: { ...query, id: selectedFeature.id },
       });
     } else if (selectedFeature?.layer == 'address') {
+      setIsSearching(true);
       const [lon, lat] = selectedFeature.geometry.coordinates;
-      router.push({
+      await router.push({
         href: '/departures',
         query: {
           ...query,
@@ -72,7 +76,15 @@ function DeparturesLayout({
         },
       });
     }
+    setIsSearching(false);
   };
+
+  const hasEmptyChild = React.Children.toArray(children).some((child) => {
+    if (React.isValidElement(child)) {
+      return 'empty' in child.props;
+    }
+    return false;
+  });
 
   return (
     <div className={style.departuresPage}>
@@ -162,11 +174,22 @@ function DeparturesLayout({
             mode="interactive_0"
             disabled={!selectedFeature}
             buttonProps={{ type: 'submit' }}
+            state={isSearching ? 'loading' : undefined}
           />
         </div>
       </form>
 
-      <section className={style.contentContainer}>{children}</section>
+      <section className={style.contentContainer}>
+        {isSearching && hasEmptyChild ? (
+          <Typo.p textType="body__primary" className={style.isSearching}>
+            {selectedFeature?.layer === 'venue'
+              ? t(PageText.Departures.search.searching.stopPlace)
+              : t(PageText.Departures.search.searching.nearby)}
+          </Typo.p>
+        ) : (
+          children
+        )}
+      </section>
     </div>
   );
 }

--- a/src/translations/pages/assistant.ts
+++ b/src/translations/pages/assistant.ts
@@ -36,6 +36,11 @@ export const Assistant = {
         title: _('Flere valg', 'More choices', 'Fleire val'),
       },
     },
+    searching: _(
+      'Laster søkeresultater…',
+      'Loading search results…',
+      'Lastar søkeresultata…',
+    ),
   },
   trip: {
     tripPattern: {

--- a/src/translations/pages/assistant.ts
+++ b/src/translations/pages/assistant.ts
@@ -37,9 +37,9 @@ export const Assistant = {
       },
     },
     searching: _(
-      'Laster søkeresultater…',
-      'Loading search results…',
-      'Lastar søkeresultata…',
+      'Laster reiseforslag...',
+      'Loading travel suggestion...',
+      'Lastar resiseforslag...',
     ),
   },
   trip: {

--- a/src/translations/pages/departures.ts
+++ b/src/translations/pages/departures.ts
@@ -34,6 +34,18 @@ export const Departures = {
         title: _('Flere valg', 'More choices', 'Fleire val'),
       },
     },
+    searching: {
+      nearby: _(
+        'Laster holdeplasser...',
+        'Loading stop places...',
+        'Lastar haldeplassar...',
+      ),
+      stopPlace: _(
+        'Laster avganger...',
+        'Loading departures...',
+        'Lastar avgangar...',
+      ),
+    },
   },
 
   nearest: {


### PR DESCRIPTION
This PR introduces searching state information when searching for travel patterns and stop places. I've added a loading indicator to the search button and a text about loading travel suggestions/stop places/departures according to the design sketches.  

Fixes https://github.com/AtB-AS/kundevendt/issues/14924

TODO:
- [x] See if there is a better approach to this
- [x] Add correct translations
- [x] Add to departure page
- [x] Animate with framer motion