### PR TITLE
refactor: removes loads of unused data

### DIFF
--- a/src/page-modules/assistant/__tests__/assistant-data.fixture.ts
+++ b/src/page-modules/assistant/__tests__/assistant-data.fixture.ts
@@ -30,8 +30,8 @@ export const tripResult: TripData = {
 
 export const nonTransitTripResult: NonTransitTripData = {
   footTrip: {
-    nextPageCursor: 'ccc',
-    previousPageCursor: 'ddd',
-    tripPatterns: [],
+    duration: 0,
+    mode: 'bus',
+    rentedBike: false,
   },
 };

--- a/src/page-modules/assistant/non-transit-pill/index.tsx
+++ b/src/page-modules/assistant/non-transit-pill/index.tsx
@@ -1,29 +1,26 @@
 import { ButtonLink } from '@atb/components/button';
 import { MonoIcon } from '@atb/components/icon';
 import { TransportMonoIcon } from '@atb/components/transport-mode';
-import { type TripPattern } from '@atb/page-modules/assistant/server/journey-planner/validators';
+import { TransportModeType } from '@atb/components/transport-mode/types';
 import { PageText, TranslateFunction, useTranslation } from '@atb/translations';
 import { secondsToDurationShort } from '@atb/utils/date';
-import { NonTransitTripData } from '..';
-import { TransportModeType } from '@atb/components/transport-mode/types';
 
 type NonTransitTripProps = {
-  tripPattern: TripPattern;
-  nonTransitType: keyof NonTransitTripData;
+  nonTransit: {
+    mode: TransportModeType;
+    rentedBike: boolean;
+    duration: number;
+  };
 };
-export function NonTransitTrip({
-  tripPattern,
-  nonTransitType,
-}: NonTransitTripProps) {
+export function NonTransitTrip({ nonTransit }: NonTransitTripProps) {
   const { t, language } = useTranslation();
 
-  if (!tripPattern) {
+  if (!nonTransit) {
     return null;
   }
 
-  const { mode, modeText } = getMode(tripPattern, t);
-
-  const durationShort = secondsToDurationShort(tripPattern.duration, language);
+  const { mode, modeText } = getMode(nonTransit, t);
+  const durationShort = secondsToDurationShort(nonTransit.duration, language);
 
   return (
     <ButtonLink
@@ -40,14 +37,13 @@ export function NonTransitTrip({
 }
 
 const getMode = (
-  tp: TripPattern,
+  opts: { mode: TransportModeType; rentedBike: boolean },
   t: TranslateFunction,
 ): { mode: TransportModeType; modeText: string } => {
-  let mode = tp.legs[0]?.mode ?? 'unknown';
+  let mode = opts.mode;
   let text = t(PageText.Assistant.trip.nonTransit.unknown);
 
-  if (tp.legs.some((leg) => leg.rentedBike)) {
-    mode = 'bicycle';
+  if (opts.rentedBike) {
     text = t(PageText.Assistant.trip.nonTransit.bikeRental);
   } else if (mode === 'foot') {
     text = t(PageText.Assistant.trip.nonTransit.foot);

--- a/src/page-modules/assistant/server/journey-planner/index.ts
+++ b/src/page-modules/assistant/server/journey-planner/index.ts
@@ -7,14 +7,16 @@ import {
   TripsNonTransitQueryVariables,
   TripsQuery,
   TripsQueryVariables,
-} from '@atb/page-modules/assistant/server/journey-planner/journey-gql/trip.generated';
+} from './journey-gql/trip.generated';
 import {
   Notice,
   Situation,
   TripData,
+  nonTransitSchema,
   tripSchema,
-} from '@atb/page-modules/assistant/server/journey-planner/validators';
+} from './validators';
 import type {
+  NonTransitData,
   NonTransitTripData,
   NonTransitTripInput,
   TripInput,
@@ -79,9 +81,17 @@ export function createJourneyApi(
 
       let nonTransits: NonTransitTripData = {};
 
-      for (let [legType, trip] of Object.entries(result.data)) {
-        const data: RecursivePartial<TripData> = mapResultToTrips(trip);
-        const validated = tripSchema.safeParse(data);
+      for (let [legType, nonTransitTrip] of Object.entries(result.data)) {
+        const data: Partial<NonTransitData> = {
+          duration: nonTransitTrip.tripPatterns[0]?.duration,
+          mode: nonTransitTrip.tripPatterns[0]?.legs[0]?.mode as any,
+          rentedBike:
+            nonTransitTrip.tripPatterns[0]?.legs?.some(
+              (leg) => leg.rentedBike,
+            ) ?? false,
+        };
+
+        const validated = nonTransitSchema.safeParse(data);
         if (!validated.success) {
           throw validated.error;
         }

--- a/src/page-modules/assistant/server/journey-planner/journey-gql/trip.gql
+++ b/src/page-modules/assistant/server/journey-planner/journey-gql/trip.gql
@@ -43,10 +43,17 @@ query TripsNonTransit(
     to: $to
     dateTime: $when
     arriveBy: $arriveBy
+    numTripPatterns: 1
     walkSpeed: $walkSpeed
     modes: { directMode: foot, transportModes: [] }
   ) @include(if: $includeFoot) {
-    ...trip
+    tripPatterns {
+      duration
+      legs {
+        mode
+        rentedBike
+      }
+    }
   }
   bikeRentalTrip: trip(
     from: $from
@@ -54,19 +61,33 @@ query TripsNonTransit(
     dateTime: $when
     arriveBy: $arriveBy
     walkSpeed: $walkSpeed
+    numTripPatterns: 1
     modes: { directMode: bike_rental, transportModes: [] }
   ) @include(if: $includeBikeRental) {
-    ...trip
+    tripPatterns {
+      duration
+      legs {
+        mode
+        rentedBike
+      }
+    }
   }
   bicycleTrip: trip(
     from: $from
     to: $to
     dateTime: $when
     arriveBy: $arriveBy
+    numTripPatterns: 1
     walkSpeed: $walkSpeed
     modes: { directMode: bicycle, transportModes: [] }
   ) @include(if: $includeBicycle) {
-    ...trip
+    tripPatterns {
+      duration
+      legs {
+        mode
+        rentedBike
+      }
+    }
   }
 }
 

--- a/src/page-modules/assistant/server/journey-planner/validators.ts
+++ b/src/page-modules/assistant/server/journey-planner/validators.ts
@@ -161,9 +161,16 @@ export const tripSchema = z.object({
   tripPatterns: z.array(tripPatternSchema),
 });
 
+export const nonTransitSchema = z.object({
+  mode: TransportModeType,
+  rentedBike: z.boolean(),
+  duration: z.number(),
+});
+
 export type Notice = z.infer<typeof noticeSchema>;
 export type Situation = z.infer<typeof situationSchema>;
 export type TripData = z.infer<typeof tripSchema>;
+export type NonTransitData = z.infer<typeof nonTransitSchema>;
 export type TripPattern = z.infer<typeof tripPatternSchema>;
 export type Leg = z.infer<typeof legSchema>;
 export type Quay = z.infer<typeof quaySchema>;

--- a/src/page-modules/assistant/trip/index.tsx
+++ b/src/page-modules/assistant/trip/index.tsx
@@ -84,12 +84,8 @@ export default function Trip({
       <div className={style.tripResults}>
         {nonTransits.length > 0 && (
           <div className={style.nonTransitResult}>
-            {Object.entries(nonTransitTrips).map(([legType, trip]) => (
-              <NonTransitTrip
-                key={legType}
-                tripPattern={trip.tripPatterns[0]}
-                nonTransitType={legType as keyof NonTransitTripData}
-              />
+            {Object.entries(nonTransitTrips).map(([legType, nonTransit]) => (
+              <NonTransitTrip key={legType} nonTransit={nonTransit} />
             ))}
           </div>
         )}

--- a/src/page-modules/assistant/types.ts
+++ b/src/page-modules/assistant/types.ts
@@ -1,7 +1,10 @@
 import { TransportModeFilterOption } from '@atb/components/transport-mode-filter/types';
 import { GeocoderFeature } from '@atb/page-modules/departures';
 import { z } from 'zod';
-import type { TripData } from './server/journey-planner/validators';
+import type {
+  NonTransitData,
+  TripData,
+} from './server/journey-planner/validators';
 
 export enum DepartureMode {
   DepartBy = 'departBy',
@@ -62,9 +65,9 @@ export type NonTransitTripInput = {
   directModes: StreetMode[];
 };
 
-export type { TripData };
+export type { TripData, NonTransitData };
 export type NonTransitTripData = {
-  cycleTrip?: TripData;
-  footTrip?: TripData;
-  bikeRentalTrip?: TripData;
+  cycleTrip?: NonTransitData;
+  footTrip?: NonTransitData;
+  bikeRentalTrip?: NonTransitData;
 };


### PR DESCRIPTION
Only pass on what is needed for showing non-transit suggestions.

Needs to be extended when the detail page is implemented (with added key/id)