### PR TITLE
feat: add initial state for search and date to departures page

### DIFF
--- a/src/modules/search-time/index.ts
+++ b/src/modules/search-time/index.ts
@@ -1,3 +1,5 @@
 export { default as SearchTimeSelector } from './selector';
 
 export * from './types';
+
+export { parseSearchTimeQuery, searchTimeToQueryString } from './utils';

--- a/src/modules/search-time/utils.ts
+++ b/src/modules/search-time/utils.ts
@@ -15,3 +15,9 @@ export function parseSearchTimeQuery(
 
   return { mode: 'now' };
 }
+
+export function searchTimeToQueryString(searchTime: SearchTime) {
+  return searchTime.mode !== 'now'
+    ? { searchMode: searchTime.mode, searchTime: searchTime.dateTime }
+    : { searchMode: searchTime.mode };
+}

--- a/src/page-modules/departures/__tests__/departure.test.tsx
+++ b/src/page-modules/departures/__tests__/departure.test.tsx
@@ -14,6 +14,8 @@ import { departureDataFixture } from './departure-data.fixture';
 import { StopPlace } from '../stop-place';
 import userEvent from '@testing-library/user-event';
 import { NearestStopPlaces } from '..';
+import { GeocoderApi } from '@atb/page-modules/departures/server/geocoder';
+
 afterEach(function () {
   cleanup();
 });
@@ -48,8 +50,8 @@ describe('departure page', function () {
     };
 
     const gqlClient: ExternalClient<
-      'graphql-journeyPlanner3',
-      JourneyPlannerApi
+      'graphql-journeyPlanner3' | 'http-entur',
+      GeocoderApi & JourneyPlannerApi
     > = {
       async departures() {
         return expectedDeparturesResult;
@@ -58,9 +60,20 @@ describe('departure page', function () {
         return {} as any;
       },
       stopPlace() {
-        return {} as any;
+        return {
+          position: {
+            lat: 0,
+            lon: 0,
+          },
+        } as any;
       },
       estimatedCalls() {
+        return {} as any;
+      },
+      async autocomplete() {
+        return {} as any;
+      },
+      async reverse(lat, lon, layers) {
         return {} as any;
       },
       serviceJourney() {

--- a/src/page-modules/departures/layout.tsx
+++ b/src/page-modules/departures/layout.tsx
@@ -17,22 +17,35 @@ import { FocusScope } from '@react-aria/focus';
 import GeolocationButton from '@atb/components/search/geolocation-button';
 import { AnimatePresence, motion } from 'framer-motion';
 import React from 'react';
-import { SearchTime, SearchTimeSelector } from '@atb/modules/search-time';
+import {
+  SearchTime,
+  SearchTimeSelector,
+  searchTimeToQueryString,
+} from '@atb/modules/search-time';
+import { ParsedUrlQueryInput } from 'node:querystring';
 
 export type DeparturesLayoutProps = PropsWithChildren<{
   initialTransportModesFilter?: TransportModeFilterOption[] | null;
+  initialSearchTime?: SearchTime;
+  initialFeature?: GeocoderFeature;
 }>;
 
 function DeparturesLayout({
   children,
   initialTransportModesFilter,
+  initialSearchTime,
+  initialFeature,
 }: DeparturesLayoutProps) {
   const { t } = useTranslation();
   const router = useRouter();
 
   const [showAlternatives, setShowAlternatives] = useState(false);
-  const [selectedFeature, setSelectedFeature] = useState<GeocoderFeature>();
-  const [searchTime, setSearchTime] = useState<SearchTime>({ mode: 'now' });
+  const [selectedFeature, setSelectedFeature] = useState<
+    GeocoderFeature | undefined
+  >(initialFeature);
+  const [searchTime, setSearchTime] = useState<SearchTime>(
+    initialSearchTime ?? { mode: 'now' },
+  );
   const [transportModeFilter, setTransportModeFilter] = useState(
     getInitialTransportModeFilter(initialTransportModesFilter),
   );
@@ -41,12 +54,15 @@ function DeparturesLayout({
   const onSubmitHandler: FormEventHandler<HTMLFormElement> = async (e) => {
     e.preventDefault();
 
-    let query = {};
+    let query: ParsedUrlQueryInput = {
+      ...searchTimeToQueryString(searchTime),
+    };
 
     const filter = filterToQueryString(transportModeFilter);
 
     if (filter) {
       query = {
+        ...query,
         filter,
       };
     }
@@ -97,6 +113,7 @@ function DeparturesLayout({
             <Search
               label={t(PageText.Departures.search.input.from)}
               selectedItem={selectedFeature}
+              initialFeature={initialFeature}
               onChange={setSelectedFeature}
               button={
                 <GeolocationButton

--- a/src/page-modules/departures/server/journey-planner/index.ts
+++ b/src/page-modules/departures/server/journey-planner/index.ts
@@ -54,6 +54,7 @@ import { formatISO } from 'date-fns';
 
 export type DepartureInput = {
   id: string;
+  date: number | null;
   transportModes: TransportModeFilterOption[] | null;
 };
 export type { DepartureData, Quay, Departure };
@@ -102,7 +103,9 @@ export function createJourneyApi(
         query: StopPlaceQuayDeparturesDocument,
         variables: {
           id: input.id,
-          startTime: new Date(),
+          startTime: input.date
+            ? new Date(input.date).toISOString()
+            : new Date().toISOString(),
           numberOfDepartures: 10,
           transportModes: getTransportModesEnums(input.transportModes),
         },

--- a/src/pages/departures/[[...id]].tsx
+++ b/src/pages/departures/[[...id]].tsx
@@ -73,7 +73,6 @@ export const getServerSideProps = withGlobalData(
     if (id && stopPlace) {
       const departures = await client.departures({
         id,
-        date: searchTime.mode !== 'now' ? searchTime.dateTime : null,
         transportModes: transportModeFilter,
       });
 

--- a/src/pages/departures/[[...id]].tsx
+++ b/src/pages/departures/[[...id]].tsx
@@ -73,6 +73,7 @@ export const getServerSideProps = withGlobalData(
     if (id && stopPlace) {
       const departures = await client.departures({
         id,
+        date: searchTime.mode !== 'now' ? searchTime.dateTime : null,
         transportModes: transportModeFilter,
       });
 


### PR DESCRIPTION
Adds initial state for the search bar and date selector on the departures page. Without the initial state it didn't matter what was in the query.