### PR TITLE
feat: add transport mode filter to estimated calls query

### DIFF
--- a/src/page-modules/departures/client/journey-planner/index.ts
+++ b/src/page-modules/departures/client/journey-planner/index.ts
@@ -4,9 +4,11 @@ export type EstimatedCallsApiReturnType = EstimatedCallsData;
 export async function nextDepartures(
   quayId: string,
   startTime: string,
+  transportModes: string | null,
 ): Promise<EstimatedCallsApiReturnType> {
   const result = await fetch(
-    `/api/departures/journey-planner?quayId=${quayId}&startTime=${startTime}`,
+    `/api/departures/journey-planner?quayId=${quayId}&startTime=${startTime}` +
+      (transportModes ? `&transportModes=${transportModes}` : ''),
   );
 
   return await result.json();

--- a/src/page-modules/departures/server/journey-planner/index.ts
+++ b/src/page-modules/departures/server/journey-planner/index.ts
@@ -253,7 +253,7 @@ export function createJourneyApi(
           numberOfDepartures: 6, // TODO: Have to add one to account for the last departure of the original set of departures?
           startTime: new Date(input.startTime),
           transportModes:
-            (input.transportModes as TransportMode[]) ?? null,
+            (input.transportModes as GraphQlTransportMode[]) ?? null,
         },
       });
 

--- a/src/page-modules/departures/server/journey-planner/index.ts
+++ b/src/page-modules/departures/server/journey-planner/index.ts
@@ -250,7 +250,7 @@ export function createJourneyApi(
         query: QuayEstimatedCallsDocument,
         variables: {
           id: input.quayId,
-          numberOfDepartures: 6, // TODO: Have to add one to account for the last departure of the original set of departures?
+          numberOfDepartures: 6,
           startTime: new Date(input.startTime),
           transportModes:
             (input.transportModes as GraphQlTransportMode[]) ?? null,

--- a/src/page-modules/departures/server/journey-planner/index.ts
+++ b/src/page-modules/departures/server/journey-planner/index.ts
@@ -67,6 +67,7 @@ export type NearestStopPlacesInput = {
 export type EstimatedCallsInput = {
   quayId: string;
   startTime: string;
+  transportModes: TransportModeType[] | null;
 };
 
 export type ServiceJourneyInput = {
@@ -249,8 +250,10 @@ export function createJourneyApi(
         query: QuayEstimatedCallsDocument,
         variables: {
           id: input.quayId,
-          numberOfDepartures: 5,
+          numberOfDepartures: 6, // TODO: Have to add one to account for the last departure of the original set of departures?
           startTime: new Date(input.startTime),
+          transportModes:
+            (input.transportModes as TransportMode[]) ?? null,
         },
       });
 

--- a/src/page-modules/departures/server/journey-planner/journey-gql/estimated-calls.gql
+++ b/src/page-modules/departures/server/journey-planner/journey-gql/estimated-calls.gql
@@ -2,6 +2,7 @@ query quayEstimatedCalls(
   $id: String!
   $numberOfDepartures: Int
   $startTime: DateTime
+  $transportModes: [TransportMode]
 ) {
   quay(id: $id) {
     description
@@ -12,6 +13,7 @@ query quayEstimatedCalls(
       numberOfDepartures: $numberOfDepartures
       startTime: $startTime
       includeCancelledTrips: true
+      whiteListedModes: $transportModes
     ) {
       aimedDepartureTime
       date

--- a/src/page-modules/departures/stop-place/index.tsx
+++ b/src/page-modules/departures/stop-place/index.tsx
@@ -47,7 +47,7 @@ export function StopPlace({ departures }: StopPlaceProps) {
       </div>
       <div className={style.quaysContainer}>
         <Link
-          href={`/departures/${departures.stopPlace.id}`}
+          href={router.asPath}
           className={style.refreshButtonLink}
           onMouseEnter={() => setIsHoveringRefreshButton(true)}
           onMouseLeave={() => setIsHoveringRefreshButton(false)}
@@ -75,6 +75,7 @@ type EstimatedCallListProps = {
 
 export function EstimatedCallList({ quay }: EstimatedCallListProps) {
   const { t } = useTranslation();
+  const router = useRouter();
   const [isCollapsed, setIsCollapsed] = useState<boolean>(false);
   const [departures, setDepartures] = useState<Departure[]>(quay.departures);
   const [isFetchingDepartures, setIsFetchingDepartures] =
@@ -85,7 +86,11 @@ export function EstimatedCallList({ quay }: EstimatedCallListProps) {
     const latestDeparture = departures[departures.length - 1];
 
     const date = new Date(latestDeparture.aimedDepartureTime);
-    const data = await nextDepartures(quay.id, date.toUTCString());
+    const data = await nextDepartures(
+      quay.id,
+      date.toISOString(),
+      router.query.filter?.toString() ?? null,
+    );
 
     const set = new Set(departures.map((departure) => departure.id));
     const filteredDepartures = data.departures.filter(

--- a/src/pages/api/departures/journey-planner.ts
+++ b/src/pages/api/departures/journey-planner.ts
@@ -7,7 +7,7 @@ import { z } from 'zod';
 import {
   getAllTransportModesFromFilterOptions,
   parseFilterQuery,
-} from '@atb/components/transport-mode-filter/utils';
+} from '@atb/modules/transport-mode';
 
 export default handlerWithDepartureClient<EstimatedCallsApiReturnType>({
   async GET(req, res, { client, ok }) {

--- a/src/pages/api/departures/journey-planner.ts
+++ b/src/pages/api/departures/journey-planner.ts
@@ -4,11 +4,19 @@ import { handlerWithDepartureClient } from '@atb/page-modules/departures/server'
 import { ServerText } from '@atb/translations';
 import { constants } from 'http2';
 import { z } from 'zod';
+import {
+  getAllTransportModesFromFilterOptions,
+  parseFilterQuery,
+} from '@atb/components/transport-mode-filter/utils';
 
 export default handlerWithDepartureClient<EstimatedCallsApiReturnType>({
   async GET(req, res, { client, ok }) {
     const query = z
-      .object({ quayId: z.string(), startTime: z.string() })
+      .object({
+        quayId: z.string(),
+        startTime: z.string(),
+        transportModes: z.string().optional(),
+      })
       .safeParse(req.query);
 
     if (!query.success) {
@@ -20,7 +28,15 @@ export default handlerWithDepartureClient<EstimatedCallsApiReturnType>({
     }
 
     return tryResult(req, res, async () => {
-      return ok(await client.estimatedCalls(query.data));
+      return ok(
+        await client.estimatedCalls({
+          quayId: query.data.quayId,
+          startTime: query.data.startTime,
+          transportModes: getAllTransportModesFromFilterOptions(
+            parseFilterQuery(query.data.transportModes),
+          ),
+        }),
+      );
     });
   },
 });


### PR DESCRIPTION
Adds transport modes as a variable to the estimated calls/nextDepartures query such that the additional estimated calls fetched adhere to the same filters as the original query. Not sure how much this matters.