### PR TITLE
fix: fix geolocation not setting selected feature

### DIFF
--- a/src/components/search/geolocation-button/index.tsx
+++ b/src/components/search/geolocation-button/index.tsx
@@ -11,7 +11,8 @@ type GeolocationButtonProps = {
 };
 function GeolocationButton({ onGeolocate, className }: GeolocationButtonProps) {
   const { t } = useTranslation();
-  const { getPosition, isLoading, isUnavailable } = useGeolocation(onGeolocate);
+  const { getPosition, isLoading, isUnavailable, error } =
+    useGeolocation(onGeolocate);
 
   if (isUnavailable) return null;
 
@@ -43,6 +44,7 @@ function useGeolocation(onSuccess: (feature: GeocoderFeature) => void) {
 
   const getPosition = () => {
     setIsLoading(true);
+    setError(null);
 
     navigator.geolocation.getCurrentPosition(
       async (position) => {
@@ -53,8 +55,8 @@ function useGeolocation(onSuccess: (feature: GeocoderFeature) => void) {
         setIsLoading(false);
       },
       (error) => {
-        setIsLoading(false);
         setError(error);
+        setIsLoading(false);
       },
       { enableHighAccuracy: true, timeout: 10000 },
     );

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -71,18 +71,6 @@ function AssistantLayout({
     setIsSearching(false);
   };
 
-  const onGeolocate = (geolocationFeature: GeocoderFeature) => {
-    if (!selectedToFeature) return;
-    const query = createTripQuery(
-      geolocationFeature,
-      selectedToFeature,
-      searchTime,
-      transportModeFilter,
-    );
-    setSelectedFromFeature(geolocationFeature);
-    router.push({ pathname: '/assistant', query });
-  };
-
   const onSubmitHandler: FormEventHandler<HTMLFormElement> = async (e) => {
     e.preventDefault();
     if (!selectedFromFeature || !selectedToFeature) return;
@@ -126,7 +114,7 @@ function AssistantLayout({
               button={
                 <GeolocationButton
                   className={style.searchInputButton}
-                  onGeolocate={onGeolocate}
+                  onGeolocate={setSelectedFromFeature}
                 />
               }
             />

--- a/src/page-modules/departures/layout.tsx
+++ b/src/page-modules/departures/layout.tsx
@@ -96,6 +96,7 @@ function DeparturesLayout({
 
             <Search
               label={t(PageText.Departures.search.input.from)}
+              selectedItem={selectedFeature}
               onChange={setSelectedFeature}
               button={
                 <GeolocationButton


### PR DESCRIPTION
The selected feature was not set on the departure page when clicking the geolocation button.

Also changed the geolocating on the assistant page to not route when clicking the geolocation button, but only setting the feature, so the user have to click the submit button to search.