### PR TITLE
feat: allow not showing an option in search time selector

### DIFF
--- a/src/modules/search-time/selector/__tests__/selector.test.tsx
+++ b/src/modules/search-time/selector/__tests__/selector.test.tsx
@@ -34,9 +34,11 @@ describe('search time selector', function () {
       />,
     );
 
-    output.getByRole('radio', {
-      name: 'Ankomst',
-    });
+    expect(
+      output.getByRole('radio', {
+        name: 'Ankomst',
+      }),
+    ).toBeChecked();
   });
 
   it('should show date and time selector when "Arrival" is selected', async () => {
@@ -136,5 +138,34 @@ describe('search time selector', function () {
 
     expect(time).toHaveValue(newTime);
     expect(onChange).toHaveBeenCalled();
+  });
+
+  it('should not show arriveBy', () => {
+    const onChange = vi.fn();
+    const output = render(
+      <SearchTimeSelector
+        initialState={{ mode: 'now' }}
+        onChange={onChange}
+        options={['now', 'departBy']}
+      />,
+    );
+
+    expect(
+      output.queryByRole('radio', {
+        name: 'Ankomst',
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      output.queryByRole('radio', {
+        name: 'Nå',
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      output.queryByRole('radio', {
+        name: 'Avgang',
+      }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/modules/search-time/selector/index.tsx
+++ b/src/modules/search-time/selector/index.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, CSSProperties, useState } from 'react';
 import { format } from 'date-fns';
 import { AnimatePresence, motion } from 'framer-motion';
 import {
@@ -10,13 +10,15 @@ import { SEARCH_MODES, SearchMode, SearchTime } from '../types';
 import style from './selector.module.css';
 
 type SearchTimeSelectorProps = {
-  initialState?: SearchTime;
   onChange: (state: SearchTime) => void;
+  initialState?: SearchTime;
+  options?: SearchMode[];
 };
 
 export default function SearchTimeSelector({
-  initialState = { mode: 'now' },
   onChange,
+  initialState = { mode: 'now' },
+  options = SEARCH_MODES,
 }: SearchTimeSelectorProps) {
   const { t } = useTranslation();
   const [selectedMode, setSelectedMode] = useState<SearchTime>(initialState);
@@ -71,8 +73,11 @@ export default function SearchTimeSelector({
 
   return (
     <div className={style.departureDateSelector}>
-      <div className={style.options}>
-        {SEARCH_MODES.map((state) => (
+      <div
+        className={style.options}
+        style={{ '--number-of-options': options.length } as CSSProperties}
+      >
+        {options.map((state) => (
           <label key={state} className={style.option}>
             <input
               type="radio"

--- a/src/modules/search-time/selector/selector.module.css
+++ b/src/modules/search-time/selector/selector.module.css
@@ -8,9 +8,10 @@
   --option-height: 2.25rem;
   --container-border-radius: 0.75rem;
   --option-border-radius: var(--border-radius-regular);
+  --number-of-options: 3;
 
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(var(--number-of-options), minmax(0, 1fr));
   padding: var(--spacings-xSmall);
   background: var(--static-background-background_0-background);
   width: fit-content;
@@ -34,7 +35,7 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  padding: var(--spacings-small);
+  padding: var(--spacings-small) var(--spacings-medium);
   border-radius: var(--option-border-radius);
   height: var(--option-height);
   transition: color 250ms;

--- a/src/page-modules/departures/layout.tsx
+++ b/src/page-modules/departures/layout.tsx
@@ -114,6 +114,7 @@ function DeparturesLayout({
             <SearchTimeSelector
               initialState={searchTime}
               onChange={setSearchTime}
+              options={['now', 'departBy']}
             />
           </div>
         </motion.div>


### PR DESCRIPTION
Added a prop to allow not showing all the options in the search time selector. E.g. for the departures page we (most likely) don't want to show "Arrival" since it does not make sense in terms of showing departures for stop places.

<img width="524" alt="2023-11-12 at 19 04 53@2x" src="https://github.com/AtB-AS/planner-web/assets/14045515/0567b067-fd70-4ddf-8503-9a93b9be57ab">
