### PR TITLE
fix: fix location bug with transport mode filter

### DIFF
--- a/src/modules/transport-mode/filter/utils.ts
+++ b/src/modules/transport-mode/filter/utils.ts
@@ -59,7 +59,10 @@ export function parseFilterQuery(
 export function getAllTransportModesFromFilterOptions(
   filterOptions: TransportModeFilterOption[] | null,
 ): TransportModeType[] {
-  if (!filterOptions) return [];
+  if (!filterOptions)
+    return Object.values(filterOptionsWithTransportModes).flatMap((option) =>
+      option.modes.map((mode) => mode.transportMode),
+    );
 
   const transportModes: TransportModeType[] = [];
 


### PR DESCRIPTION
If no filter was set an empty array was passed and no results were returned. Setting all the modes if no filter is in the query, it means that "All" is selected.