### PR TITLE
feat: situations and notices in departure details

### DIFF
--- a/src/modules/situations/index.ts
+++ b/src/modules/situations/index.ts
@@ -1,3 +1,4 @@
 export { SituationOrNoticeIcon } from './situation-or-notice-icon';
+export { SituationMessageBox, MessageBox } from './situation-message-box';
 export * from './types';
 export * from './utils';

--- a/src/modules/situations/situation-message-box.tsx
+++ b/src/modules/situations/situation-message-box.tsx
@@ -17,6 +17,7 @@ import { useRef } from 'react';
 import dictionary from '@atb/translations/dictionary';
 import { Situation as SituationTexts } from '@atb/translations/modules';
 import { formatToLongDateTime } from '@atb/utils/date';
+
 export type Props = {
   situation: Situation;
   noStatusIcon?: MessageBoxProps['noStatusIcon'];

--- a/src/modules/situations/situation-message-box.tsx
+++ b/src/modules/situations/situation-message-box.tsx
@@ -1,0 +1,162 @@
+import { Theme } from '@atb-as/theme';
+import {
+  getMessageTypeForSituation,
+  getSituationSummary,
+  messageTypeToColorIcon,
+  messageTypeToMonoIcon,
+  validateEndTime,
+} from './utils';
+import { ColorIcon, MonoIcon } from '@atb/components/icon';
+import { Typo } from '@atb/components/typography';
+import { Situation } from './types';
+import { useTranslation, getTextForLanguage } from '@atb/translations';
+import { useTheme } from '@atb/modules/theme';
+import style from './situation.module.css';
+import { Button } from '@atb/components/button';
+import { useRef } from 'react';
+import dictionary from '@atb/translations/dictionary';
+import { Situation as SituationTexts } from '@atb/translations/modules';
+import { formatToLongDateTime } from '@atb/utils/date';
+export type Props = {
+  situation: Situation;
+  noStatusIcon?: MessageBoxProps['noStatusIcon'];
+};
+
+export const SituationMessageBox = ({ situation, noStatusIcon }: Props) => {
+  const { language, t } = useTranslation();
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  const messageType = getMessageTypeForSituation(situation);
+  const text = getSituationSummary(situation, language);
+  const validityPeriodText = useValidityPeriodText(situation.validityPeriod);
+
+  if (!text) return null;
+
+  return (
+    <>
+      <dialog ref={dialogRef} className={style.dialog}>
+        <div className={style.dialog__wrapper}>
+          <div className={style.dialog__content}>
+            <div className={style.dialog__title}>
+              <ColorIcon
+                className={style.icon}
+                icon={messageTypeToColorIcon(messageType)}
+              />
+              {situation.summary && (
+                <Typo.h2 textType="body__primary--bold">
+                  {getTextForLanguage(situation.summary, language)}
+                </Typo.h2>
+              )}
+            </div>
+
+            <Typo.p textType="body__primary">
+              {getTextForLanguage(situation.description, language)}
+            </Typo.p>
+
+            {validityPeriodText && (
+              <div className={style.dialog__validity}>
+                <MonoIcon className={style.icon} icon="time/Time" />
+                <Typo.p
+                  className={style.secondaryTextColor}
+                  textType="body__secondary"
+                >
+                  {validityPeriodText}
+                </Typo.p>
+              </div>
+            )}
+          </div>
+          <Button
+            buttonProps={{ formMethod: 'dialog' }}
+            title={t(dictionary.close)}
+            mode="interactive_0"
+            className={style.dialog__button}
+            onClick={() => dialogRef.current?.close()}
+          />
+        </div>
+      </dialog>
+      <MessageBox
+        type={messageType}
+        noStatusIcon={noStatusIcon}
+        message={text}
+        onClick={() => dialogRef.current?.showModal()}
+      />
+    </>
+  );
+};
+
+export type MessageBoxProps = {
+  type: keyof Theme['static']['status'];
+  title?: string;
+  message: string;
+  noStatusIcon?: boolean;
+  onClick?: () => void;
+};
+
+export const MessageBox = ({
+  noStatusIcon,
+  type,
+  message,
+  title,
+  onClick,
+}: MessageBoxProps) => {
+  const { static: staticColors } = useTheme();
+  const { t } = useTranslation();
+  const backgroundColorStyle = {
+    backgroundColor: staticColors['status'][type].background,
+  };
+
+  return (
+    <div className={style.container} style={backgroundColorStyle}>
+      {!noStatusIcon && (
+        <MonoIcon className={style.icon} icon={messageTypeToMonoIcon(type)} />
+      )}
+      <div className={style.content}>
+        {title && (
+          <Typo.h2 className={style.title} textType="body__primary--bold">
+            {title}
+          </Typo.h2>
+        )}
+        <Typo.p className={style.body} textType="body__primary">
+          {message}
+        </Typo.p>
+        {onClick && (
+          <Button
+            mode="transparent--underline"
+            onClick={() => onClick()}
+            title={t(dictionary.readMore)}
+            className={style.messageBox__button}
+            size="compact"
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export const useValidityPeriodText = (period?: Situation['validityPeriod']) => {
+  const { t, language } = useTranslation();
+
+  const endTime = period?.endTime && validateEndTime(period.endTime);
+  if (period?.startTime && endTime) {
+    return t(
+      SituationTexts.validity.fromAndTo(
+        formatToLongDateTime(period.startTime, language),
+        formatToLongDateTime(endTime, language),
+      ),
+    );
+  }
+  if (period?.startTime) {
+    return t(
+      SituationTexts.validity.from(
+        formatToLongDateTime(period.startTime, language),
+      ),
+    );
+  }
+  if (endTime) {
+    return t(
+      SituationTexts.validity.to(formatToLongDateTime(endTime, language)),
+    );
+  }
+
+  return undefined;
+};

--- a/src/modules/situations/situation-or-notice-icon.tsx
+++ b/src/modules/situations/situation-or-notice-icon.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { getIconForMostCriticalSituationOrNotice } from './utils';
-import { NoticeFragment, SituationFragment } from './types';
+import { Notice, Situation } from './types';
 import { ColorIcon } from '@atb/components/icon';
 
 type SituationOrNoticeIconProps = {
   accessibilityLabel?: string;
-  notices?: NoticeFragment[];
+  notices?: Notice[];
   cancellation?: boolean;
-} & ({ situations: SituationFragment[] } | { situation: SituationFragment });
+} & ({ situations: Situation[] } | { situation: Situation });
 
 export const SituationOrNoticeIcon = ({
   accessibilityLabel,

--- a/src/modules/situations/situation.module.css
+++ b/src/modules/situations/situation.module.css
@@ -27,7 +27,7 @@
 
 .dialog {
   padding: var(--spacings-large);
-  margin: auto auto;
+  margin: auto;
   border: none;
   border-radius: var(--border-radius-circle);
   background-color: var(--static-background-background_1-background);

--- a/src/modules/situations/situation.module.css
+++ b/src/modules/situations/situation.module.css
@@ -1,0 +1,66 @@
+.container {
+  display: flex;
+  padding: var(--spacings-medium);
+  border-radius: var(--border-radius-regular);
+}
+.content {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+.linkText {
+  margin-top: var(--spacings-medium);
+}
+.title {
+  margin-bottom: var(--spacings-small);
+  padding: var(--spacings-small);
+}
+.body {
+  padding: var(--spacings-small);
+}
+.messageBox__button {
+  padding: var(--spacings-small);
+}
+.icon {
+  margin-right: var(--spacings-medium);
+}
+
+.dialog {
+  padding: var(--spacings-large);
+  margin: auto auto;
+  border: none;
+  border-radius: var(--border-radius-circle);
+  background-color: var(--static-background-background_1-background);
+}
+
+.dialog::backdrop {
+  -webkit-backdrop-filter: blur(2px);
+  backdrop-filter: blur(2px);
+}
+.dialog__wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacings-medium);
+}
+.dialog__content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacings-medium);
+  padding: var(--spacings-large);
+  background-color: var(--static-background-background_0-background);
+  border-radius: var(--border-radius-regular);
+}
+.dialog__button {
+  text-align: center;
+}
+.dialog__title {
+  display: flex;
+  align-items: center;
+}
+.dialog__validity {
+  display: flex;
+  align-items: center;
+}
+.secondaryTextColor {
+  color: var(--text-colors-secondary);
+}

--- a/src/modules/situations/situation.module.css
+++ b/src/modules/situations/situation.module.css
@@ -22,7 +22,7 @@
   padding: var(--spacings-small);
 }
 .icon {
-  margin-right: var(--spacings-medium);
+  margin-top: var(--spacings-small);
 }
 
 .dialog {

--- a/src/modules/situations/types.ts
+++ b/src/modules/situations/types.ts
@@ -1,9 +1,31 @@
-export type NoticeFragment = {
-  id: string;
-  text: string | null;
-};
+import { languageAndTextSchema } from '@atb/translations/types';
+import { z } from 'zod';
 
-export type SituationFragment = {
-  situationNumber: string | null;
-  reportType: 'general' | 'incident' | null;
-};
+export const infoLinkSchema = z.object({
+  uri: z.string(),
+  label: z.string().nullable(),
+});
+
+export const situationSchema = z.object({
+  id: z.string(),
+  situationNumber: z.string().nullable(),
+  reportType: z.enum(['general', 'incident']).nullable(),
+  summary: z.array(languageAndTextSchema),
+  description: z.array(languageAndTextSchema),
+  advice: z.array(languageAndTextSchema),
+  infoLinks: z.array(infoLinkSchema).nullable(),
+  validityPeriod: z
+    .object({
+      startTime: z.string().nullable(),
+      endTime: z.string().nullable(),
+    })
+    .nullable(),
+});
+
+export const noticeSchema = z.object({
+  id: z.string(),
+  text: z.string().nullable(),
+});
+
+export type Notice = z.infer<typeof noticeSchema>;
+export type Situation = z.infer<typeof situationSchema>;

--- a/src/page-modules/assistant/server/journey-planner/index.ts
+++ b/src/page-modules/assistant/server/journey-planner/index.ts
@@ -8,13 +8,7 @@ import {
   TripsQuery,
   TripsQueryVariables,
 } from './journey-gql/trip.generated';
-import {
-  Notice,
-  Situation,
-  TripData,
-  nonTransitSchema,
-  tripSchema,
-} from './validators';
+import { TripData, nonTransitSchema, tripSchema } from './validators';
 import type {
   NonTransitData,
   NonTransitTripData,
@@ -26,6 +20,7 @@ import {
   isTransportModeType,
   isTransportSubmodeType,
 } from '@atb/modules/transport-mode';
+import { Notice, Situation } from '@atb/modules/situations';
 
 const MIN_NUMBER_OF_TRIP_PATTERNS = 8;
 const MAX_NUMBER_OF_SEARCH_ATTEMPTS = 5;
@@ -352,18 +347,24 @@ function mapSituations(
     id: situation.id,
     situationNumber: situation.situationNumber ?? null,
     reportType: situation.reportType ?? null,
-    summary: situation.summary.map((summary) => ({
-      language: summary.language ?? null,
-      value: summary.value,
-    })),
-    description: situation.description.map((description) => ({
-      language: description.language ?? null,
-      value: description.value,
-    })),
-    advice: situation.advice.map((advice) => ({
-      language: advice.language ?? null,
-      value: advice.value,
-    })),
+    summary: situation.summary
+      .map((summary) => ({
+        ...(summary.language ? { language: summary.language } : {}),
+        value: summary.value,
+      }))
+      .filter((summary) => Boolean(summary.value)),
+    description: situation.description
+      .map((description) => ({
+        ...(description.language ? { language: description.language } : {}),
+        value: description.value,
+      }))
+      .filter((description) => Boolean(description.value)),
+    advice: situation.advice
+      .map((advice) => ({
+        ...(advice.language ? { language: advice.language } : {}),
+        value: advice.value,
+      }))
+      .filter((advice) => Boolean(advice.value)),
     infoLinks: situation.infoLinks
       ? situation.infoLinks.map((infoLink) => ({
           uri: infoLink.uri,

--- a/src/page-modules/assistant/server/journey-planner/validators.ts
+++ b/src/page-modules/assistant/server/journey-planner/validators.ts
@@ -3,11 +3,7 @@ import {
   transportModeSchema,
   transportSubmodeSchema,
 } from '@atb/modules/transport-mode';
-
-export const noticeSchema = z.object({
-  id: z.string(),
-  text: z.string().nullable(),
-});
+import { noticeSchema, situationSchema } from '@atb/modules/situations';
 
 export const serviceJourneySchema = z.object({
   id: z.string(),
@@ -42,30 +38,6 @@ export const datedServiceJourneySchema = z.object({
 export const tariffZoneSchema = z.object({
   id: z.string(),
   name: z.string(),
-});
-export const languageAndTextSchema = z.object({
-  language: z.string().nullable(),
-  value: z.string(),
-});
-export const infoLinkSchema = z.object({
-  uri: z.string(),
-  label: z.string().nullable(),
-});
-
-export const situationSchema = z.object({
-  id: z.string(),
-  situationNumber: z.string().nullable(),
-  reportType: z.enum(['general', 'incident']).nullable(),
-  summary: z.array(languageAndTextSchema),
-  description: z.array(languageAndTextSchema),
-  advice: z.array(languageAndTextSchema),
-  infoLinks: z.array(infoLinkSchema).nullable(),
-  validityPeriod: z
-    .object({
-      startTime: z.string().nullable(),
-      endTime: z.string().nullable(),
-    })
-    .nullable(),
 });
 
 export const quaySchema = z.object({
@@ -168,8 +140,6 @@ export const nonTransitSchema = z.object({
   duration: z.number(),
 });
 
-export type Notice = z.infer<typeof noticeSchema>;
-export type Situation = z.infer<typeof situationSchema>;
 export type TripData = z.infer<typeof tripSchema>;
 export type NonTransitData = z.infer<typeof nonTransitSchema>;
 export type TripPattern = z.infer<typeof tripPatternSchema>;

--- a/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/utils.ts
+++ b/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/utils.ts
@@ -1,18 +1,5 @@
-import { NoticeFragment } from '@atb/modules/situations/types';
-import { onlyUniquesBasedOnField } from '@atb/utils/only-uniques';
+import { filterNotices } from '@atb/modules/situations';
 import { Leg } from '../../../server/journey-planner/validators';
-
-/**
- * Filter notices by removing duplicates (by id), removing those without text,
- * and also sorting them since the order from Entur may change on each request.
- */
-export const filterNotices = (
-  notices: NoticeFragment[],
-): Required<NoticeFragment>[] =>
-  notices
-    .filter((n): n is Required<NoticeFragment> => !!n.text)
-    .filter(onlyUniquesBasedOnField('id'))
-    .sort((s1, s2) => s1.id.localeCompare(s2.id));
 
 export const getNoticesForLeg = (leg: Leg) =>
   filterNotices([

--- a/src/page-modules/departures/__tests__/service-journey-data.fixture.ts
+++ b/src/page-modules/departures/__tests__/service-journey-data.fixture.ts
@@ -8,7 +8,8 @@ export const serviceJourneyFixture: ServiceJourneyData = {
   id: 'ATB:ServiceJourney:22_230306097862461_113',
   transportMode: 'bus' as TransportModeType,
   transportSubmode: 'localBus' as TransportSubmodeType,
-  line: { publicCode: '22' },
+  line: { publicCode: '22', notices: [] },
+  notices: [],
   estimatedCalls: [
     {
       actualArrivalTime: '2023-11-10T14:59:24+01:00',
@@ -31,6 +32,8 @@ export const serviceJourneyFixture: ServiceJourneyData = {
         id: 'NSR:Quay:73030',
         stopPlace: { id: 'NSR:StopPlace:42623' },
       },
+      situations: [],
+      notices: [],
     },
     {
       actualArrivalTime: '2023-11-10T15:01:22+01:00',
@@ -53,6 +56,8 @@ export const serviceJourneyFixture: ServiceJourneyData = {
         id: 'NSR:Quay:72609',
         stopPlace: { id: 'NSR:StopPlace:42400' },
       },
+      situations: [],
+      notices: [],
     },
     {
       actualArrivalTime: '2023-11-10T15:02:11+01:00',
@@ -75,6 +80,8 @@ export const serviceJourneyFixture: ServiceJourneyData = {
         id: 'NSR:Quay:71898',
         stopPlace: { id: 'NSR:StopPlace:42004' },
       },
+      situations: [],
+      notices: [],
     },
     {
       actualArrivalTime: '2023-11-10T15:03:04+01:00',
@@ -97,6 +104,8 @@ export const serviceJourneyFixture: ServiceJourneyData = {
         id: 'NSR:Quay:71678',
         stopPlace: { id: 'NSR:StopPlace:41882' },
       },
+      situations: [],
+      notices: [],
     },
     {
       actualArrivalTime: '2023-11-10T15:03:54+01:00',
@@ -119,6 +128,8 @@ export const serviceJourneyFixture: ServiceJourneyData = {
         id: 'NSR:Quay:75585',
         stopPlace: { id: 'NSR:StopPlace:44015' },
       },
+      situations: [],
+      notices: [],
     },
     {
       actualArrivalTime: '2023-11-10T15:04:42+01:00',
@@ -141,6 +152,8 @@ export const serviceJourneyFixture: ServiceJourneyData = {
         id: 'NSR:Quay:71659',
         stopPlace: { id: 'NSR:StopPlace:41875' },
       },
+      situations: [],
+      notices: [],
     },
     {
       actualArrivalTime: '2023-11-10T15:05:19+01:00',
@@ -163,6 +176,8 @@ export const serviceJourneyFixture: ServiceJourneyData = {
         id: 'NSR:Quay:75616',
         stopPlace: { id: 'NSR:StopPlace:44034' },
       },
+      situations: [],
+      notices: [],
     },
     {
       actualArrivalTime: '2023-11-10T15:06:34+01:00',
@@ -185,6 +200,8 @@ export const serviceJourneyFixture: ServiceJourneyData = {
         id: 'NSR:Quay:74990',
         stopPlace: { id: 'NSR:StopPlace:43687' },
       },
+      situations: [],
+      notices: [],
     },
     {
       actualArrivalTime: '2023-11-10T15:07:52+01:00',
@@ -207,6 +224,8 @@ export const serviceJourneyFixture: ServiceJourneyData = {
         id: 'NSR:Quay:75371',
         stopPlace: { id: 'NSR:StopPlace:43896' },
       },
+      situations: [],
+      notices: [],
     },
     {
       actualArrivalTime: '2023-11-10T15:09:56+01:00',
@@ -229,6 +248,8 @@ export const serviceJourneyFixture: ServiceJourneyData = {
         id: 'NSR:Quay:74497',
         stopPlace: { id: 'NSR:StopPlace:43418' },
       },
+      situations: [],
+      notices: [],
     },
   ],
 };

--- a/src/page-modules/departures/details/details.module.css
+++ b/src/page-modules/departures/details/details.module.css
@@ -8,7 +8,7 @@
   grid-template-areas:
     'header header'
     'serviceJourney map';
-  gap: var(--spacings-small);
+  gap: var(--spacings-large);
 }
 @media (max-width: 650px) {
   .container {
@@ -33,6 +33,9 @@
 }
 .serviceJourneyContainer {
   grid-area: serviceJourney;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacings-medium);
 }
 
 .header {

--- a/src/page-modules/departures/details/estimated-call-rows.tsx
+++ b/src/page-modules/departures/details/estimated-call-rows.tsx
@@ -14,13 +14,24 @@ import {
   type TransportModeType,
   useTransportationThemeColor,
 } from '@atb/modules/transport-mode';
+import {
+  Situation,
+  SituationMessageBox,
+  SituationOrNoticeIcon,
+} from '@atb/modules/situations';
+import { getSituationsToShowForCall } from './utils';
 
 export type EstimatedCallRowsProps = {
   calls: EstimatedCallWithMetadata[];
   mode: TransportModeType;
+  alreadyShownSituationNumbers: string[];
 };
 
-export function EstimatedCallRows({ calls, mode }: EstimatedCallRowsProps) {
+export function EstimatedCallRows({
+  calls,
+  mode,
+  alreadyShownSituationNumbers,
+}: EstimatedCallRowsProps) {
   const { t } = useTranslation();
   const [collapsed, setCollapsed] = useState(true);
 
@@ -75,6 +86,10 @@ export function EstimatedCallRows({ calls, mode }: EstimatedCallRowsProps) {
                 collapseButton={
                   call.metadata.isStartOfServiceJourney ? collapseButton : null
                 }
+                situations={getSituationsToShowForCall(
+                  call,
+                  alreadyShownSituationNumbers,
+                )}
               />
             </motion.div>
           ))}
@@ -92,7 +107,15 @@ export function EstimatedCallRows({ calls, mode }: EstimatedCallRowsProps) {
               delay: i * 0.015,
             }}
           >
-            <EstimatedCallRow call={call} mode={mode} collapseButton={null} />
+            <EstimatedCallRow
+              call={call}
+              mode={mode}
+              collapseButton={null}
+              situations={getSituationsToShowForCall(
+                call,
+                alreadyShownSituationNumbers,
+              )}
+            />
           </motion.div>
         ))}
       </div>
@@ -104,11 +127,13 @@ type EstimatedCallRowProps = {
   call: EstimatedCallWithMetadata;
   mode: TransportModeType;
   collapseButton: JSX.Element | null;
+  situations: Situation[];
 };
 function EstimatedCallRow({
   call,
   mode,
   collapseButton,
+  situations,
 }: EstimatedCallRowProps) {
   const { t } = useTranslation();
   const { group, isStartOfGroup, isEndOfGroup } = call.metadata;
@@ -152,6 +177,14 @@ function EstimatedCallRow({
           </Typo.p>
         )}
       </Row>
+      {situations.map((situation) => (
+        <Row
+          key={situation.situationNumber}
+          rowLabel={<SituationOrNoticeIcon situation={situation} />}
+        >
+          <SituationMessageBox noStatusIcon={true} situation={situation} />
+        </Row>
+      ))}
       {collapseButton}
     </div>
   );

--- a/src/page-modules/departures/details/index.tsx
+++ b/src/page-modules/departures/details/index.tsx
@@ -104,7 +104,7 @@ export const getNoticesForServiceJourney = (
   const focusedEstimatedCall =
     serviceJourney.estimatedCalls?.find(
       ({ quay }) => quay?.id && quay.id === fromQuayId,
-    ) || serviceJourney.estimatedCalls?.[0];
+    ) ?? serviceJourney.estimatedCalls?.[0];
 
   return filterNotices([
     ...serviceJourney.notices,

--- a/src/page-modules/departures/details/index.tsx
+++ b/src/page-modules/departures/details/index.tsx
@@ -109,6 +109,6 @@ export const getNoticesForServiceJourney = (
   return filterNotices([
     ...serviceJourney.notices,
     ...serviceJourney.line.notices,
-    ...(focusedEstimatedCall?.notices || []),
+    ...(focusedEstimatedCall?.notices ?? []),
   ]);
 };

--- a/src/page-modules/departures/details/utils.ts
+++ b/src/page-modules/departures/details/utils.ts
@@ -34,3 +34,26 @@ export function addMetadataToEstimatedCalls(
     [],
   );
 }
+
+/**
+ * Get the situations to show for an estimated call. Based on the following
+ * rules:
+ * - We don't show situations on passed calls or calls which are after the trip
+ * - We don't show situations which are already shown at the top, above the
+ *   service journey
+ * - If the trip have an end quay we only show situations on the end quay of the
+ *   trip, or else we show situations on all intermediate quays on the trip
+ */
+export function getSituationsToShowForCall(
+  { situations, metadata: { group, isEndOfGroup } }: EstimatedCallWithMetadata,
+  alreadyShownSituationNumbers: string[],
+  toQuayId?: string,
+) {
+  if (group === 'passed' || group === 'after') return [];
+  if (toQuayId && !isEndOfGroup) return [];
+  return situations.filter(
+    (s) =>
+      !s.situationNumber ||
+      !alreadyShownSituationNumbers.includes(s.situationNumber),
+  );
+}

--- a/src/page-modules/departures/server/journey-planner/index.ts
+++ b/src/page-modules/departures/server/journey-planner/index.ts
@@ -310,7 +310,17 @@ export function createJourneyApi(
         transportSubmode: serviceJourney?.transportSubmode,
         line: {
           publicCode: serviceJourney?.line.publicCode,
+          notices:
+            serviceJourney?.notices?.map((notice) => ({
+              id: notice.id,
+              text: notice.text,
+            })) ?? [],
         },
+        notices:
+          serviceJourney?.notices?.map((notice) => ({
+            id: notice.id,
+            text: notice.text,
+          })) ?? [],
         estimatedCalls: serviceJourney?.estimatedCalls?.map(
           (estimatedCall) => ({
             actualArrivalTime: estimatedCall.actualArrivalTime || null,
@@ -335,6 +345,49 @@ export function createJourneyApi(
                 id: estimatedCall.quay.stopPlace?.id,
               },
             },
+            notices:
+              estimatedCall.notices?.map((notice) => ({
+                id: notice.id,
+                text: notice.text,
+              })) ?? [],
+            situations:
+              estimatedCall.situations?.map((situation) => ({
+                id: situation.id,
+                situationNumber: situation.situationNumber ?? null,
+                reportType: situation.reportType ?? null,
+                summary: situation.summary
+                  .map((summary) => ({
+                    ...(summary.language ? { language: summary.language } : {}),
+                    value: summary.value ?? undefined,
+                  }))
+                  .filter((summary) => Boolean(summary.value)),
+                description: situation.description
+                  .map((description) => ({
+                    ...(description.language
+                      ? { language: description.language }
+                      : {}),
+                    value: description.value ?? undefined,
+                  }))
+                  .filter((description) => Boolean(description.value)),
+                advice: situation.advice
+                  .map((advice) => ({
+                    ...(advice.language ? { language: advice.language } : {}),
+                    value: advice.value ?? undefined,
+                  }))
+                  .filter((advice) => Boolean(advice.value)),
+                infoLinks: situation.infoLinks
+                  ? situation.infoLinks.map((infoLink) => ({
+                      uri: infoLink.uri,
+                      label: infoLink.label ?? null,
+                    }))
+                  : null,
+                validityPeriod: situation.validityPeriod
+                  ? {
+                      startTime: situation.validityPeriod.startTime ?? null,
+                      endTime: situation.validityPeriod.endTime ?? null,
+                    }
+                  : null,
+              })) ?? [],
           }),
         ),
       };

--- a/src/page-modules/departures/server/journey-planner/journey-gql/service-journey-with-estimated-calls.gql
+++ b/src/page-modules/departures/server/journey-planner/journey-gql/service-journey-with-estimated-calls.gql
@@ -6,6 +6,12 @@ query serviceJourneyWithEstimatedCalls($id: String!, $date: Date) {
     publicCode
     line {
       publicCode
+      notices {
+        ...notice
+      }
+    }
+    notices {
+      ...notice
     }
     estimatedCalls(date: $date) {
       actualArrivalTime
@@ -29,6 +35,12 @@ query serviceJourneyWithEstimatedCalls($id: String!, $date: Date) {
         stopPlace {
           id
         }
+      }
+      notices {
+        ...notice
+      }
+      situations {
+        ...situation
       }
     }
   }

--- a/src/page-modules/departures/server/journey-planner/validators.ts
+++ b/src/page-modules/departures/server/journey-planner/validators.ts
@@ -1,3 +1,4 @@
+import { noticeSchema, situationSchema } from '@atb/modules/situations';
 import {
   transportModeSchema,
   transportSubmodeSchema,
@@ -58,7 +59,9 @@ export const serviceJourneySchema = z.object({
   transportSubmode: transportSubmodeSchema.optional(),
   line: z.object({
     publicCode: z.string(),
+    notices: z.array(noticeSchema),
   }),
+  notices: z.array(noticeSchema),
   estimatedCalls: z.array(
     z.object({
       actualArrivalTime: z.string().nullable(),
@@ -81,6 +84,8 @@ export const serviceJourneySchema = z.object({
           id: z.string(),
         }),
       }),
+      notices: z.array(noticeSchema),
+      situations: z.array(situationSchema),
     }),
   ),
 });

--- a/src/translations/dictionary.ts
+++ b/src/translations/dictionary.ts
@@ -25,6 +25,8 @@ const dictionary = {
   },
   a11yRouteTimePrefix: _('rutetid ', 'route time ', `rutetid `),
   missingRealTimePrefix: _('ca. ', 'ca. ', `ca. `),
+  readMore: _('Les mer', 'Read more', `Les meir`),
+  close: _('Lukk', 'Close', 'Lukk'),
 };
 
 export default orgSpecificTranslations(dictionary, {

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -13,6 +13,8 @@ export {
   useLanguageSettings,
 } from './language-context';
 
+export { getTextForLanguage } from './utils';
+
 export * as CommonText from './common';
 export * as ServerText from './server';
 export * as ComponentText from './components';

--- a/src/translations/modules/index.ts
+++ b/src/translations/modules/index.ts
@@ -1,2 +1,3 @@
 export { Layout } from './layout';
 export { SearchTime } from './search-time';
+export { Situation } from './situation';

--- a/src/translations/modules/situation.ts
+++ b/src/translations/modules/situation.ts
@@ -1,0 +1,20 @@
+import { translation as _ } from '@atb/translations/commons';
+
+export const Situation = {
+  validity: {
+    from: (fromDate: string) =>
+      _(
+        `Gyldig fra ${fromDate}`,
+        `Valid from ${fromDate}`,
+        `Gyldig frå ${fromDate}`,
+      ),
+    to: (toDate: string) =>
+      _(`Gyldig til ${toDate}`, `Valid to ${toDate}`, `Gyldig til ${toDate}`),
+    fromAndTo: (fromDate: string, toDate: string) =>
+      _(
+        `Gyldig fra ${fromDate} til ${toDate}`,
+        `Valid from ${fromDate} to ${toDate}`,
+        `Gyldig frå ${fromDate} til ${toDate}`,
+      ),
+  },
+};

--- a/src/translations/types.ts
+++ b/src/translations/types.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 export enum LanguageAndTextLanguagesEnum {
   'nob' = 'nob',
   'nno' = 'nno',
@@ -8,9 +10,15 @@ export enum LanguageAndTextLanguagesEnum {
   'en' = 'en',
 }
 
-export type LanguageAndTextType =
-  | {
-      lang: string;
-      value: string;
-    }
-  | { language?: string; value?: string };
+export const languageAndTextSchema = z.union([
+  z.object({
+    lang: z.string(),
+    value: z.string(),
+  }),
+  z.object({
+    language: z.string().optional(),
+    value: z.string().optional(),
+  }),
+]);
+
+export type LanguageAndTextType = z.infer<typeof languageAndTextSchema>;


### PR DESCRIPTION
This PR features situations and notices on the departure detail page. 

At the time of writing this, one can look up bus 78 from Ringvål and from Lergårdsbakken to test situations. 

Closes https://github.com/AtB-AS/kundevendt/issues/9162

<details>
<summary>Screenshots</summary>

<img width="522" alt="image" src="https://github.com/AtB-AS/planner-web/assets/43166974/2c6817eb-8991-45f6-bb5a-f2d8f46ea178">

<img width="917" alt="image" src="https://github.com/AtB-AS/planner-web/assets/43166974/2b639d25-bc59-4ee9-b6a2-00e441ad12ff">

<img width="620" alt="image" src="https://github.com/AtB-AS/planner-web/assets/43166974/3a5cf1f7-c504-4bc4-a047-835a94a28ab3">


</details>