### PR TITLE
fix: parse trip query

### DIFF
--- a/src/page-modules/assistant/utils.ts
+++ b/src/page-modules/assistant/utils.ts
@@ -78,7 +78,7 @@ export function parseTripQuery(query: any): TripQuery | undefined {
       query[field] = parseFloat(query[field]);
   });
 
-  const optionalNumericFields = ['departureDate'];
+  const optionalNumericFields = ['searchTime'];
   optionalNumericFields.forEach((field) => {
     if (query[field] && typeof query[field] === 'string')
       query[field] = Number(query[field]);


### PR DESCRIPTION
Currently, a search with a specific search time doesn't work because the trip query parsing fails. This fixes that. 