### PR TITLE
fix: quay header

### DIFF
--- a/src/page-modules/departures/stop-place/stop-place.module.css
+++ b/src/page-modules/departures/stop-place/stop-place.module.css
@@ -67,6 +67,7 @@
   display: flex;
   align-items: center;
   gap: var(--spacings-xSmall);
+  flex-wrap: wrap;
 }
 
 .listItem {


### PR DESCRIPTION
This makes it so that the quay header behaves similarly to the app. 
Fixes https://github.com/AtB-AS/kundevendt/issues/15497

Before:
<img width="521" alt="image" src="https://github.com/AtB-AS/planner-web/assets/43166974/745f36d2-a92b-48ad-a7a4-4bb0bf209a3f">


With fix: 
<img width="670" alt="image" src="https://github.com/AtB-AS/planner-web/assets/43166974/56b3d840-cd7a-4599-b39e-2648fe89c681">
