### PR TITLE
fix: quay name

### DIFF
--- a/src/page-modules/departures/details/estimated-call-rows.tsx
+++ b/src/page-modules/departures/details/estimated-call-rows.tsx
@@ -19,7 +19,7 @@ import {
   SituationMessageBox,
   SituationOrNoticeIcon,
 } from '@atb/modules/situations';
-import { getSituationsToShowForCall } from './utils';
+import { formatQuayName, getSituationsToShowForCall } from './utils';
 
 export type EstimatedCallRowsProps = {
   calls: EstimatedCallWithMetadata[];
@@ -165,7 +165,9 @@ function EstimatedCallRow({
         isBetween={isBetween}
         href={`/departures/${call.quay.stopPlace.id}`}
       >
-        <Typo.p textType="body__primary">{call.quay.name}</Typo.p>
+        <Typo.p textType="body__primary">
+          {formatQuayName(call.quay.name, call.quay.publicCode)}
+        </Typo.p>
         {!call.forAlighting && !call.metadata.isStartOfServiceJourney && (
           <Typo.p textType="body__secondary" className={style.boardingInfo}>
             {t(PageText.Departures.details.messages.noAlighting)}

--- a/src/page-modules/departures/details/utils.ts
+++ b/src/page-modules/departures/details/utils.ts
@@ -57,3 +57,9 @@ export function getSituationsToShowForCall(
       !alreadyShownSituationNumbers.includes(s.situationNumber),
   );
 }
+
+export function formatQuayName(quayName?: string, publicCode?: string | null) {
+  if (!quayName) return;
+  if (!publicCode) return quayName;
+  return `${quayName} ${publicCode}`;
+}


### PR DESCRIPTION
This adds the public code to the quay name if defined (P1, 1, etc.). 

<img width="306" alt="image" src="https://github.com/AtB-AS/planner-web/assets/43166974/462b40dc-10b0-4de1-b5e5-3bcc93226401">


Fixes https://github.com/AtB-AS/kundevendt/issues/15506