### PR TITLE
feat: notices and situations for departures

### DIFF
--- a/src/modules/situations/situation-message-box.tsx
+++ b/src/modules/situations/situation-message-box.tsx
@@ -17,13 +17,19 @@ import { useRef } from 'react';
 import dictionary from '@atb/translations/dictionary';
 import { Situation as SituationTexts } from '@atb/translations/modules';
 import { formatToLongDateTime } from '@atb/utils/date';
+import { and } from '@atb/utils/css';
 
 export type Props = {
   situation: Situation;
   noStatusIcon?: MessageBoxProps['noStatusIcon'];
+  borderRadius?: boolean;
 };
 
-export const SituationMessageBox = ({ situation, noStatusIcon }: Props) => {
+export const SituationMessageBox = ({
+  situation,
+  noStatusIcon,
+  borderRadius = true,
+}: Props) => {
   const { language, t } = useTranslation();
   const dialogRef = useRef<HTMLDialogElement>(null);
 
@@ -73,6 +79,7 @@ export const SituationMessageBox = ({ situation, noStatusIcon }: Props) => {
         </div>
       </dialog>
       <MessageBox
+        borderRadius={borderRadius}
         type={messageType}
         noStatusIcon={noStatusIcon}
         message={text}
@@ -88,6 +95,7 @@ export type MessageBoxProps = {
   message: string;
   noStatusIcon?: boolean;
   onClick?: () => void;
+  borderRadius?: boolean;
 };
 
 export const MessageBox = ({
@@ -96,6 +104,7 @@ export const MessageBox = ({
   message,
   title,
   onClick,
+  borderRadius = true,
 }: MessageBoxProps) => {
   const { static: staticColors } = useTheme();
   const { t } = useTranslation();
@@ -103,8 +112,13 @@ export const MessageBox = ({
     backgroundColor: staticColors['status'][type].background,
   };
 
+  const borderRadiusStyle = borderRadius ? style.borderRadius : '';
+
   return (
-    <div className={style.container} style={backgroundColorStyle}>
+    <div
+      className={and(style.container, borderRadiusStyle)}
+      style={backgroundColorStyle}
+    >
       {!noStatusIcon && (
         <MonoIcon className={style.icon} icon={messageTypeToMonoIcon(type)} />
       )}

--- a/src/modules/situations/situation-message-box.tsx
+++ b/src/modules/situations/situation-message-box.tsx
@@ -17,7 +17,7 @@ import { useRef } from 'react';
 import dictionary from '@atb/translations/dictionary';
 import { Situation as SituationTexts } from '@atb/translations/modules';
 import { formatToLongDateTime } from '@atb/utils/date';
-import { and } from '@atb/utils/css';
+import { andIf } from '@atb/utils/css';
 
 export type Props = {
   situation: Situation;
@@ -112,11 +112,12 @@ export const MessageBox = ({
     backgroundColor: staticColors['status'][type].background,
   };
 
-  const borderRadiusStyle = borderRadius ? style.borderRadius : '';
-
   return (
     <div
-      className={and(style.container, borderRadiusStyle)}
+      className={andIf({
+        [style.container]: true,
+        [style.borderRadius]: borderRadius,
+      })}
       style={backgroundColorStyle}
     >
       {!noStatusIcon && (

--- a/src/modules/situations/situation-or-notice-icon.tsx
+++ b/src/modules/situations/situation-or-notice-icon.tsx
@@ -7,12 +7,14 @@ type SituationOrNoticeIconProps = {
   accessibilityLabel?: string;
   notices?: Notice[];
   cancellation?: boolean;
+  className?: string;
 } & ({ situations: Situation[] } | { situation: Situation });
 
 export const SituationOrNoticeIcon = ({
   accessibilityLabel,
   notices,
   cancellation,
+  className,
   ...props
 }: SituationOrNoticeIconProps) => {
   const situations =
@@ -26,5 +28,7 @@ export const SituationOrNoticeIcon = ({
   );
   if (!icon) return null;
 
-  return <ColorIcon icon={icon} alt={accessibilityLabel} />;
+  return (
+    <ColorIcon className={className} icon={icon} alt={accessibilityLabel} />
+  );
 };

--- a/src/modules/situations/situation.module.css
+++ b/src/modules/situations/situation.module.css
@@ -1,6 +1,8 @@
 .container {
   display: flex;
   padding: var(--spacings-medium);
+}
+.borderRadius {
   border-radius: var(--border-radius-regular);
 }
 .content {

--- a/src/page-modules/departures/__tests__/departure-data.fixture.ts
+++ b/src/page-modules/departures/__tests__/departure-data.fixture.ts
@@ -15,6 +15,7 @@ export const departureDataFixture: DepartureData = {
       id: 'NSR:Quay:71184',
       publicCode: 'P1',
       description: 'ved Bunnpris',
+      situations: [],
       departures: [
         {
           id: 'ATB:ServiceJourney:71_230306097870252_7024',
@@ -24,6 +25,9 @@ export const departureDataFixture: DepartureData = {
           aimedDepartureTime: '2023-10-08T20:50:00+02:00',
           transportMode: 'bus',
           publicCode: '71',
+          cancelled: false,
+          notices: [],
+          situations: [],
         },
         {
           id: 'ATB:ServiceJourney:25_230306097862768_7070',
@@ -33,6 +37,9 @@ export const departureDataFixture: DepartureData = {
           aimedDepartureTime: '2023-10-08T20:47:00+02:00',
           transportMode: 'bus',
           publicCode: '25',
+          cancelled: false,
+          notices: [],
+          situations: [],
         },
       ],
     },
@@ -41,6 +48,7 @@ export const departureDataFixture: DepartureData = {
       id: 'NSR:Quay:71181',
       publicCode: 'P2',
       description: 'ved AtB Kundesenter',
+      situations: [],
       departures: [
         {
           id: 'ATB:ServiceJourney:10_230905147222030_7096',
@@ -50,6 +58,9 @@ export const departureDataFixture: DepartureData = {
           aimedDepartureTime: '2023-10-08T20:54:00+02:00',
           transportMode: 'bus',
           publicCode: '10',
+          cancelled: false,
+          notices: [],
+          situations: [],
         },
         {
           id: 'ATB:ServiceJourney:20_230306097869036_7048',
@@ -59,6 +70,9 @@ export const departureDataFixture: DepartureData = {
           aimedDepartureTime: '2023-10-08T20:54:00+02:00',
           transportMode: 'bus',
           publicCode: '20',
+          cancelled: false,
+          notices: [],
+          situations: [],
         },
         {
           id: 'ATB:ServiceJourney:12_230306097866716_7048',
@@ -68,6 +82,9 @@ export const departureDataFixture: DepartureData = {
           aimedDepartureTime: '2023-10-08T20:56:00+02:00',
           transportMode: 'bus',
           publicCode: '12',
+          cancelled: false,
+          notices: [],
+          situations: [],
         },
       ],
     },

--- a/src/page-modules/departures/__tests__/departure.test.tsx
+++ b/src/page-modules/departures/__tests__/departure.test.tsx
@@ -42,6 +42,7 @@ describe('departure page', function () {
           publicCode: '123',
           departures: [],
           description: null,
+          situations: [],
         },
       ],
     };

--- a/src/page-modules/departures/nearest-stop-places/index.tsx
+++ b/src/page-modules/departures/nearest-stop-places/index.tsx
@@ -11,6 +11,7 @@ import { useRouter } from 'next/router';
 import VenueIcon, { FeatureCategory } from '@atb/components/venue-icon';
 import { PageText, useTranslation } from '@atb/translations';
 import EmptySearchResults from '@atb/components/empty-search-results';
+import { SituationOrNoticeIcon } from '@atb/modules/situations';
 
 export type NearestStopPlacesProps = {
   activeLocation: GeocoderFeature | undefined;
@@ -96,11 +97,12 @@ export default function StopPlaceItem({ item }: StopPlaceItemProps) {
         </Typo.span>
       </div>
 
-      <VenueIcon
-        category={[FeatureCategory.BUS_STATION]}
-        size="large"
-        className={style.stopPlaceItem__icon}
-      />
+      <div className={style.stopPlaceItem__icon}>
+        {item.stopPlace.situations.length > 0 && (
+          <SituationOrNoticeIcon situations={item.stopPlace.situations} />
+        )}
+        <VenueIcon category={[FeatureCategory.BUS_STATION]} size="large" />
+      </div>
     </Link>
   );
 }

--- a/src/page-modules/departures/nearest-stop-places/nearest-stop-places.module.css
+++ b/src/page-modules/departures/nearest-stop-places/nearest-stop-places.module.css
@@ -36,6 +36,9 @@
 }
 .stopPlaceItem__icon {
   margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--spacings-small);
 }
 
 .secondaryText {

--- a/src/page-modules/departures/server/journey-planner/journey-gql/departures.gql
+++ b/src/page-modules/departures/server/journey-planner/journey-gql/departures.gql
@@ -1,7 +1,7 @@
 query stopPlaceQuayDepartures(
   $id: String!
   $numberOfDepartures: Int
-  $startTime: DateTime,
+  $startTime: DateTime
   $transportModes: [TransportMode]
 ) {
   stopPlace(id: $id) {
@@ -43,7 +43,24 @@ query stopPlaceQuayDepartures(
             transportMode
             transportSubmode
           }
+          journeyPattern {
+            notices {
+              ...notice
+            }
+          }
+          notices {
+            ...notice
+          }
         }
+        situations {
+          ...situation
+        }
+        notices {
+          ...notice
+        }
+      }
+      situations {
+        ...situation
       }
     }
   }

--- a/src/page-modules/departures/server/journey-planner/journey-gql/nearest-stop-places.gql
+++ b/src/page-modules/departures/server/journey-planner/journey-gql/nearest-stop-places.gql
@@ -14,7 +14,7 @@ query nearestStopPlaces(
     after: $after
     filterByInUse: true
     filterByPlaceTypes: stopPlace
-    multiModalMode: parent,
+    multiModalMode: parent
     filterByModes: $transportModes
   ) {
     pageInfo {
@@ -35,6 +35,9 @@ query nearestStopPlaces(
               publicCode
               stopPlace {
                 id
+              }
+              situations {
+                ...situation
               }
             }
             transportMode

--- a/src/page-modules/departures/server/journey-planner/validators.ts
+++ b/src/page-modules/departures/server/journey-planner/validators.ts
@@ -26,8 +26,11 @@ export const departureSchema = z.object({
   date: z.string(),
   aimedDepartureTime: z.string(),
   expectedDepartureTime: z.string(),
+  cancelled: z.boolean(),
   transportMode: transportModeSchema.optional(),
   transportSubmode: transportSubmodeSchema.optional(),
+  notices: z.array(noticeSchema),
+  situations: z.array(situationSchema),
 });
 
 export const quaySchema = z.object({
@@ -36,6 +39,7 @@ export const quaySchema = z.object({
   id: z.string(),
   description: z.string().nullable(),
   departures: z.array(departureSchema),
+  situations: z.array(situationSchema),
 });
 
 export const departureDataSchema = z.object({
@@ -44,7 +48,9 @@ export const departureDataSchema = z.object({
 });
 
 const stopPlaceWithDistance = z.object({
-  stopPlace: stopPlaceSchema,
+  stopPlace: stopPlaceSchema.extend({
+    situations: z.array(situationSchema),
+  }),
   distance: z.number(),
 });
 

--- a/src/page-modules/departures/stop-place/index.tsx
+++ b/src/page-modules/departures/stop-place/index.tsx
@@ -5,7 +5,7 @@ import {
   Departure,
 } from '@atb/page-modules/departures/server/journey-planner';
 import style from './stop-place.module.css';
-import { MonoIcon } from '@atb/components/icon';
+import { ColorIcon, MonoIcon } from '@atb/components/icon';
 import {
   formatLocaleTime,
   formatToClockOrRelativeMinutes,
@@ -22,6 +22,10 @@ import { Departures } from '@atb/translations/pages';
 import { nextDepartures } from '../client';
 import { Button } from '@atb/components/button';
 import LineChip from '@atb/components/line-chip';
+import {
+  SituationMessageBox,
+  SituationOrNoticeIcon,
+} from '@atb/modules/situations';
 
 export type StopPlaceProps = {
   departures: DepartureData;
@@ -137,6 +141,15 @@ export function EstimatedCallList({ quay }: EstimatedCallListProps) {
       </button>
       {!isCollapsed && (
         <ul>
+          {quay.situations.length > 0 &&
+            quay.situations.map((situation) => (
+              <li key={situation.id}>
+                <SituationMessageBox
+                  situation={situation}
+                  borderRadius={false}
+                />
+              </li>
+            ))}
           {departures.length > 0 ? (
             <>
               {departures.map((departure) => (
@@ -190,17 +203,33 @@ export function EstimatedCallItem({
       >
         <div className={style.transportInfo}>
           {(departure.transportMode || departure.publicCode) && (
-            <LineChip
-              transportMode={departure.transportMode || 'unknown'}
-              publicCode={departure.publicCode}
-              transportSubmode={departure.transportSubmode}
-            />
+            <>
+              {departure.cancelled ? (
+                <ColorIcon
+                  icon="status/Error"
+                  className={style.situationIcon}
+                />
+              ) : (
+                <SituationOrNoticeIcon
+                  situations={departure.situations}
+                  notices={departure.notices}
+                  className={style.situationIcon}
+                />
+              )}
+
+              <LineChip
+                transportMode={departure.transportMode || 'unknown'}
+                publicCode={departure.publicCode}
+                transportSubmode={departure.transportSubmode}
+              />
+            </>
           )}
 
           <p>{departure.name}</p>
         </div>
 
         <DepartureTime
+          cancelled={departure.cancelled}
           expectedDepartureTime={departure.expectedDepartureTime}
           aimedDepartureTime={departure.aimedDepartureTime}
         />
@@ -212,15 +241,20 @@ export function EstimatedCallItem({
 type DepartureTimeProps = {
   expectedDepartureTime: string;
   aimedDepartureTime: string;
+  cancelled?: boolean;
 };
 export function DepartureTime({
   expectedDepartureTime,
   aimedDepartureTime,
+  cancelled = false,
 }: DepartureTimeProps) {
   const { t, language } = useTranslation();
   return (
     <div className={style.departureTime}>
-      <Typo.p textType="body__primary--bold">
+      <Typo.p
+        textType="body__primary--bold"
+        className={cancelled ? style.departureTime__cancelled : ''}
+      >
         {formatToClockOrRelativeMinutes(
           expectedDepartureTime,
           language,

--- a/src/page-modules/departures/stop-place/index.tsx
+++ b/src/page-modules/departures/stop-place/index.tsx
@@ -26,6 +26,7 @@ import {
   SituationMessageBox,
   SituationOrNoticeIcon,
 } from '@atb/modules/situations';
+import { screenReaderPause } from '@atb/components/typography/utils';
 
 export type StopPlaceProps = {
   departures: DepartureData;
@@ -254,6 +255,13 @@ export function DepartureTime({
       <Typo.p
         textType="body__primary--bold"
         className={cancelled ? style.departureTime__cancelled : ''}
+        aria-label={
+          cancelled
+            ? `${screenReaderPause} ${t(
+                PageText.Departures.stopPlace.quaySection.cancelled,
+              )}`
+            : ''
+        }
       >
         {formatToClockOrRelativeMinutes(
           expectedDepartureTime,

--- a/src/page-modules/departures/stop-place/stop-place.module.css
+++ b/src/page-modules/departures/stop-place/stop-place.module.css
@@ -89,21 +89,18 @@
   display: flex;
   gap: var(--spacings-medium);
   align-items: center;
+  position: relative;
 }
-.lineChip {
-  min-width: 4.125rem;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--spacings-xSmall);
-  padding: var(--spacings-small);
-  border-radius: var(--spacings-small);
-}
-.lineChip__publicCode {
-  text-align: right;
+.situationIcon {
+  position: absolute;
+  top: calc(var(--spacings-small) * -1);
+  left: calc(var(--spacings-small) * -1);
 }
 .departureTime {
   text-align: right;
+}
+.departureTime__cancelled {
+  text-decoration: line-through;
 }
 
 @media only screen and (max-width: 650px) {

--- a/src/translations/pages/departures.ts
+++ b/src/translations/pages/departures.ts
@@ -100,6 +100,11 @@ export const Departures = {
         'See more departures',
         'Sjå fleire avgangar',
       ),
+      cancelled: _(
+        'Avgangen fra denne holdeplassen er kansellert.',
+        'The departure from this stop has been cancelled.',
+        'Avgangen frå denne haldeplassen er kansellert.',
+      ),
     },
   },
   details: {


### PR DESCRIPTION
This PR adds notices, situations and cancellations for departures. 

At the time of writing this, you can test by looking up Trondheim hovedbrannstasjon and Sluppenvegen, Trondheim. 

<details>
<summary>Screenshots</summary>

<img width="1054" alt="image" src="https://github.com/AtB-AS/planner-web/assets/43166974/a7bb3073-8151-4ffd-bcc1-db321a4bdc4c">

<img width="986" alt="image" src="https://github.com/AtB-AS/planner-web/assets/43166974/e6c9a506-6383-4239-9920-7551341e3d14">


</details>

Closes https://github.com/AtB-AS/kundevendt/issues/9150