### PR TITLE
fix: dark mode

### DIFF
--- a/src/modules/cookies/cookies-context.tsx
+++ b/src/modules/cookies/cookies-context.tsx
@@ -44,7 +44,7 @@ export function AppCookiesProvider({
   const darkmode = useCookie<boolean>(
     DARKMODE_COOKIE_NAME,
     initialCookies.darkmode ?? undefined,
-    (i) => i == true,
+    (i) => (typeof i === 'string' ? i === 'true' : i == true),
   );
 
   return (

--- a/src/modules/cookies/cookies-context.tsx
+++ b/src/modules/cookies/cookies-context.tsx
@@ -44,7 +44,7 @@ export function AppCookiesProvider({
   const darkmode = useCookie<boolean>(
     DARKMODE_COOKIE_NAME,
     initialCookies.darkmode ?? undefined,
-    (i) => (typeof i === 'string' ? i === 'true' : i == true),
+    (i) => (typeof i === 'string' ? i === 'true' : i === true),
   );
 
   return (


### PR DESCRIPTION
To be honest, I'm not sure why this is the case, but the input for this function seems to be a string resulting in `i == true` returning `false`. This is why the dark mode isn't working properly. This fixes that, but it might be a better approach to this. My best guess is that cookies are stored as strings, but then I don't see why this isn't failing in the webshop. 🤷

Fixes https://github.com/AtB-AS/kundevendt/issues/15498