### PR TITLE
fix: fix colors of transport mode filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start": "next start",
     "lint": "next lint",
     "clean-assets": "rimraf ./public/assets/",
+    "presetup": "rimraf ./next/",
     "setup": "generate-assets all $NEXT_PUBLIC_PLANNER_ORG_ID -o ./public/assets/ -ts -ts-o ./src/components/icon",
     "generate": "graphql-codegen",
     "prestart": "yarn generate",

--- a/src/modules/transport-mode/filter/filter.module.css
+++ b/src/modules/transport-mode/filter/filter.module.css
@@ -24,7 +24,7 @@
   padding: var(--spacings-xSmall) var(--spacings-medium);
   border-radius: var(--border-radius-circle);
   border: 1px solid var(--static-background-background_0-background);
-  color: var(--text-colors-primary);
+  color: var(--static-background-background_accent_0-text);
   transition: border-color 150ms, background-color 150ms;
   cursor: pointer;
   display: flex;
@@ -57,6 +57,7 @@
 .transportMode input:hover ~ label {
   background-color: var(--static-background-background_1-background);
   border-color: var(--static-background-background_1-background);
+  color: var(--static-background-background_0-text);
 }
 
 .infoText {

--- a/src/modules/transport-mode/filter/filter.module.css
+++ b/src/modules/transport-mode/filter/filter.module.css
@@ -23,8 +23,8 @@
 .transportMode label {
   padding: var(--spacings-xSmall) var(--spacings-medium);
   border-radius: var(--border-radius-circle);
-  border: 1px solid var(--interactive-interactive_1-default-text);
-  color: var(--interactive-interactive_1-default-text);
+  border: 1px solid var(--static-background-background_0-background);
+  color: var(--text-colors-primary);
   transition: border-color 150ms, background-color 150ms;
   cursor: pointer;
   display: flex;
@@ -45,21 +45,18 @@
 }
 
 .transportMode input:checked ~ label {
-  background-color: var(--interactive-interactive_0-default-background);
-  border-color: var(--interactive-interactive_0-default-background);
+  background-color: var(--static-background-background_0-background);
+  border-color: var(--static-background-background_0-background);
+  color: var(--static-background-background_0-text);
 }
 
 .transportMode input:focus-visible ~ label {
-  border-color: var(--interactive-interactive_0-outline-background);
+  border-color: var(--static-status-info-background);
 }
 
-.transportMode input:checked:hover ~ label {
-  background-color: var(--interactive-interactive_0-hover-background);
-  border-color: var(--interactive-interactive_0-hover-background);
-}
-
-.transportMode input:not(:checked):hover ~ label {
-  border-color: var(--interactive-interactive_2-hover-background);
+.transportMode input:hover ~ label {
+  background-color: var(--static-background-background_1-background);
+  border-color: var(--static-background-background_1-background);
 }
 
 .infoText {

--- a/src/modules/transport-mode/filter/filter.tsx
+++ b/src/modules/transport-mode/filter/filter.tsx
@@ -6,6 +6,7 @@ import { TransportModeFilterOption, TransportModeFilterState } from './types';
 import { Typo } from '@atb/components/typography';
 import { getTransportModeIcon } from '../icon';
 import { filterOptionsWithTransportModes, setAllValues } from './utils';
+import { useTheme } from '@atb/modules/theme';
 
 type TransportModeFilterProps = {
   filterState: TransportModeFilterState;
@@ -17,6 +18,7 @@ export default function TransportModeFilter({
   onFilterChange,
 }: TransportModeFilterProps) {
   const { t, language } = useTranslation();
+  const { isDarkMode } = useTheme();
 
   return (
     <div className={style.container}>
@@ -67,7 +69,7 @@ export default function TransportModeFilter({
                       mode: option.icon?.transportMode,
                       subMode: option.icon?.transportSubMode,
                     })}
-                    overrideMode="dark"
+                    overrideMode={selected && !isDarkMode ? 'light' : 'dark'}
                   />
                   <span id={`label-${option.id}`}>{text}</span>
                 </label>

--- a/src/modules/transport-mode/filter/filter.tsx
+++ b/src/modules/transport-mode/filter/filter.tsx
@@ -7,6 +7,8 @@ import { Typo } from '@atb/components/typography';
 import { getTransportModeIcon } from '../icon';
 import { filterOptionsWithTransportModes, setAllValues } from './utils';
 import { useTheme } from '@atb/modules/theme';
+import { TransportModeFilterOptionType } from '@atb-as/config-specs';
+import { ChangeEventHandler, useState } from 'react';
 
 type TransportModeFilterProps = {
   filterState: TransportModeFilterState;
@@ -18,7 +20,6 @@ export default function TransportModeFilter({
   onFilterChange,
 }: TransportModeFilterProps) {
   const { t, language } = useTranslation();
-  const { isDarkMode } = useTheme();
 
   return (
     <div className={style.container}>
@@ -44,36 +45,18 @@ export default function TransportModeFilter({
           const option =
             filterOptionsWithTransportModes[key as TransportModeFilterOption];
 
-          const text = getTextForLanguage(option.text, language);
-
           return (
             <li key={option.id} className={style.transportMode}>
-              <div>
-                <input
-                  type="checkbox"
-                  id={option.id}
-                  name={option.id}
-                  value={option.id}
-                  checked={selected}
-                  onChange={(event) => {
-                    onFilterChange({
-                      ...filterState,
-                      [key]: event.target.checked,
-                    });
-                  }}
-                  aria-labelledby={`label-${option.id}`}
-                />
-                <label htmlFor={option.id} aria-hidden>
-                  <MonoIcon
-                    icon={getTransportModeIcon({
-                      mode: option.icon?.transportMode,
-                      subMode: option.icon?.transportSubMode,
-                    })}
-                    overrideMode={selected && !isDarkMode ? 'light' : 'dark'}
-                  />
-                  <span id={`label-${option.id}`}>{text}</span>
-                </label>
-              </div>
+              <FilterCheckbox
+                option={option}
+                checked={selected}
+                onChange={(event) => {
+                  onFilterChange({
+                    ...filterState,
+                    [key]: event.target.checked,
+                  });
+                }}
+              />
 
               {option.description && (
                 <Typo.p textType="body__tertiary" className={style.infoText}>
@@ -84,6 +67,49 @@ export default function TransportModeFilter({
           );
         })}
       </ul>
+    </div>
+  );
+}
+
+type FilterCheckboxProps = {
+  option: TransportModeFilterOptionType;
+  checked: boolean;
+  onChange: ChangeEventHandler<HTMLInputElement>;
+};
+
+function FilterCheckbox({ option, checked, onChange }: FilterCheckboxProps) {
+  const { language } = useTranslation();
+  const { isDarkMode } = useTheme();
+  const [isHovering, setIsHovering] = useState(false);
+
+  const text = getTextForLanguage(option.text, language);
+
+  return (
+    <div
+      onMouseEnter={() => setIsHovering(true)}
+      onMouseLeave={() => setIsHovering(false)}
+    >
+      <input
+        type="checkbox"
+        id={option.id}
+        name={option.id}
+        value={option.id}
+        checked={checked}
+        onChange={onChange}
+        aria-labelledby={`label-${option.id}`}
+      />
+      <label htmlFor={option.id} aria-hidden>
+        <MonoIcon
+          icon={getTransportModeIcon({
+            mode: option.icon?.transportMode,
+            subMode: option.icon?.transportSubMode,
+          })}
+          overrideMode={
+            (checked || isHovering) && !isDarkMode ? 'light' : 'dark'
+          }
+        />
+        <span id={`label-${option.id}`}>{text}</span>
+      </label>
     </div>
   );
 }

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -184,9 +184,11 @@ function AssistantLayout({
           <Button
             title={t(PageText.Assistant.search.buttons.alternatives.title)}
             className={style.button}
-            mode={showAlternatives ? 'interactive_3' : 'interactive_2'}
+            mode="interactive_1"
             onClick={() => setShowAlternatives(!showAlternatives)}
-            icon={{ right: <MonoIcon icon="actions/Adjust" /> }}
+            icon={{
+              right: <MonoIcon icon="actions/Adjust" overrideMode="dark" />,
+            }}
           />
 
           <Button

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -184,11 +184,9 @@ function AssistantLayout({
           <Button
             title={t(PageText.Assistant.search.buttons.alternatives.title)}
             className={style.button}
-            mode="interactive_1"
+            mode="interactive_2"
             onClick={() => setShowAlternatives(!showAlternatives)}
-            icon={{
-              right: <MonoIcon icon="actions/Adjust" overrideMode="dark" />,
-            }}
+            icon={{ right: <MonoIcon icon="actions/Adjust" /> }}
           />
 
           <Button

--- a/src/page-modules/assistant/trip/trip-pattern/trip-pattern.module.css
+++ b/src/page-modules/assistant/trip/trip-pattern/trip-pattern.module.css
@@ -66,7 +66,7 @@
 .legs__lastLegLine {
   width: 0.3125rem;
   height: 0.125rem;
-  background-color: var(--text-colors-disabled);
+  background-color: var(--interactive-interactive_1-disabled-background);
   border-radius: var(--border-radius-circle);
 }
 


### PR DESCRIPTION
## New colors

Text color: `--static-background-background_accent_0-text`
Checked: Background `--static-background-background_0-background`
Unchecked: Border `--static-background-background_0-background`
Hover: Background and border `--static-background-background_1-background`
Focus: Border `--static-status-info-background`

## Button

Changed the "More alternatives" button to always mode `interactive_2`. Should revisit this button.


## FRAM Light mode

<img width="608" alt="image" src="https://github.com/AtB-AS/planner-web/assets/14045515/20b702b8-b6c7-4095-a15e-9c0c968b6969">

## FRAM Dark mode
<img width="575" alt="image" src="https://github.com/AtB-AS/planner-web/assets/14045515/2814906a-062e-4e08-bcf1-2e8848de8653">

<img width="429" alt="image" src="https://github.com/AtB-AS/planner-web/assets/14045515/f3a9938b-f0ff-40c2-8c46-a12389d28d8f">
