### PR TITLE
fix: no radius for input boxes on safari ios

### DIFF
--- a/src/components/search/search.module.css
+++ b/src/components/search/search.module.css
@@ -32,6 +32,7 @@
   padding: var(--spacings-small);
   border: none;
   width: 100%;
+  border-radius: 0;
   background-color: var(--static-background-background_0-background);
   color: var(--static-background-background_0-text);
 }


### PR DESCRIPTION
Fixes issue as shown here:

![image](https://github.com/AtB-AS/planner-web/assets/606374/6334a4cf-48d7-4aef-85d5-94436231f0ed)
