### PR TITLE
feat: show error when geolocation fails/is blocked

### DIFF
--- a/src/components/loading-empty-results/index.tsx
+++ b/src/components/loading-empty-results/index.tsx
@@ -8,11 +8,13 @@ import style from './loading-empty-results.module.css';
 
 export type LoadingEmptyResultsProps = PropsWithChildren<{
   isSearching: boolean;
+  isGeolocationError?: boolean;
   type: keyof typeof ComponentText.EmptySearch.searching;
 }>;
 
 export default function LoadingEmptyResults({
   isSearching,
+  isGeolocationError = false,
   type,
   children,
 }: LoadingEmptyResultsProps) {
@@ -27,7 +29,7 @@ export default function LoadingEmptyResults({
 
   return (
     <>
-      {!isSearching && hasEmptyChild && (
+      {!isSearching && !isGeolocationError && hasEmptyChild && (
         <EmptyMessage
           title={t(ComponentText.EmptySearch.notSearched)}
           details={t(ComponentText.EmptySearch.emptyDetails[type])}
@@ -45,6 +47,12 @@ export default function LoadingEmptyResults({
             {t(ComponentText.EmptySearch.searching[type])}
           </Typo.p>
         </motion.div>
+      )}
+      {!isSearching && isGeolocationError && hasEmptyChild && (
+        <EmptyMessage
+          title={t(ComponentText.EmptySearch.nearbyNoGeolocation.title)}
+          details={t(ComponentText.EmptySearch.nearbyNoGeolocation.details)}
+        />
       )}
       {!isSearching && !hasEmptyChild && children}
     </>

--- a/src/components/message-box/index.tsx
+++ b/src/components/message-box/index.tsx
@@ -1,0 +1,69 @@
+import { useTranslation } from '@atb/translations';
+import { Theme } from '@atb-as/theme';
+import { useTheme } from '@atb/modules/theme';
+import { andIf } from '@atb/utils/css';
+import { MonoIcon } from '@atb/components/icon';
+import { messageTypeToMonoIcon } from '@atb/modules/situations';
+import { Button } from '@atb/components/button';
+import dictionary from '@atb/translations/dictionary';
+import { Typo } from '@atb/components/typography';
+
+import style from './message-box.module.css';
+
+export type MessageBoxProps = {
+  type: keyof Theme['static']['status'];
+  title?: string;
+  message: string;
+  noStatusIcon?: boolean;
+  onClick?: () => void;
+  borderRadius?: boolean;
+};
+
+export const MessageBox = ({
+  noStatusIcon,
+  type,
+  message,
+  title,
+  onClick,
+  borderRadius = true,
+}: MessageBoxProps) => {
+  const { static: staticColors } = useTheme();
+  const { t } = useTranslation();
+  const backgroundColorStyle = {
+    backgroundColor: staticColors['status'][type].background,
+    color: staticColors['status'][type].text,
+  };
+
+  return (
+    <div
+      className={andIf({
+        [style.container]: true,
+        [style.borderRadius]: borderRadius,
+      })}
+      style={backgroundColorStyle}
+    >
+      {!noStatusIcon && (
+        <MonoIcon className={style.icon} icon={messageTypeToMonoIcon(type)} />
+      )}
+      <div className={style.content}>
+        {title && (
+          <Typo.h2 className={style.title} textType="body__primary--bold">
+            {title}
+          </Typo.h2>
+        )}
+        <Typo.p className={style.body} textType="body__primary">
+          {message}
+        </Typo.p>
+        {onClick && (
+          <Button
+            mode="transparent--underline"
+            onClick={() => onClick()}
+            title={t(dictionary.readMore)}
+            className={style.messageBox__button}
+            size="compact"
+          />
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/components/message-box/message-box.module.css
+++ b/src/components/message-box/message-box.module.css
@@ -1,0 +1,25 @@
+.container {
+  display: flex;
+  padding: var(--spacings-medium);
+}
+.borderRadius {
+  border-radius: var(--border-radius-regular);
+}
+.content {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+.title {
+  margin-bottom: var(--spacings-small);
+  padding: var(--spacings-small);
+}
+.body {
+  padding: var(--spacings-small);
+}
+.messageBox__button {
+  padding: var(--spacings-small);
+}
+.icon {
+  margin-top: var(--spacings-small);
+}

--- a/src/components/search/geolocation-button/index.tsx
+++ b/src/components/search/geolocation-button/index.tsx
@@ -2,16 +2,31 @@ import { Component, useEffect, useState } from 'react';
 import { LoadingIcon } from '@atb/components/loading';
 import { reverse } from '@atb/page-modules/departures/client';
 import { GeocoderFeature } from '@atb/page-modules/departures';
-import { ComponentText, useTranslation } from '@atb/translations';
+import {
+  ComponentText,
+  TranslateFunction,
+  useTranslation,
+} from '@atb/translations';
 import { MonoIcon } from '@atb/components/icon';
 
 type GeolocationButtonProps = {
   onGeolocate: (feature: GeocoderFeature) => void;
+  onError?: (error: string | null) => void;
   className?: string;
 };
-function GeolocationButton({ onGeolocate, className }: GeolocationButtonProps) {
+function GeolocationButton({
+  onGeolocate,
+  onError,
+  className,
+}: GeolocationButtonProps) {
   const { t } = useTranslation();
-  const { getPosition, isLoading, isUnavailable } = useGeolocation(onGeolocate);
+  const { getPosition, isLoading, isUnavailable, error } =
+    useGeolocation(onGeolocate);
+
+  useEffect(() => {
+    if (error) onError?.(getErrorMessage(error.code, t));
+    else onError?.(null);
+  }, [error, onError, t]);
 
   if (isUnavailable) return null;
 
@@ -70,3 +85,15 @@ function useGeolocation(onSuccess: (feature: GeocoderFeature) => void) {
 }
 
 export default GeolocationButton;
+
+function getErrorMessage(code: number, t: TranslateFunction) {
+  switch (code) {
+    case GeolocationPositionError.PERMISSION_DENIED:
+      return t(ComponentText.GeolocationButton.error.denied);
+    case GeolocationPositionError.TIMEOUT:
+      return t(ComponentText.GeolocationButton.error.timeout);
+    case GeolocationPositionError.POSITION_UNAVAILABLE:
+    default:
+      return t(ComponentText.GeolocationButton.error.unavailable);
+  }
+}

--- a/src/components/search/geolocation-button/index.tsx
+++ b/src/components/search/geolocation-button/index.tsx
@@ -20,13 +20,10 @@ function GeolocationButton({
   className,
 }: GeolocationButtonProps) {
   const { t } = useTranslation();
-  const { getPosition, isLoading, isUnavailable, error } =
-    useGeolocation(onGeolocate);
-
-  useEffect(() => {
-    if (error) onError?.(getErrorMessage(error.code, t));
-    else onError?.(null);
-  }, [error, onError, t]);
+  const { getPosition, isLoading, isUnavailable } = useGeolocation(
+    onGeolocate,
+    onError,
+  );
 
   if (isUnavailable) return null;
 
@@ -47,7 +44,11 @@ function GeolocationButton({
   );
 }
 
-function useGeolocation(onSuccess: (feature: GeocoderFeature) => void) {
+function useGeolocation(
+  onSuccess: (feature: GeocoderFeature) => void,
+  onError: (error: string | null) => void = () => {},
+) {
+  const { t } = useTranslation();
   const [error, setError] = useState<GeolocationPositionError | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [isUnavailable, setIsUnavailable] = useState(false);
@@ -69,6 +70,7 @@ function useGeolocation(onSuccess: (feature: GeocoderFeature) => void) {
         setIsLoading(false);
       },
       (error) => {
+        onError?.(getErrorMessage(error.code, t));
         setError(error);
         setIsLoading(false);
       },

--- a/src/modules/situations/index.ts
+++ b/src/modules/situations/index.ts
@@ -1,4 +1,4 @@
 export { SituationOrNoticeIcon } from './situation-or-notice-icon';
-export { SituationMessageBox, MessageBox } from './situation-message-box';
+export { SituationMessageBox } from './situation-message-box';
 export * from './types';
 export * from './utils';

--- a/src/modules/situations/situation-message-box.tsx
+++ b/src/modules/situations/situation-message-box.tsx
@@ -1,23 +1,20 @@
-import { Theme } from '@atb-as/theme';
 import {
   getMessageTypeForSituation,
   getSituationSummary,
   messageTypeToColorIcon,
-  messageTypeToMonoIcon,
   validateEndTime,
 } from './utils';
 import { ColorIcon, MonoIcon } from '@atb/components/icon';
 import { Typo } from '@atb/components/typography';
 import { Situation } from './types';
 import { useTranslation, getTextForLanguage } from '@atb/translations';
-import { useTheme } from '@atb/modules/theme';
 import style from './situation.module.css';
 import { Button } from '@atb/components/button';
 import { useRef } from 'react';
 import dictionary from '@atb/translations/dictionary';
 import { Situation as SituationTexts } from '@atb/translations/modules';
 import { formatToLongDateTime } from '@atb/utils/date';
-import { andIf } from '@atb/utils/css';
+import { MessageBox, MessageBoxProps } from '@atb/components/message-box';
 
 export type Props = {
   situation: Situation;
@@ -86,64 +83,6 @@ export const SituationMessageBox = ({
         onClick={() => dialogRef.current?.showModal()}
       />
     </>
-  );
-};
-
-export type MessageBoxProps = {
-  type: keyof Theme['static']['status'];
-  title?: string;
-  message: string;
-  noStatusIcon?: boolean;
-  onClick?: () => void;
-  borderRadius?: boolean;
-};
-
-export const MessageBox = ({
-  noStatusIcon,
-  type,
-  message,
-  title,
-  onClick,
-  borderRadius = true,
-}: MessageBoxProps) => {
-  const { static: staticColors } = useTheme();
-  const { t } = useTranslation();
-  const backgroundColorStyle = {
-    backgroundColor: staticColors['status'][type].background,
-    color: staticColors['status'][type].text,
-  };
-
-  return (
-    <div
-      className={andIf({
-        [style.container]: true,
-        [style.borderRadius]: borderRadius,
-      })}
-      style={backgroundColorStyle}
-    >
-      {!noStatusIcon && (
-        <MonoIcon className={style.icon} icon={messageTypeToMonoIcon(type)} />
-      )}
-      <div className={style.content}>
-        {title && (
-          <Typo.h2 className={style.title} textType="body__primary--bold">
-            {title}
-          </Typo.h2>
-        )}
-        <Typo.p className={style.body} textType="body__primary">
-          {message}
-        </Typo.p>
-        {onClick && (
-          <Button
-            mode="transparent--underline"
-            onClick={() => onClick()}
-            title={t(dictionary.readMore)}
-            className={style.messageBox__button}
-            size="compact"
-          />
-        )}
-      </div>
-    </div>
   );
 };
 

--- a/src/modules/situations/situation.module.css
+++ b/src/modules/situations/situation.module.css
@@ -1,30 +1,5 @@
-.container {
-  display: flex;
-  padding: var(--spacings-medium);
-}
-.borderRadius {
-  border-radius: var(--border-radius-regular);
-}
-.content {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-}
 .linkText {
   margin-top: var(--spacings-medium);
-}
-.title {
-  margin-bottom: var(--spacings-small);
-  padding: var(--spacings-small);
-}
-.body {
-  padding: var(--spacings-small);
-}
-.messageBox__button {
-  padding: var(--spacings-small);
-}
-.icon {
-  margin-top: var(--spacings-small);
 }
 
 .dialog {

--- a/src/page-modules/assistant/assistant.module.css
+++ b/src/page-modules/assistant/assistant.module.css
@@ -130,12 +130,6 @@
   gap: var(--spacings-medium);
 }
 
-.geolocationError {
-  background-color: var(--static-status-warning-background);
-  color: var(--static-status-warning-text);
-  padding: var(--spacings-medium);
+.spanColumns {
   grid-column: 1 / -1;
-  border-radius: var(--border-radius-regular);
-  display: flex;
-  gap: var(--spacings-small);
 }

--- a/src/page-modules/assistant/assistant.module.css
+++ b/src/page-modules/assistant/assistant.module.css
@@ -129,3 +129,13 @@
   flex-wrap: wrap;
   gap: var(--spacings-medium);
 }
+
+.geolocationError {
+  background-color: var(--static-status-warning-background);
+  color: var(--static-status-warning-text);
+  padding: var(--spacings-medium);
+  grid-column: 1 / -1;
+  border-radius: var(--border-radius-regular);
+  display: flex;
+  gap: var(--spacings-small);
+}

--- a/src/page-modules/assistant/assistant.module.css
+++ b/src/page-modules/assistant/assistant.module.css
@@ -65,8 +65,7 @@
   width: 100%;
   max-width: var(--maxPageWidth);
   margin: 0 auto;
-  padding: 0 var(--spacings-xLarge) var(--spacings-xLarge)
-    var(--spacings-xLarge);
+  padding: 0 var(--spacings-xLarge) var(--spacings-xLarge) var(--spacings-xLarge);
   z-index: 10;
   position: absolute;
   left: 0;

--- a/src/page-modules/assistant/details/trip-section/index.tsx
+++ b/src/page-modules/assistant/details/trip-section/index.tsx
@@ -12,7 +12,7 @@ import {
 import { Typo } from '@atb/components/typography';
 import WalkSection from './walk-section';
 import { ColorIcon } from '@atb/components/icon';
-import { MessageBox } from '@atb/modules/situations';
+import { MessageBox } from '@atb/components/message-box';
 import { PageText, useTranslation } from '@atb/translations';
 import { InterchangeDetails, InterchangeSection } from './interchange-section';
 import { formatLineName, getPlaceName } from '../utils';

--- a/src/page-modules/assistant/details/trip-section/interchange-section.tsx
+++ b/src/page-modules/assistant/details/trip-section/interchange-section.tsx
@@ -1,7 +1,7 @@
 import { useTransportationThemeColor } from '@atb/modules/transport-mode';
 import { DecorationLine, TripRow } from '@atb/modules/trip-details';
 import { MonoIcon } from '@atb/components/icon';
-import { MessageBox } from '@atb/modules/situations';
+import { MessageBox } from '@atb/components/message-box';
 import { TripPatternWithDetails } from '../../server/journey-planner/validators';
 import { getPlaceName } from '../utils';
 import { PageText, useTranslation } from '@atb/translations';

--- a/src/page-modules/assistant/details/trip-section/wait-section.tsx
+++ b/src/page-modules/assistant/details/trip-section/wait-section.tsx
@@ -5,7 +5,7 @@ import { PageText, useTranslation } from '@atb/translations';
 import { secondsBetween, secondsToDuration } from '@atb/utils/date';
 import style from './trip-section.module.css';
 import { ColorIcon, MonoIcon } from '@atb/components/icon';
-import { MessageBox } from '@atb/modules/situations';
+import { MessageBox } from '@atb/components/message-box';
 import { TripPatternWithDetails } from '../../server/journey-planner/validators';
 
 // Set number of seconds required before showing waiting indicator

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -204,7 +204,11 @@ function AssistantLayout({
       </form>
 
       <section className={style.contentContainer}>
-        <EmptySearch isSearching={isSearching} type="trip">
+        <EmptySearch
+          isSearching={isSearching}
+          isGeolocationError={geolocationError !== null}
+          type="trip"
+        >
           {children}
         </EmptySearch>
       </section>

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -51,6 +51,7 @@ function AssistantLayout({
   );
   const [isSwapping, setIsSwapping] = useState(false);
   const [isSearching, setIsSearching] = useState(false);
+  const [geolocationError, setGeolocationError] = useState<string | null>(null);
 
   const onSwap = async () => {
     if (!selectedToFeature || !selectedFromFeature) return;
@@ -108,6 +109,7 @@ function AssistantLayout({
                 <GeolocationButton
                   className={style.searchInputButton}
                   onGeolocate={setSelectedFromFeature}
+                  onError={setGeolocationError}
                 />
               }
             />
@@ -136,6 +138,13 @@ function AssistantLayout({
               onChange={setSearchTime}
             />
           </div>
+
+          {geolocationError !== null && (
+            <div className={style.geolocationError}>
+              <MonoIcon icon="status/Info" />
+              <Typo.p textType="body__primary">{geolocationError}</Typo.p>
+            </div>
+          )}
         </motion.div>
 
         <AnimatePresence initial={false}>

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -18,6 +18,7 @@ import { useRouter } from 'next/router';
 import { FormEventHandler, PropsWithChildren, useState } from 'react';
 import style from './assistant.module.css';
 import { createTripQuery } from './utils';
+import { MessageBox } from '@atb/components/message-box';
 
 export type AssistantLayoutProps = PropsWithChildren<{
   initialFromFeature?: GeocoderFeature;
@@ -140,10 +141,7 @@ function AssistantLayout({
           </div>
 
           {geolocationError !== null && (
-            <div className={style.geolocationError}>
-              <MonoIcon icon="status/Info" />
-              <Typo.p textType="body__primary">{geolocationError}</Typo.p>
-            </div>
+            <MessageBox type="warning" message={geolocationError} />
           )}
         </motion.div>
 

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -141,7 +141,9 @@ function AssistantLayout({
           </div>
 
           {geolocationError !== null && (
-            <MessageBox type="warning" message={geolocationError} />
+            <div className={style.spanColumns}>
+              <MessageBox type="warning" message={geolocationError} />
+            </div>
           )}
         </motion.div>
 

--- a/src/page-modules/departures/departures.module.css
+++ b/src/page-modules/departures/departures.module.css
@@ -44,6 +44,16 @@
   align-items: center;
 }
 
+.geolocationError {
+  background-color: var(--static-status-warning-background);
+  color: var(--static-status-warning-text);
+  padding: var(--spacings-medium);
+  grid-column: 1 / -1;
+  border-radius: var(--border-radius-regular);
+  display: flex;
+  gap: var(--spacings-small);
+}
+
 .alternativesWrapper {
   grid-area: alternatives;
   overflow: hidden;
@@ -67,8 +77,7 @@
   width: 100%;
   max-width: var(--maxPageWidth);
   margin: 0 auto;
-  padding: 0 var(--spacings-xLarge) var(--spacings-xLarge)
-    var(--spacings-xLarge);
+  padding: 0 var(--spacings-xLarge) var(--spacings-xLarge) var(--spacings-xLarge);
   z-index: 10;
   position: absolute;
   left: 0;

--- a/src/page-modules/departures/departures.module.css
+++ b/src/page-modules/departures/departures.module.css
@@ -44,14 +44,8 @@
   align-items: center;
 }
 
-.geolocationError {
-  background-color: var(--static-status-warning-background);
-  color: var(--static-status-warning-text);
-  padding: var(--spacings-medium);
+.spanColumns {
   grid-column: 1 / -1;
-  border-radius: var(--border-radius-regular);
-  display: flex;
-  gap: var(--spacings-small);
 }
 
 .alternativesWrapper {

--- a/src/page-modules/departures/details/index.tsx
+++ b/src/page-modules/departures/details/index.tsx
@@ -8,12 +8,9 @@ import { ServiceJourneyData } from '../server/journey-planner/validators';
 import { EstimatedCallRows } from './estimated-call-rows';
 import { PageText, useTranslation } from '@atb/translations';
 import { Map } from '@atb/components/map';
-import {
-  MessageBox,
-  SituationMessageBox,
-  filterNotices,
-} from '@atb/modules/situations';
+import { SituationMessageBox, filterNotices } from '@atb/modules/situations';
 import { useRealtimeText } from '@atb/modules/trip-details';
+import { MessageBox } from '@atb/components/message-box';
 
 export type DeparturesDetailsProps = {
   fromQuayId?: string;

--- a/src/page-modules/departures/layout.tsx
+++ b/src/page-modules/departures/layout.tsx
@@ -50,6 +50,7 @@ function DeparturesLayout({
     getInitialTransportModeFilter(initialTransportModesFilter),
   );
   const [isSearching, setIsSearching] = useState(false);
+  const [geolocationError, setGeolocationError] = useState<string | null>(null);
 
   const onSubmitHandler: FormEventHandler<HTMLFormElement> = async (e) => {
     e.preventDefault();
@@ -112,6 +113,7 @@ function DeparturesLayout({
                 <GeolocationButton
                   className={style.geolocationButton}
                   onGeolocate={setSelectedFeature}
+                  onError={setGeolocationError}
                 />
               }
             />
@@ -128,6 +130,13 @@ function DeparturesLayout({
               options={['now', 'departBy']}
             />
           </div>
+
+          {geolocationError !== null && (
+            <div className={style.geolocationError}>
+              <MonoIcon icon="status/Info" />
+              <Typo.p textType="body__primary">{geolocationError}</Typo.p>
+            </div>
+          )}
         </motion.div>
 
         <AnimatePresence initial={false}>

--- a/src/page-modules/departures/layout.tsx
+++ b/src/page-modules/departures/layout.tsx
@@ -197,6 +197,7 @@ function DeparturesLayout({
       <section className={style.contentContainer}>
         <LoadingEmptySearch
           isSearching={isSearching}
+          isGeolocationError={geolocationError !== null}
           type={selectedFeature?.layer === 'venue' ? 'stopPlace' : 'nearby'}
         >
           {children}

--- a/src/page-modules/departures/layout.tsx
+++ b/src/page-modules/departures/layout.tsx
@@ -23,6 +23,7 @@ import { useRouter } from 'next/router';
 import { ParsedUrlQueryInput } from 'node:querystring';
 import { FormEventHandler, PropsWithChildren, useState } from 'react';
 import style from './departures.module.css';
+import { MessageBox } from '@atb/components/message-box';
 
 export type DeparturesLayoutProps = PropsWithChildren<{
   initialTransportModesFilter?: TransportModeFilterOption[] | null;
@@ -132,10 +133,7 @@ function DeparturesLayout({
           </div>
 
           {geolocationError !== null && (
-            <div className={style.geolocationError}>
-              <MonoIcon icon="status/Info" />
-              <Typo.p textType="body__primary">{geolocationError}</Typo.p>
-            </div>
+            <MessageBox type="warning" message={geolocationError} />
           )}
         </motion.div>
 

--- a/src/page-modules/departures/layout.tsx
+++ b/src/page-modules/departures/layout.tsx
@@ -133,7 +133,9 @@ function DeparturesLayout({
           </div>
 
           {geolocationError !== null && (
-            <MessageBox type="warning" message={geolocationError} />
+            <div className={style.spanColumns}>
+              <MessageBox type="warning" message={geolocationError} />
+            </div>
           )}
         </motion.div>
 

--- a/src/translations/components/empty-search.ts
+++ b/src/translations/components/empty-search.ts
@@ -41,4 +41,16 @@ export const EmptySearch = {
       'Lastar avgangar...',
     ),
   },
+  nearbyNoGeolocation: {
+    title: _(
+      'Holdeplasser i nærheten er ikke tilgjengelig',
+      'Stop places nearby are not available',
+      'Haldeplassar i nærleiken er ikkje tilgjengeleg',
+    ),
+    details: _(
+      'Del din posisjon for å finne holdeplasser i nærheten. Bruk søkefeltet for å finne andre holdeplasser.',
+      'Share your position to find stop places nearby. Use the search field to find other stop places.',
+      'Del din posisjon for å finne haldeplassar i nærleiken. Bruk søkefeltet for å finne andre haldeplassar.',
+    ),
+  },
 };

--- a/src/translations/components/geolocation-button.ts
+++ b/src/translations/components/geolocation-button.ts
@@ -2,4 +2,21 @@ import { translation as _ } from '@atb/translations/commons';
 
 export const GeolocationButton = {
   alt: _('Finn min posisjon', 'Find my position', 'Finn min posisjon'),
+  error: {
+    denied: _(
+      'Du må endre stedsinnstillinger i nettleseren din for å bruke din posisjon i reisesøket.',
+      'You need to change your browser settings to use your position in the journey planner.',
+      'Du må endre stadsinnstillingar i nettlesaren din for å bruke din posisjon i reisesøket.',
+    ),
+    unavailable: _(
+      'Posisjonen din er ikke tilgjengelig.',
+      'Your position is not available.',
+      'Posisjonen din er ikkje tilgjengeleg.',
+    ),
+    timeout: _(
+      'Det tok for lang tid å hente posisjonen din. Prøv på nytt.',
+      'It took too long to get your position. Please try again.',
+      'Det tok for lang tid å hente posisjonen din. Prøv på nytt.',
+    ),
+  },
 };


### PR DESCRIPTION
This PR introduces a new feature that improves the user experience by showing an informative error message whenever geolocation services fail or are blocked. It enhances the app's transparency about its operations and guides users to resolve location-based issues.

With this update, we can avoid confusion, assure the user about the application's functionality and increase overall reliability. 

<details><summary>Screenshot</summary>
<p>

<img width="1008" alt="image" src="https://github.com/AtB-AS/planner-web/assets/14045515/f56f6499-54b3-49b1-8364-54b08a71db0b">


</p>
</details> 

Fixes https://github.com/AtB-AS/kundevendt/issues/15347