### PR TITLE
feat: single trip query

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "haversine-distance": "^1.2.1",
     "humanize-duration": "^3.30.0",
     "lodash": "^4.17.21",
+    "lz-string": "^1.5.0",
     "mapbox-gl": "^2.15.0",
     "next": "13.4.19",
     "next-router-mock": "^0.9.10",

--- a/src/page-modules/assistant/__tests__/assistant.test.tsx
+++ b/src/page-modules/assistant/__tests__/assistant.test.tsx
@@ -45,6 +45,9 @@ describe('assistant page', function () {
         if (layers === 'address') return fromFeature;
         else return toFeature;
       },
+      async singleTrip() {
+        return {} as any;
+      },
       client: null as any,
     };
 

--- a/src/page-modules/assistant/details/details.module.css
+++ b/src/page-modules/assistant/details/details.module.css
@@ -1,0 +1,39 @@
+.container {
+  margin: 0 auto;
+  max-width: var(--maxPageWidth);
+  padding: var(--spacings-xLarge);
+
+  display: grid;
+  grid-template-columns: 2fr 3fr;
+  grid-template-areas:
+    'header header'
+    'trip map';
+  gap: var(--spacings-large);
+}
+@media (max-width: 650px) {
+  .container {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      'header'
+      'trip'
+      'map';
+  }
+}
+.headerContainer {
+  grid-area: header;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacings-large);
+}
+.mapContainer {
+  grid-area: map;
+  max-height: 37.5rem;
+  width: 100%;
+  margin: 0 auto;
+}
+.tripContainer {
+  grid-area: trip;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacings-medium);
+}

--- a/src/page-modules/assistant/details/index.tsx
+++ b/src/page-modules/assistant/details/index.tsx
@@ -23,7 +23,7 @@ export function AssistantDetails({ tripPattern }: AssistantDetailsProps) {
           onClick={(e) => {
             e.preventDefault();
             history.back();
-          }
+          }}
           title={t(PageText.Assistant.details.header.backLink)}
           icon={{ left: <MonoIcon icon="navigation/ArrowLeft" /> }}
         />

--- a/src/page-modules/assistant/details/index.tsx
+++ b/src/page-modules/assistant/details/index.tsx
@@ -19,7 +19,11 @@ export function AssistantDetails({ tripPattern }: AssistantDetailsProps) {
       <div className={style.headerContainer}>
         <ButtonLink
           mode="transparent"
-          href="/assistant" // @TODO: Use correct href.
+          href="/assistant"
+          onClick={(e) => {
+            e.preventDefault();
+            history.back();
+          }
           title={t(PageText.Assistant.details.header.backLink)}
           icon={{ left: <MonoIcon icon="navigation/ArrowLeft" /> }}
         />

--- a/src/page-modules/assistant/details/index.tsx
+++ b/src/page-modules/assistant/details/index.tsx
@@ -1,0 +1,39 @@
+import { ButtonLink } from '@atb/components/button';
+import { TripPatternWithDetails } from '../server/journey-planner/validators';
+import { PageText, useTranslation } from '@atb/translations';
+import { MonoIcon } from '@atb/components/icon';
+import { Typo } from '@atb/components/typography';
+
+import style from './details.module.css';
+
+export type AssistantDetailsProps = {
+  tripPattern: TripPatternWithDetails;
+};
+
+export function AssistantDetails({ tripPattern }: AssistantDetailsProps) {
+  const { t } = useTranslation();
+  const fromName = tripPattern.legs[0].fromPlace.name;
+  const toName = tripPattern.legs[tripPattern.legs.length - 1].toPlace.name;
+  return (
+    <div className={style.container}>
+      <div className={style.headerContainer}>
+        <ButtonLink
+          mode="transparent"
+          href="/assistant" // @TODO: Use correct href.
+          title={t(PageText.Assistant.details.header.backLink)}
+          icon={{ left: <MonoIcon icon="navigation/ArrowLeft" /> }}
+        />
+        <Typo.h2 textType="heading--big">
+          {fromName && toName
+            ? t(
+                PageText.Assistant.details.header.titleFromTo({
+                  fromName,
+                  toName,
+                }),
+              )
+            : t(PageText.Assistant.details.header.title)}
+        </Typo.h2>
+      </div>
+    </div>
+  );
+}

--- a/src/page-modules/assistant/server/journey-planner/journey-gql/trip-with-details.gql
+++ b/src/page-modules/assistant/server/journey-planner/journey-gql/trip-with-details.gql
@@ -1,0 +1,44 @@
+query TripsWithDetails(
+  $from: Location!
+  $to: Location!
+  $arriveBy: Boolean!
+  $when: DateTime
+  $cursor: String
+  $transferPenalty: Int
+  $waitReluctance: Float
+  $walkReluctance: Float
+  $walkSpeed: Float
+  $modes: Modes
+  $numTripPatterns: Int
+) {
+  trip(
+    from: $from
+    to: $to
+    dateTime: $when
+    arriveBy: $arriveBy
+    pageCursor: $cursor
+    transferPenalty: $transferPenalty
+    waitReluctance: $waitReluctance
+    walkReluctance: $walkReluctance
+    walkSpeed: $walkSpeed
+    modes: $modes
+    numTripPatterns: $numTripPatterns
+    searchWindow: 60 # 1 hour
+  ) {
+    tripPatterns {
+      expectedStartTime
+      expectedEndTime
+      legs {
+        fromPlace {
+          name
+        }
+        toPlace {
+          name
+        }
+        serviceJourney {
+          id
+        }
+      }
+    }
+  }
+}

--- a/src/page-modules/assistant/server/journey-planner/validators.ts
+++ b/src/page-modules/assistant/server/journey-planner/validators.ts
@@ -63,6 +63,7 @@ export const tripPatternSchema = z.object({
   duration: z.number(),
   walkDistance: z.number(),
   legs: z.array(legSchema),
+  compressedQuery: z.string(),
 });
 
 export const tripSchema = z.object({
@@ -77,8 +78,29 @@ export const nonTransitSchema = z.object({
   duration: z.number(),
 });
 
+export const tripPatternWithDetailsSchema = z.object({
+  expectedStartTime: z.string(),
+  expectedEndTime: z.string(),
+  legs: z.array(
+    z.object({
+      fromPlace: z.object({
+        name: z.string(),
+      }),
+      toPlace: z.object({
+        name: z.string(),
+      }),
+      serviceJourney: z.object({
+        id: z.string().nullable(),
+      }),
+    }),
+  ),
+});
+
 export type TripData = z.infer<typeof tripSchema>;
 export type NonTransitData = z.infer<typeof nonTransitSchema>;
 export type TripPattern = z.infer<typeof tripPatternSchema>;
 export type Leg = z.infer<typeof legSchema>;
 export type Quay = z.infer<typeof quaySchema>;
+export type TripPatternWithDetails = z.infer<
+  typeof tripPatternWithDetailsSchema
+>;

--- a/src/page-modules/assistant/trip/trip-pattern/__tests__/trip-pattern.fixture.ts
+++ b/src/page-modules/assistant/trip/trip-pattern/__tests__/trip-pattern.fixture.ts
@@ -42,4 +42,5 @@ export const tripPatternFixture: TripPattern = {
       },
     },
   ],
+  compressedQuery: 'H4sIAAAAAAAA',
 };

--- a/src/page-modules/assistant/trip/trip-pattern/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/index.tsx
@@ -53,7 +53,7 @@ export default function TripPattern({
 
   return (
     <motion.a
-      href={`/assistant/${tripPattern.compressedQuery}`} // TODO: Use correct href.
+      href={`/assistant/${tripPattern.compressedQuery}`}
       className={style.tripPattern}
       initial={{ opacity: 0, x: -10 }}
       animate={{ opacity: 1, x: 0 }}

--- a/src/page-modules/assistant/trip/trip-pattern/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/index.tsx
@@ -53,7 +53,7 @@ export default function TripPattern({
 
   return (
     <motion.a
-      href="#" // TODO: Use correct href.
+      href={`/assistant/${tripPattern.compressedQuery}`} // TODO: Use correct href.
       className={style.tripPattern}
       initial={{ opacity: 0, x: -10 }}
       animate={{ opacity: 1, x: 0 }}

--- a/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/__tests__/trip-pattern.fixture.ts
+++ b/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/__tests__/trip-pattern.fixture.ts
@@ -42,4 +42,5 @@ export const tripPatternFixture: TripPattern = {
       },
     },
   ],
+  compressedQuery: 'H4sIAAAAAAAA',
 };

--- a/src/pages/assistant/[id].tsx
+++ b/src/pages/assistant/[id].tsx
@@ -1,0 +1,73 @@
+import DefaultLayout from '@atb/layouts/default';
+import type { WithGlobalData } from '@atb/layouts/global-data';
+import { withGlobalData } from '@atb/layouts/global-data';
+import { NextPage } from 'next';
+import { withAssistantClient } from '@atb/page-modules/assistant/server';
+import {
+  AssistantDetails,
+  AssistantDetailsProps,
+} from '@atb/page-modules/assistant/details';
+import { PageText, useTranslation } from '@atb/translations';
+import EmptyMessage from '@atb/components/empty-message';
+
+type AssistantDetailsRoutingProps =
+  | AssistantDetailsProps
+  | {
+      empty: true;
+    };
+
+function AssistantDetailsRouting(props: AssistantDetailsRoutingProps) {
+  const { t } = useTranslation();
+  if (isAssistantDetailsProps(props)) {
+    return <AssistantDetails {...props} />;
+  }
+
+  return (
+    <EmptyMessage
+      title={t(PageText.Assistant.details.errorDefault)}
+      details={t(PageText.Assistant.details.errorDefault)}
+    />
+  );
+}
+
+function isAssistantDetailsProps(a: any): a is AssistantDetailsProps {
+  return a && a.tripPattern;
+}
+
+export type AssistantDetailsPageProps =
+  WithGlobalData<AssistantDetailsRoutingProps>;
+const AssistantDetailsPage: NextPage<AssistantDetailsPageProps> = (props) => {
+  return (
+    <DefaultLayout {...props}>
+      <AssistantDetailsRouting {...props} />
+    </DefaultLayout>
+  );
+};
+
+export default AssistantDetailsPage;
+
+export const getServerSideProps = withGlobalData(
+  withAssistantClient<
+    AssistantDetailsRoutingProps,
+    { id: string[] | undefined }
+  >(async function ({ client, params }) {
+    if (!params?.id) {
+      return {
+        props: { empty: true },
+      };
+    }
+
+    const id = params.id.toString();
+    const tripPattern = await client.singleTrip(id);
+
+    if (!tripPattern) {
+      return {
+        props: { empty: true },
+      };
+    }
+
+    return {
+      props: { tripPattern },
+    };
+  }),
+);

--- a/src/translations/pages/assistant.ts
+++ b/src/translations/pages/assistant.ts
@@ -296,4 +296,31 @@ export const Assistant = {
       ),
     },
   },
+  details: {
+    errorDefault: _(
+      'Vi kunne ikke oppdatere reiseforslaget ditt. Det kan hende reisen har endra seg eller er utdatert?',
+      'We could not update your trip plan. Perhaps your trip has changed or timed out?',
+      'Vi kunne ikkje oppdatere reiseforslaget ditt. Det kan hende reisa har endra seg eller er utdatert.',
+    ),
+    header: {
+      backLink: _(
+        'Tilbake til avganger',
+        'Back to departures',
+        'Tilbake til avgangar',
+      ),
+      title: _('Reisedetaljer', 'Trip details', 'Reisedetaljar'),
+      titleFromTo: ({
+        fromName,
+        toName,
+      }: {
+        fromName: string;
+        toName: string;
+      }) =>
+        _(
+          `${fromName}  -  ${toName}`,
+          `${fromName}  -  ${toName}`,
+          `${fromName}  -  ${toName}`,
+        ),
+    },
+  },
 };


### PR DESCRIPTION
This PR introduces a new query for fetching trips with more details, functionality to create a compressed query string that can be used to look up a specific trip, and the base layout for the assistant details page. 

Partially closes https://github.com/AtB-AS/kundevendt/issues/15639