### PR TITLE
feat: trip details header

### DIFF
--- a/src/page-modules/assistant/details/details-header/details-header.module.css
+++ b/src/page-modules/assistant/details/details-header/details-header.module.css
@@ -1,0 +1,16 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacings-xLarge);
+}
+.tripDetails {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacings-small);
+}
+.date,
+.duration {
+  display: flex;
+  gap: var(--spacings-small);
+  color: var(--text-colors-secondary);
+}

--- a/src/page-modules/assistant/details/details-header/index.tsx
+++ b/src/page-modules/assistant/details/details-header/index.tsx
@@ -1,0 +1,61 @@
+import { PageText, useTranslation } from '@atb/translations';
+import { TripPatternWithDetails } from '../../server/journey-planner/validators';
+import {
+  formatSimpleTime,
+  formatToSimpleDate,
+  formatToWeekday,
+  secondsToDuration,
+} from '@atb/utils/date';
+import { MonoIcon } from '@atb/components/icon';
+import { Typo } from '@atb/components/typography';
+
+import style from './details-header.module.css';
+
+export type DetailsHeaderProps = {
+  tripPattern: TripPatternWithDetails;
+};
+export default function DetailsHeader({ tripPattern }: DetailsHeaderProps) {
+  const { t, language } = useTranslation();
+  const fromName = tripPattern.legs[0].fromPlace.name;
+  const toName = tripPattern.legs[tripPattern.legs.length - 1].toPlace.name;
+
+  const weekdayAndDate = `${formatToWeekday(
+    tripPattern.expectedStartTime,
+    language,
+    'EEEE',
+  )} ${formatToSimpleDate(tripPattern.expectedStartTime, language)}`;
+
+  const timeRange = `${formatSimpleTime(
+    tripPattern.expectedStartTime,
+  )} - ${formatSimpleTime(tripPattern.expectedEndTime)}`;
+
+  const tripDuration = secondsToDuration(tripPattern.duration, language);
+
+  return (
+    <div className={style.container}>
+      <Typo.h2 textType="heading--big">
+        {fromName && toName
+          ? t(
+              PageText.Assistant.details.header.titleFromTo({
+                fromName,
+                toName,
+              }),
+            )
+          : t(PageText.Assistant.details.header.title)}
+      </Typo.h2>
+      <div className={style.tripDetails}>
+        <div className={style.date}>
+          <MonoIcon icon="time/Date" />
+          <Typo.p textType="body__primary">{weekdayAndDate}</Typo.p>
+        </div>
+        <div className={style.duration}>
+          <MonoIcon icon="time/Duration" />
+          <Typo.p textType="body__primary">{timeRange}</Typo.p>
+          <Typo.p textType="body__primary--bold">
+            {t(PageText.Assistant.details.header.travelTime(tripDuration))}
+          </Typo.p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/page-modules/assistant/details/details.module.css
+++ b/src/page-modules/assistant/details/details.module.css
@@ -37,3 +37,15 @@
   flex-direction: column;
   gap: var(--spacings-medium);
 }
+
+.tripDetails {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacings-small);
+}
+.date,
+.duration {
+  display: flex;
+  gap: var(--spacings-small);
+  color: var(--text-colors-secondary);
+}

--- a/src/page-modules/assistant/details/details.module.css
+++ b/src/page-modules/assistant/details/details.module.css
@@ -37,15 +37,3 @@
   flex-direction: column;
   gap: var(--spacings-medium);
 }
-
-.tripDetails {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacings-small);
-}
-.date,
-.duration {
-  display: flex;
-  gap: var(--spacings-small);
-  color: var(--text-colors-secondary);
-}

--- a/src/page-modules/assistant/details/index.tsx
+++ b/src/page-modules/assistant/details/index.tsx
@@ -18,7 +18,7 @@ export type AssistantDetailsProps = {
 
 export function AssistantDetails({ tripPattern }: AssistantDetailsProps) {
   const { t } = useTranslation();
-  const { fromName, toName, weekdayAndDate, timeRange, tripDuratrion } =
+  const { fromName, toName, weekdayAndDate, timeRange, tripDuration } =
     useTripDetailsHeader(tripPattern);
   return (
     <div className={style.container}>
@@ -52,7 +52,7 @@ export function AssistantDetails({ tripPattern }: AssistantDetailsProps) {
             <MonoIcon icon="time/Duration" />
             <Typo.p textType="body__primary">{timeRange}</Typo.p>
             <Typo.p textType="body__primary--bold">
-              {t(PageText.Assistant.details.header.travelTime(tripDuratrion))}
+              {t(PageText.Assistant.details.header.travelTime(tripDuration))}
             </Typo.p>
           </div>
         </div>
@@ -76,17 +76,13 @@ const useTripDetailsHeader = (tripPattern: TripPatternWithDetails) => {
     tripPattern.expectedStartTime,
   )} - ${formatSimpleTime(tripPattern.expectedEndTime)}`;
 
-  const totalDuration = tripPattern.legs.reduce(
-    (total, leg) => total + leg.duration,
-    0,
-  );
-  const tripDuratrion = secondsToDuration(totalDuration, language);
+  const tripDuration = secondsToDuration(tripPattern.duration, language);
 
   return {
     fromName,
     toName,
     weekdayAndDate,
     timeRange,
-    tripDuratrion,
+    tripDuration,
   };
 };

--- a/src/page-modules/assistant/details/index.tsx
+++ b/src/page-modules/assistant/details/index.tsx
@@ -3,6 +3,12 @@ import { TripPatternWithDetails } from '../server/journey-planner/validators';
 import { PageText, useTranslation } from '@atb/translations';
 import { MonoIcon } from '@atb/components/icon';
 import { Typo } from '@atb/components/typography';
+import {
+  formatSimpleTime,
+  formatToSimpleDate,
+  formatToWeekday,
+  secondsToDuration,
+} from '@atb/utils/date';
 
 import style from './details.module.css';
 
@@ -12,8 +18,8 @@ export type AssistantDetailsProps = {
 
 export function AssistantDetails({ tripPattern }: AssistantDetailsProps) {
   const { t } = useTranslation();
-  const fromName = tripPattern.legs[0].fromPlace.name;
-  const toName = tripPattern.legs[tripPattern.legs.length - 1].toPlace.name;
+  const { fromName, toName, weekdayAndDate, timeRange, tripDuratrion } =
+    useTripDetailsHeader(tripPattern);
   return (
     <div className={style.container}>
       <div className={style.headerContainer}>
@@ -37,7 +43,50 @@ export function AssistantDetails({ tripPattern }: AssistantDetailsProps) {
               )
             : t(PageText.Assistant.details.header.title)}
         </Typo.h2>
+        <div className={style.tripDetails}>
+          <div className={style.date}>
+            <MonoIcon icon="time/Date" />
+            <Typo.p textType="body__primary">{weekdayAndDate}</Typo.p>
+          </div>
+          <div className={style.duration}>
+            <MonoIcon icon="time/Duration" />
+            <Typo.p textType="body__primary">{timeRange}</Typo.p>
+            <Typo.p textType="body__primary--bold">
+              {t(PageText.Assistant.details.header.travelTime(tripDuratrion))}
+            </Typo.p>
+          </div>
+        </div>
       </div>
     </div>
   );
 }
+
+const useTripDetailsHeader = (tripPattern: TripPatternWithDetails) => {
+  const { language } = useTranslation();
+  const fromName = tripPattern.legs[0].fromPlace.name;
+  const toName = tripPattern.legs[tripPattern.legs.length - 1].toPlace.name;
+
+  const weekdayAndDate = `${formatToWeekday(
+    tripPattern.expectedStartTime,
+    language,
+    'EEEE',
+  )} ${formatToSimpleDate(tripPattern.expectedStartTime, language)}`;
+
+  const timeRange = `${formatSimpleTime(
+    tripPattern.expectedStartTime,
+  )} - ${formatSimpleTime(tripPattern.expectedEndTime)}`;
+
+  const totalDuration = tripPattern.legs.reduce(
+    (total, leg) => total + leg.duration,
+    0,
+  );
+  const tripDuratrion = secondsToDuration(totalDuration, language);
+
+  return {
+    fromName,
+    toName,
+    weekdayAndDate,
+    timeRange,
+    tripDuratrion,
+  };
+};

--- a/src/page-modules/assistant/details/index.tsx
+++ b/src/page-modules/assistant/details/index.tsx
@@ -1,16 +1,10 @@
-import { ButtonLink } from '@atb/components/button';
 import { TripPatternWithDetails } from '../server/journey-planner/validators';
-import { PageText, useTranslation } from '@atb/translations';
-import { MonoIcon } from '@atb/components/icon';
-import { Typo } from '@atb/components/typography';
-import {
-  formatSimpleTime,
-  formatToSimpleDate,
-  formatToWeekday,
-  secondsToDuration,
-} from '@atb/utils/date';
 
 import style from './details.module.css';
+import DetailsHeader from './details-header';
+import { ButtonLink } from '@atb/components/button';
+import { PageText, useTranslation } from '@atb/translations';
+import { MonoIcon } from '@atb/components/icon';
 
 export type AssistantDetailsProps = {
   tripPattern: TripPatternWithDetails;
@@ -18,8 +12,6 @@ export type AssistantDetailsProps = {
 
 export function AssistantDetails({ tripPattern }: AssistantDetailsProps) {
   const { t } = useTranslation();
-  const { fromName, toName, weekdayAndDate, timeRange, tripDuration } =
-    useTripDetailsHeader(tripPattern);
   return (
     <div className={style.container}>
       <div className={style.headerContainer}>
@@ -33,56 +25,8 @@ export function AssistantDetails({ tripPattern }: AssistantDetailsProps) {
           title={t(PageText.Assistant.details.header.backLink)}
           icon={{ left: <MonoIcon icon="navigation/ArrowLeft" /> }}
         />
-        <Typo.h2 textType="heading--big">
-          {fromName && toName
-            ? t(
-                PageText.Assistant.details.header.titleFromTo({
-                  fromName,
-                  toName,
-                }),
-              )
-            : t(PageText.Assistant.details.header.title)}
-        </Typo.h2>
-        <div className={style.tripDetails}>
-          <div className={style.date}>
-            <MonoIcon icon="time/Date" />
-            <Typo.p textType="body__primary">{weekdayAndDate}</Typo.p>
-          </div>
-          <div className={style.duration}>
-            <MonoIcon icon="time/Duration" />
-            <Typo.p textType="body__primary">{timeRange}</Typo.p>
-            <Typo.p textType="body__primary--bold">
-              {t(PageText.Assistant.details.header.travelTime(tripDuration))}
-            </Typo.p>
-          </div>
-        </div>
+        <DetailsHeader tripPattern={tripPattern} />
       </div>
     </div>
   );
 }
-
-const useTripDetailsHeader = (tripPattern: TripPatternWithDetails) => {
-  const { language } = useTranslation();
-  const fromName = tripPattern.legs[0].fromPlace.name;
-  const toName = tripPattern.legs[tripPattern.legs.length - 1].toPlace.name;
-
-  const weekdayAndDate = `${formatToWeekday(
-    tripPattern.expectedStartTime,
-    language,
-    'EEEE',
-  )} ${formatToSimpleDate(tripPattern.expectedStartTime, language)}`;
-
-  const timeRange = `${formatSimpleTime(
-    tripPattern.expectedStartTime,
-  )} - ${formatSimpleTime(tripPattern.expectedEndTime)}`;
-
-  const tripDuration = secondsToDuration(tripPattern.duration, language);
-
-  return {
-    fromName,
-    toName,
-    weekdayAndDate,
-    timeRange,
-    tripDuration,
-  };
-};

--- a/src/page-modules/assistant/server/journey-planner/index.ts
+++ b/src/page-modules/assistant/server/journey-planner/index.ts
@@ -230,6 +230,7 @@ export function createJourneyApi(
         expectedStartTime: singleTripPattern?.expectedStartTime,
         expectedEndTime: singleTripPattern?.expectedEndTime,
         legs: singleTripPattern?.legs.map((leg) => ({
+          duration: leg.duration,
           fromPlace: {
             name: leg.fromPlace.name,
           },

--- a/src/page-modules/assistant/server/journey-planner/index.ts
+++ b/src/page-modules/assistant/server/journey-planner/index.ts
@@ -229,8 +229,8 @@ export function createJourneyApi(
       const data: RecursivePartial<TripPatternWithDetails> = {
         expectedStartTime: singleTripPattern?.expectedStartTime,
         expectedEndTime: singleTripPattern?.expectedEndTime,
+        duration: singleTripPattern?.duration || 0,
         legs: singleTripPattern?.legs.map((leg) => ({
-          duration: leg.duration,
           fromPlace: {
             name: leg.fromPlace.name,
           },

--- a/src/page-modules/assistant/server/journey-planner/index.ts
+++ b/src/page-modules/assistant/server/journey-planner/index.ts
@@ -229,7 +229,7 @@ export function createJourneyApi(
       const data: RecursivePartial<TripPatternWithDetails> = {
         expectedStartTime: singleTripPattern?.expectedStartTime,
         expectedEndTime: singleTripPattern?.expectedEndTime,
-        duration: singleTripPattern?.duration || 0,
+        duration: singleTripPattern?.duration ?? 0,
         legs: singleTripPattern?.legs.map((leg) => ({
           fromPlace: {
             name: leg.fromPlace.name,

--- a/src/page-modules/assistant/server/journey-planner/journey-gql/trip-with-details.gql
+++ b/src/page-modules/assistant/server/journey-planner/journey-gql/trip-with-details.gql
@@ -29,6 +29,7 @@ query TripsWithDetails(
       expectedStartTime
       expectedEndTime
       legs {
+        duration
         fromPlace {
           name
         }

--- a/src/page-modules/assistant/server/journey-planner/journey-gql/trip-with-details.gql
+++ b/src/page-modules/assistant/server/journey-planner/journey-gql/trip-with-details.gql
@@ -28,8 +28,8 @@ query TripsWithDetails(
     tripPatterns {
       expectedStartTime
       expectedEndTime
+      duration
       legs {
-        duration
         fromPlace {
           name
         }

--- a/src/page-modules/assistant/server/journey-planner/validators.ts
+++ b/src/page-modules/assistant/server/journey-planner/validators.ts
@@ -83,6 +83,7 @@ export const tripPatternWithDetailsSchema = z.object({
   expectedEndTime: z.string(),
   legs: z.array(
     z.object({
+      duration: z.number(),
       fromPlace: z.object({
         name: z.string(),
       }),

--- a/src/page-modules/assistant/server/journey-planner/validators.ts
+++ b/src/page-modules/assistant/server/journey-planner/validators.ts
@@ -81,9 +81,9 @@ export const nonTransitSchema = z.object({
 export const tripPatternWithDetailsSchema = z.object({
   expectedStartTime: z.string(),
   expectedEndTime: z.string(),
+  duration: z.number(),
   legs: z.array(
     z.object({
-      duration: z.number(),
       fromPlace: z.object({
         name: z.string(),
       }),

--- a/src/translations/pages/assistant.ts
+++ b/src/translations/pages/assistant.ts
@@ -321,6 +321,12 @@ export const Assistant = {
           `${fromName}  -  ${toName}`,
           `${fromName}  -  ${toName}`,
         ),
+      travelTime: (duration: string) =>
+        _(
+          `${duration} reisetid`,
+          `${duration} travel time`,
+          `${duration} reisetid`,
+        ),
     },
   },
 };


### PR DESCRIPTION
This PR adds the trip details header information. 

![image](https://github.com/AtB-AS/planner-web/assets/43166974/2f8a1de8-0dd8-45f3-b7f0-7c5ff95d9c94)

![image](https://github.com/AtB-AS/planner-web/assets/43166974/a2c6983f-1731-4dd9-9f4c-041c95dd03c8)

Based on https://github.com/AtB-AS/planner-web/pull/85 (awaiting merge)

Partially closes https://github.com/AtB-AS/kundevendt/issues/15639
