### PR TITLE
fix: Change widget to init by passing URL to client

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,6 @@
   "bracketSameLine": false,
   "singleQuote": true,
   "trailingComma": "all",
-  "proseWrap": "always"
+  "proseWrap": "always",
+  "htmlWhitespaceSensitivity": "ignore"
 }

--- a/README.md
+++ b/README.md
@@ -8,3 +8,20 @@ TBA
 # What ORG to activate (nfk | atb | fram)
 NEXT_PUBLIC_PLANNER_ORG_ID=atb
 ```
+
+## Building Planner Widget code
+
+Example of creating widget for AtB:
+
+```
+NEXT_PUBLIC_PLANNER_ORG_ID=atb yarn build:widget
+```
+
+This will place asset inside `public/widget/` and then
+`http://localhost:3000/widget` can reach it.
+
+During development you can watch for changes:
+
+```
+NEXT_PUBLIC_PLANNER_ORG_ID=atb yarn build:widget -w
+```

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "prettier": "^3.0.3",
     "rimraf": "^5.0.1",
     "vite": "^4.4.9",
+    "vite-plugin-dts": "^3.6.3",
     "vitest": "^0.34.4"
   },
   "resolutions": {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,7 +10,6 @@ for orgId in atb nfk fram; do
   mkdir dist/$orgId
   export NEXT_PUBLIC_PLANNER_ORG_ID=$orgId
   # @TODO FIX THIS
-  export VITE_WIDGET_BASE_URL=http://localhost:3000/
   echo "Running yarn setup && yarn build for $orgId"
   yarn setup $orgId
   yarn build

--- a/src/widget/vite.config.js
+++ b/src/widget/vite.config.js
@@ -1,14 +1,11 @@
 import { resolve } from 'path';
 import { defineConfig } from 'vite';
+import dts from 'vite-plugin-dts';
 
 const orgId = process.env.NEXT_PUBLIC_PLANNER_ORG_ID;
 
 if (!orgId) {
   throw new Error('Missing env NEXT_PUBLIC_PLANNER_ORG_ID');
-}
-
-if (!process.env.VITE_WIDGET_BASE_URL) {
-  throw new Error('Missing env VITE_WIDGET_BASE_URL');
 }
 
 export default defineConfig({
@@ -21,6 +18,12 @@ export default defineConfig({
         '@atb-as/theme/lib/typography.module.css',
     },
   },
+  plugins: [
+    dts({
+      include: [resolve(__dirname, 'widget.ts')],
+      rollupTypes: true,
+    }),
+  ],
   build: {
     lib: {
       // Could also be a dictionary or array of multiple entry points

--- a/src/widget/widget.ts
+++ b/src/widget/widget.ts
@@ -6,278 +6,53 @@ import Combobox from '@github/combobox-nav';
 
 import style from './widget.module.css';
 
-const URL_BASE = import.meta.env.VITE_WIDGET_BASE_URL;
-
-export { URL_BASE };
-export const URL_JS_UMD = `${URL_BASE}widget/planner-web.umd.js`;
-export const URL_JS_ESM = `${URL_BASE}widget/planner-web.mjs`;
-export const URL_CSS = `${URL_BASE}widget/style.css`;
-
 const DEFAULT_DEBOUNCE_TIME = 300;
+
+type SettingConstants = {
+  URL_BASE: string;
+  URL_JS_UMD: string;
+  URL_JS_ESM: string;
+  URL_CSS: string;
+};
 
 const html = String.raw;
 
-const buttons = html`
-  <div class="${style.buttonGroup}">
-    <button type="submit" class="${style.button}" aria-disabled="true">
-      <span>Finn avganger</span>
-    </button>
-  </div>
-`;
-const searchTime = (withArriveBy: boolean = true) => html`
-  <div class="${style.inputBoxes}">
-    <p class="${style.heading}">Når vil du reise?</p>
-    <div>
-      <div
-        class="${style.selector_options} ${!withArriveBy
-          ? style.selector_options__small
-          : ''}"
-      >
-        <label class="${style.selector_option}"
-          ><input
-            type="radio"
-            name="searchTimeSelector"
-            aria-label="Nå"
-            class="${style.selector_option__input}"
-            value="now"
-            checked=""
-          /><span aria-hidden="true" class="${style.selector_option__label}"
-            ><span class="${style.selector_option__text}">Nå</span></span
-          ></label
-        >${withArriveBy
-          ? html`<label class="${style.selector_option}"
-              ><input
-                type="radio"
-                name="searchTimeSelector"
-                aria-label="Ankomst"
-                class="${style.selector_option__input}"
-                value="arriveBy"
-              /><span aria-hidden="true" class="${style.selector_option__label}"
-                ><span class="${style.selector_option__text}"
-                  >Ankomst</span
-                ></span
-              ></label
-            >`
-          : ''}<label class="${style.selector_option}"
-          ><input
-            type="radio"
-            name="searchTimeSelector"
-            aria-label="Avgang"
-            class="${style.selector_option__input}"
-            value="departBy"
-          /><span aria-hidden="true" class="${style.selector_option__label}"
-            ><span class="${style.selector_option__text}">Avgang</span></span
-          ></label
-        >
-      </div>
-      <div
-        class="${style.selector_dateAndTimeSelectorsWrapper} js-search-date-details"
-        hidden
-      >
-        <div class="${style.selector_dateAndTimeSelectors}">
-          <div class="${style.selector_dateSelector}">
-            <label for="searchTimeSelector-date">Dato</label
-            ><input
-              type="date"
-              id="searchTimeSelector-date"
-              value="2023-11-10"
-            />
-          </div>
-          <div class="${style.selector_timeSelector}">
-            <label for="searchTimeSelector-time">Tid</label
-            ><input type="time" id="searchTimeSelector-time" value="12:19" />
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-`;
-const assistant = html`
-  <form
-    class="${style.form}"
-    action="${URL_BASE}/assistant"
-    id="pw-form-assistant"
-    method="get"
-  >
-    <div class="${style.main}">
-      <div class="${style.inputBoxes}">
-        <p class="${style.heading}">Hvor vil du reise?</p>
-        <div class="${style.search_container}">
-          <label
-            class="${style.search_label}"
-            for="pw-from-1-input"
-            id="pw-from-1-label"
-            >Fra</label
-          >
-          <div
-            class="${style.search_inputContainer}"
-            role="combobox"
-            aria-expanded="false"
-            aria-haspopup="listbox"
-            aria-labelledby="pw-from-1-label"
-          >
-            <pw-autocomplete for="from-popup-1">
-              <input
-                class="${style.search_input}"
-                aria-autocomplete="list"
-                aria-labelledby="pw-from-1-label"
-                autocomplete="off"
-                id="pw-from-1-input"
-                name="from"
-                value=""
-              />
-              <ul
-                id="from-popup-1"
-                role="listbox"
-                aria-labelledby="pw-from-1-label"
-                class="${style.popupContainer}"
-                hidden
-              ></ul>
-            </pw-autocomplete>
-          </div>
-          <button
-            class="${style.button_geolocation}"
-            title="Finn min posisjon"
-            aria-label="Finn min posisjon"
-            type="button"
-          >
-            <img
-              src="${URL_BASE}/assets/mono/light/places/City.svg"
-              width="20"
-              height="20"
-              role="none"
-              alt=""
-            />
-          </button>
-        </div>
-        <div class="${style.search_container}">
-          <label
-            class="${style.search_label}"
-            for="pw-to-1-input"
-            id="pw-to-1-label"
-            >Til</label
-          >
-          <div
-            class="${style.search_inputContainer}"
-            role="combobox"
-            aria-expanded="false"
-            aria-haspopup="listbox"
-            aria-labelledby="pw-to-1-label"
-          >
-            <pw-autocomplete for="to-popup-1">
-              <input
-                class="${style.search_input} ${style.search_inputLast}"
-                aria-autocomplete="list"
-                aria-labelledby="pw-to-1-label"
-                autocomplete="off"
-                id="pw-to-1-input"
-                name="to"
-                value=""
-              />
-              <ul
-                id="to-popup-1"
-                role="listbox"
-                aria-labelledby="pw-to-1-label"
-                class="${style.popupContainer}"
-                hidden
-              ></ul>
-            </pw-autocomplete>
-          </div>
-        </div>
-      </div>
-      ${searchTime()}
-    </div>
-    ${buttons}
-  </form>
-`;
-const departures = html`
-  <form
-    class="${style.form}"
-    action="${URL_BASE}/departures"
-    id="pw-form-departures"
-    method="get"
-  >
-    <div class="${style.main}">
-      <div class="${style.inputBoxes}">
-        <p class="${style.heading}">Hvor vil du reise?</p>
-        <div class="${style.search_container}">
-          <label
-            class="${style.search_label}"
-            for="pw-from-2-input"
-            id="pw-from-2-label"
-            >Fra</label
-          >
-          <div
-            class="${style.search_inputContainer}"
-            role="combobox"
-            aria-expanded="false"
-            aria-haspopup="listbox"
-            aria-labelledby="pw-from-2-label"
-          >
-            <pw-autocomplete for="to-popup-2">
-              <input
-                class="${style.search_input}"
-                aria-autocomplete="list"
-                aria-labelledby="pw-from-1-label"
-                autocomplete="off"
-                name="from"
-                id="pw-from-2-input"
-                value=""
-              />
-              <ul
-                id="to-popup-2"
-                role="listbox"
-                aria-labelledby="pw-from-2-label"
-                class="${style.popupContainer}"
-                hidden
-              ></ul>
-            </pw-autocomplete>
-          </div>
-          <button
-            class="${style.button_geolocation}"
-            title="Finn min posisjon"
-            aria-label="Finn min posisjon"
-            type="button"
-          >
-            <img
-              src="${URL_BASE}/assets/mono/light/places/City.svg"
-              width="20"
-              height="20"
-              role="none"
-              alt=""
-            />
-          </button>
-        </div>
-      </div>
-      ${searchTime(false)}
-    </div>
-    ${buttons}
-  </form>
-`;
+function createSettingsConstants(urlBase: string) {
+  if (!urlBase?.startsWith('http')) {
+    throw new Error('Missing urlBase in correct schema.');
+  }
 
-export const output = html`
-  <div class="${style.wrapper}">
-    <nav class="${style.nav}">
-      <ul class="${style.tabs} js-tablist">
-        <li>
-          <a
-            href="/assistant"
-            class="${style.tabSelected}"
-            id="pw-assistant-tab"
-            >Planlegg reisen</a
-          >
-        </li>
-        <li><a href="/departures" id="pw-departures-tab">Finn avganger</a></li>
-      </ul>
-    </nav>
-    <div class="js-tabpanel" id="pw-assistant">${assistant}</div>
-    <div class="js-tabpanel ${style.hidden}" id="pw-departures">
-      ${departures}
-    </div>
-  </div>
-`;
+  if (!urlBase.endsWith('/')) {
+    urlBase += '/';
+  }
 
-export function init() {
+  return {
+    URL_BASE: urlBase,
+    URL_JS_UMD: `${urlBase}widget/planner-web.umd.js`,
+    URL_JS_ESM: `${urlBase}widget/planner-web.mjs`,
+    URL_CSS: `${urlBase}widget/style.css`,
+  };
+}
+
+export type WidgetOptions = {
+  urlBase: string;
+};
+export type PlannerWebOutput = {
+  output: string;
+  init: () => void;
+  urls: SettingConstants;
+};
+export function createWidget({ urlBase }: WidgetOptions): PlannerWebOutput {
+  const settings = createSettingsConstants(urlBase);
+  const output = createOutput(settings);
+  return {
+    output,
+    init,
+    urls: settings,
+  };
+}
+
+function init() {
   tabBar();
 
   let fromTo = {
@@ -314,6 +89,401 @@ export function init() {
       const form = e.currentTarget as HTMLFormElement;
       submitAssistant(form.action, fromTo.from!, fromTo.to);
     });
+}
+
+function createOutput({ URL_BASE }: SettingConstants) {
+  function searchItem(item: GeocoderFeature) {
+    const img = venueIcon(item);
+    const title = el('span', [item.name]);
+    const locality = el('span', [item.locality ?? ''], style.itemLocality);
+    const li = el('li', [img, title, locality], style.listItem);
+    li.role = 'option';
+    li.setAttribute('data-feature-id', item.id);
+    return li;
+  }
+
+  function venueIcon(item: GeocoderFeature) {
+    const icon = iconData(item.category);
+
+    const img = el('img');
+    img.src = `${URL_BASE}assets/mono/light/${icon.icon}.svg`;
+    img.alt = icon.alt;
+    img.role = 'img';
+
+    const div = el('div', [img], style.itemIcon);
+    div.ariaHidden = 'true';
+    return div;
+  }
+
+  class AutocompleteBox extends HTMLElement {
+    private dataList: Record<string, GeocoderFeature> = {};
+
+    constructor() {
+      super();
+    }
+
+    getItem(id: string) {
+      return this.dataList[id];
+    }
+
+    setItems(list: GeocoderFeature[]) {
+      this.dataList = {};
+      for (let item of list) {
+        this.dataList[item.id] = item;
+      }
+    }
+
+    connectedCallback() {
+      const self = this;
+
+      const debounceTime = safeParse(
+        this.getAttribute('data-debounce-ms'),
+        DEFAULT_DEBOUNCE_TIME,
+      );
+
+      const input = this.querySelector('input')!;
+      const list = this.querySelector<HTMLElement>(
+        '#' + this.getAttribute('for')!,
+      )!;
+
+      let combobox = new Combobox(input, list, {
+        scrollIntoViewOptions: false,
+      });
+
+      function toggleList(show?: boolean) {
+        if (!show) {
+          combobox.clearSelection();
+          combobox.stop();
+        } else {
+          combobox.start();
+        }
+
+        list.hidden = !show;
+      }
+
+      const fetcher = debounce(async (el: HTMLInputElement) => {
+        const data = await autocomplete(el.value);
+
+        self.setItems(data);
+        list.innerHTML = '';
+        for (let item of data) {
+          const li = searchItem(item);
+          list.appendChild(li);
+        }
+
+        toggleList(true);
+      }, debounceTime);
+      input.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+          toggleList(false);
+        }
+      });
+      input.addEventListener('input', (e) =>
+        fetcher(e.target as HTMLInputElement),
+      );
+      input.addEventListener('focus', () => toggleList(true));
+      input.addEventListener(
+        'blur',
+        // Blur after properly selecting
+        debounce(() => toggleList(false), 100),
+      );
+      document.addEventListener('click', (e) => {
+        if (!hasParent(e.target as HTMLElement, this)) {
+          toggleList(false);
+        }
+      });
+
+      list.addEventListener('combobox-commit', function (event) {
+        const itemId = (event.target as HTMLElement).getAttribute(
+          'data-feature-id',
+        );
+        const item = itemId ? self.getItem(itemId) : undefined;
+        input.value = item ? `${item.name}, ${item.locality}` : input.value;
+        document.dispatchEvent(
+          new CustomEvent('search-selected', {
+            bubbles: true,
+            detail: {
+              mode: 'assistant',
+              key: input.name,
+              item,
+            },
+          }),
+        );
+
+        list.hidden = true;
+        combobox.clearSelection();
+        combobox.stop();
+      });
+    }
+  }
+
+  customElements.define('pw-autocomplete', AutocompleteBox);
+
+  const buttons = html`
+    <div class="${style.buttonGroup}">
+      <button type="submit" class="${style.button}" aria-disabled="true">
+        <span>Finn avganger</span>
+      </button>
+    </div>
+  `;
+  const searchTime = (withArriveBy: boolean = true) => html`
+    <div class="${style.inputBoxes}">
+      <p class="${style.heading}">Når vil du reise?</p>
+      <div>
+        <div
+          class="${style.selector_options} ${!withArriveBy
+            ? style.selector_options__small
+            : ''}"
+        >
+          <label class="${style.selector_option}"
+            ><input
+              type="radio"
+              name="searchTimeSelector"
+              aria-label="Nå"
+              class="${style.selector_option__input}"
+              value="now"
+              checked=""
+            /><span aria-hidden="true" class="${style.selector_option__label}"
+              ><span class="${style.selector_option__text}">Nå</span></span
+            ></label
+          >${withArriveBy
+            ? html`<label class="${style.selector_option}"
+                ><input
+                  type="radio"
+                  name="searchTimeSelector"
+                  aria-label="Ankomst"
+                  class="${style.selector_option__input}"
+                  value="arriveBy"
+                /><span
+                  aria-hidden="true"
+                  class="${style.selector_option__label}"
+                  ><span class="${style.selector_option__text}"
+                    >Ankomst</span
+                  ></span
+                ></label
+              >`
+            : ''}<label class="${style.selector_option}"
+            ><input
+              type="radio"
+              name="searchTimeSelector"
+              aria-label="Avgang"
+              class="${style.selector_option__input}"
+              value="departBy"
+            /><span aria-hidden="true" class="${style.selector_option__label}"
+              ><span class="${style.selector_option__text}">Avgang</span></span
+            ></label
+          >
+        </div>
+        <div
+          class="${style.selector_dateAndTimeSelectorsWrapper} js-search-date-details"
+          hidden
+        >
+          <div class="${style.selector_dateAndTimeSelectors}">
+            <div class="${style.selector_dateSelector}">
+              <label for="searchTimeSelector-date">Dato</label
+              ><input
+                type="date"
+                id="searchTimeSelector-date"
+                value="2023-11-10"
+              />
+            </div>
+            <div class="${style.selector_timeSelector}">
+              <label for="searchTimeSelector-time">Tid</label
+              ><input type="time" id="searchTimeSelector-time" value="12:19" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  `;
+  const assistant = html`
+    <form
+      class="${style.form}"
+      action="${URL_BASE}/assistant"
+      id="pw-form-assistant"
+      method="get"
+    >
+      <div class="${style.main}">
+        <div class="${style.inputBoxes}">
+          <p class="${style.heading}">Hvor vil du reise?</p>
+          <div class="${style.search_container}">
+            <label
+              class="${style.search_label}"
+              for="pw-from-1-input"
+              id="pw-from-1-label"
+              >Fra</label
+            >
+            <div
+              class="${style.search_inputContainer}"
+              role="combobox"
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-labelledby="pw-from-1-label"
+            >
+              <pw-autocomplete for="from-popup-1">
+                <input
+                  class="${style.search_input}"
+                  aria-autocomplete="list"
+                  aria-labelledby="pw-from-1-label"
+                  autocomplete="off"
+                  id="pw-from-1-input"
+                  name="from"
+                  value=""
+                />
+                <ul
+                  id="from-popup-1"
+                  role="listbox"
+                  aria-labelledby="pw-from-1-label"
+                  class="${style.popupContainer}"
+                  hidden
+                ></ul>
+              </pw-autocomplete>
+            </div>
+            <button
+              class="${style.button_geolocation}"
+              title="Finn min posisjon"
+              aria-label="Finn min posisjon"
+              type="button"
+            >
+              <img
+                src="${URL_BASE}/assets/mono/light/places/City.svg"
+                width="20"
+                height="20"
+                role="none"
+                alt=""
+              />
+            </button>
+          </div>
+          <div class="${style.search_container}">
+            <label
+              class="${style.search_label}"
+              for="pw-to-1-input"
+              id="pw-to-1-label"
+              >Til</label
+            >
+            <div
+              class="${style.search_inputContainer}"
+              role="combobox"
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-labelledby="pw-to-1-label"
+            >
+              <pw-autocomplete for="to-popup-1">
+                <input
+                  class="${style.search_input} ${style.search_inputLast}"
+                  aria-autocomplete="list"
+                  aria-labelledby="pw-to-1-label"
+                  autocomplete="off"
+                  id="pw-to-1-input"
+                  name="to"
+                  value=""
+                />
+                <ul
+                  id="to-popup-1"
+                  role="listbox"
+                  aria-labelledby="pw-to-1-label"
+                  class="${style.popupContainer}"
+                  hidden
+                ></ul>
+              </pw-autocomplete>
+            </div>
+          </div>
+        </div>
+        ${searchTime()}
+      </div>
+      ${buttons}
+    </form>
+  `;
+  const departures = html`
+    <form
+      class="${style.form}"
+      action="${URL_BASE}/departures"
+      id="pw-form-departures"
+      method="get"
+    >
+      <div class="${style.main}">
+        <div class="${style.inputBoxes}">
+          <p class="${style.heading}">Hvor vil du reise?</p>
+          <div class="${style.search_container}">
+            <label
+              class="${style.search_label}"
+              for="pw-from-2-input"
+              id="pw-from-2-label"
+              >Fra</label
+            >
+            <div
+              class="${style.search_inputContainer}"
+              role="combobox"
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-labelledby="pw-from-2-label"
+            >
+              <pw-autocomplete for="to-popup-2">
+                <input
+                  class="${style.search_input}"
+                  aria-autocomplete="list"
+                  aria-labelledby="pw-from-1-label"
+                  autocomplete="off"
+                  name="from"
+                  id="pw-from-2-input"
+                  value=""
+                />
+                <ul
+                  id="to-popup-2"
+                  role="listbox"
+                  aria-labelledby="pw-from-2-label"
+                  class="${style.popupContainer}"
+                  hidden
+                ></ul>
+              </pw-autocomplete>
+            </div>
+            <button
+              class="${style.button_geolocation}"
+              title="Finn min posisjon"
+              aria-label="Finn min posisjon"
+              type="button"
+            >
+              <img
+                src="${URL_BASE}/assets/mono/light/places/City.svg"
+                width="20"
+                height="20"
+                role="none"
+                alt=""
+              />
+            </button>
+          </div>
+        </div>
+        ${searchTime(false)}
+      </div>
+      ${buttons}
+    </form>
+  `;
+
+  const output = html`
+    <div class="${style.wrapper}">
+      <nav class="${style.nav}">
+        <ul class="${style.tabs} js-tablist">
+          <li>
+            <a
+              href="/assistant"
+              class="${style.tabSelected}"
+              id="pw-assistant-tab"
+              >Planlegg reisen</a
+            >
+          </li>
+          <li>
+            <a href="/departures" id="pw-departures-tab">Finn avganger</a>
+          </li>
+        </ul>
+      </nav>
+      <div class="js-tabpanel" id="pw-assistant">${assistant}</div>
+      <div class="js-tabpanel ${style.hidden}" id="pw-departures">
+        ${departures}
+      </div>
+    </div>
+  `;
+
+  return output;
 }
 
 function submitAssistant(
@@ -394,132 +564,6 @@ type SelectedSearchEvent = {
   item?: GeocoderFeature;
 };
 
-class AutocompleteBox extends HTMLElement {
-  private dataList: Record<string, GeocoderFeature> = {};
-
-  constructor() {
-    super();
-  }
-
-  getItem(id: string) {
-    return this.dataList[id];
-  }
-
-  setItems(list: GeocoderFeature[]) {
-    this.dataList = {};
-    for (let item of list) {
-      this.dataList[item.id] = item;
-    }
-  }
-
-  connectedCallback() {
-    const self = this;
-
-    const debounceTime = safeParse(
-      this.getAttribute('data-debounce-ms'),
-      DEFAULT_DEBOUNCE_TIME,
-    );
-
-    const input = this.querySelector('input')!;
-    const list = this.querySelector<HTMLElement>(
-      '#' + this.getAttribute('for')!,
-    )!;
-
-    let combobox = new Combobox(input, list, {
-      scrollIntoViewOptions: false,
-    });
-
-    function toggleList(show?: boolean) {
-      if (!show) {
-        combobox.clearSelection();
-        combobox.stop();
-      } else {
-        combobox.start();
-      }
-
-      list.hidden = !show;
-    }
-
-    const fetcher = debounce(async (el: HTMLInputElement) => {
-      const data = await autocomplete(el.value);
-
-      self.setItems(data);
-      list.innerHTML = '';
-      for (let item of data) {
-        const li = searchItem(item);
-        list.appendChild(li);
-      }
-
-      toggleList(true);
-    }, debounceTime);
-    input.addEventListener('keydown', (event) => {
-      if (event.key === 'Escape') {
-        toggleList(false);
-      }
-    });
-    input.addEventListener('input', (e) =>
-      fetcher(e.target as HTMLInputElement),
-    );
-    input.addEventListener('focus', () => toggleList(true));
-    input.addEventListener(
-      'blur',
-      // Blur after properly selecting
-      debounce(() => toggleList(false), 100),
-    );
-    document.addEventListener('click', (e) => {
-      if (!hasParent(e.target as HTMLElement, this)) {
-        toggleList(false);
-      }
-    });
-
-    list.addEventListener('combobox-commit', function (event) {
-      const itemId = (event.target as HTMLElement).getAttribute(
-        'data-feature-id',
-      );
-      const item = itemId ? self.getItem(itemId) : undefined;
-      input.value = item ? `${item.name}, ${item.locality}` : input.value;
-      document.dispatchEvent(
-        new CustomEvent('search-selected', {
-          bubbles: true,
-          detail: {
-            mode: 'assistant',
-            key: input.name,
-            item,
-          },
-        }),
-      );
-
-      list.hidden = true;
-      combobox.clearSelection();
-      combobox.stop();
-    });
-  }
-}
-
-function searchItem(item: GeocoderFeature) {
-  const img = venueIcon(item);
-  const title = el('span', [item.name]);
-  const locality = el('span', [item.locality ?? ''], style.itemLocality);
-  const li = el('li', [img, title, locality], style.listItem);
-  li.role = 'option';
-  li.setAttribute('data-feature-id', item.id);
-  return li;
-}
-
-function venueIcon(item: GeocoderFeature) {
-  const icon = iconData(item.category);
-
-  // http://localhost:3000/assets/mono/light/transportation-entur/Bus.svg
-  const img = el('img');
-  img.src = `${URL_BASE}assets/mono/light/${icon.icon}.svg`;
-  img.alt = icon.alt;
-  img.role = 'img';
-
-  const div = el('div', [img], style.itemIcon);
-  div.ariaHidden = 'true';
-  return div;
-}
-
 function el<K extends keyof HTMLElementTagNameMap>(
   tag: K,
   children: (HTMLElement | string)[] = [],
@@ -536,8 +580,6 @@ function el<K extends keyof HTMLElementTagNameMap>(
   item.className = className;
   return item;
 }
-
-customElements.define('pw-autocomplete', AutocompleteBox);
 
 function safeParse(input: string | null, defaultValue: number) {
   const parsed = parseInt(input!, 10);

--- a/src/widget/widget.ts
+++ b/src/widget/widget.ts
@@ -411,7 +411,7 @@ function createOutput({ URL_BASE }: SettingConstants) {
     >
       <div class="${style.main}">
         <div class="${style.inputBoxes}">
-          <p class="${style.heading}">Hvor vil du reise?</p>
+          <p class="${style.heading}">Hvor vil du reise fra?</p>
           <div class="${style.search_container}">
             <label
               class="${style.search_label}"

--- a/src/widget/widget.ts
+++ b/src/widget/widget.ts
@@ -235,44 +235,50 @@ function createOutput({ URL_BASE }: SettingConstants) {
             ? style.selector_options__small
             : ''}"
         >
-          <label class="${style.selector_option}"
-            ><input
+          <label class="${style.selector_option}">
+            <input
               type="radio"
               name="searchTimeSelector"
               aria-label="Nå"
               class="${style.selector_option__input}"
               value="now"
               checked=""
-            /><span aria-hidden="true" class="${style.selector_option__label}"
-              ><span class="${style.selector_option__text}">Nå</span></span
-            ></label
-          >${withArriveBy
-            ? html`<label class="${style.selector_option}"
-                ><input
-                  type="radio"
-                  name="searchTimeSelector"
-                  aria-label="Ankomst"
-                  class="${style.selector_option__input}"
-                  value="arriveBy"
-                /><span
-                  aria-hidden="true"
-                  class="${style.selector_option__label}"
-                  ><span class="${style.selector_option__text}"
-                    >Ankomst</span
-                  ></span
-                ></label
-              >`
-            : ''}<label class="${style.selector_option}"
-            ><input
+            />
+            <span aria-hidden="true" class="${style.selector_option__label}">
+              <span class="${style.selector_option__text}">Nå</span>
+            </span>
+          </label>
+          ${withArriveBy
+            ? html`
+                <label class="${style.selector_option}">
+                  <input
+                    type="radio"
+                    name="searchTimeSelector"
+                    aria-label="Ankomst"
+                    class="${style.selector_option__input}"
+                    value="arriveBy"
+                  />
+                  <span
+                    aria-hidden="true"
+                    class="${style.selector_option__label}"
+                  >
+                    <span class="${style.selector_option__text}">Ankomst</span>
+                  </span>
+                </label>
+              `
+            : ''}
+          <label class="${style.selector_option}">
+            <input
               type="radio"
               name="searchTimeSelector"
               aria-label="Avgang"
               class="${style.selector_option__input}"
               value="departBy"
-            /><span aria-hidden="true" class="${style.selector_option__label}"
-              ><span class="${style.selector_option__text}">Avgang</span></span
-            ></label
-          >
+            />
+            <span aria-hidden="true" class="${style.selector_option__label}">
+              <span class="${style.selector_option__text}">Avgang</span>
+            </span>
+          </label>
         </div>
         <div
           class="${style.selector_dateAndTimeSelectorsWrapper} js-search-date-details"
@@ -280,16 +286,16 @@ function createOutput({ URL_BASE }: SettingConstants) {
         >
           <div class="${style.selector_dateAndTimeSelectors}">
             <div class="${style.selector_dateSelector}">
-              <label for="searchTimeSelector-date">Dato</label
-              ><input
+              <label for="searchTimeSelector-date">Dato</label>
+              <input
                 type="date"
                 id="searchTimeSelector-date"
                 value="2023-11-10"
               />
             </div>
             <div class="${style.selector_timeSelector}">
-              <label for="searchTimeSelector-time">Tid</label
-              ><input type="time" id="searchTimeSelector-time" value="12:19" />
+              <label for="searchTimeSelector-time">Tid</label>
+              <input type="time" id="searchTimeSelector-time" value="12:19" />
             </div>
           </div>
         </div>
@@ -311,8 +317,9 @@ function createOutput({ URL_BASE }: SettingConstants) {
               class="${style.search_label}"
               for="pw-from-1-input"
               id="pw-from-1-label"
-              >Fra</label
             >
+              Fra
+            </label>
             <div
               class="${style.search_inputContainer}"
               role="combobox"
@@ -359,8 +366,9 @@ function createOutput({ URL_BASE }: SettingConstants) {
               class="${style.search_label}"
               for="pw-to-1-input"
               id="pw-to-1-label"
-              >Til</label
             >
+              Til
+            </label>
             <div
               class="${style.search_inputContainer}"
               role="combobox"
@@ -409,8 +417,9 @@ function createOutput({ URL_BASE }: SettingConstants) {
               class="${style.search_label}"
               for="pw-from-2-input"
               id="pw-from-2-label"
-              >Fra</label
             >
+              Fra
+            </label>
             <div
               class="${style.search_inputContainer}"
               role="combobox"
@@ -468,8 +477,9 @@ function createOutput({ URL_BASE }: SettingConstants) {
               href="/assistant"
               class="${style.tabSelected}"
               id="pw-assistant-tab"
-              >Planlegg reisen</a
             >
+              Planlegg reisen
+            </a>
           </li>
           <li>
             <a href="/departures" id="pw-departures-tab">Finn avganger</a>

--- a/yarn.lock
+++ b/yarn.lock
@@ -304,6 +304,11 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.23.0.tgz#da950e622420bf96ca0d0f2909cdddac3acd8719"
   integrity sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==
 
+"@babel/parser@^7.23.3":
+  version "7.23.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.23.4.tgz#409fbe690c333bb70187e2de4021e1e47a026661"
+  integrity sha512-vf3Xna6UEprW+7t6EtOmFpHNAuxw3xqPZghy+brsnusscJRW5BMUzzHZc5ICjULee81WeUV2jjakG09MDglJXQ==
+
 "@babel/plugin-proposal-class-properties@^7.0.0":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz#b110f59741895f7ec21a6fff696ec46265c446a3"
@@ -1351,6 +1356,48 @@
   resolved "https://registry.yarnpkg.com/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz#497c67a1cef50d1a2459ba60f315e448d2ad87fe"
   integrity sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==
 
+"@microsoft/api-extractor-model@7.28.2":
+  version "7.28.2"
+  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor-model/-/api-extractor-model-7.28.2.tgz#91c66dd820ccc70e0c163e06b392d8363f1b9269"
+  integrity sha512-vkojrM2fo3q4n4oPh4uUZdjJ2DxQ2+RnDQL/xhTWSRUNPF6P4QyrvY357HBxbnltKcYu+nNNolVqc6TIGQ73Ig==
+  dependencies:
+    "@microsoft/tsdoc" "0.14.2"
+    "@microsoft/tsdoc-config" "~0.16.1"
+    "@rushstack/node-core-library" "3.61.0"
+
+"@microsoft/api-extractor@^7.38.0":
+  version "7.38.3"
+  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor/-/api-extractor-7.38.3.tgz#2b0157d166c1a23642e22d139c7b7b39ad6340fd"
+  integrity sha512-xt9iYyC5f39281j77JTA9C3ISJpW1XWkCcnw+2vM78CPnro6KhPfwQdPDfwS5JCPNuq0grm8cMdPUOPvrchDWw==
+  dependencies:
+    "@microsoft/api-extractor-model" "7.28.2"
+    "@microsoft/tsdoc" "0.14.2"
+    "@microsoft/tsdoc-config" "~0.16.1"
+    "@rushstack/node-core-library" "3.61.0"
+    "@rushstack/rig-package" "0.5.1"
+    "@rushstack/ts-command-line" "4.17.1"
+    colors "~1.2.1"
+    lodash "~4.17.15"
+    resolve "~1.22.1"
+    semver "~7.5.4"
+    source-map "~0.6.1"
+    typescript "~5.0.4"
+
+"@microsoft/tsdoc-config@~0.16.1":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@microsoft/tsdoc-config/-/tsdoc-config-0.16.2.tgz#b786bb4ead00d54f53839a458ce626c8548d3adf"
+  integrity sha512-OGiIzzoBLgWWR0UdRJX98oYO+XKGf7tiK4Zk6tQ/E4IJqGCe7dvkTvgDZV5cFJUzLGDOjeAXrnZoA6QkVySuxw==
+  dependencies:
+    "@microsoft/tsdoc" "0.14.2"
+    ajv "~6.12.6"
+    jju "~1.4.0"
+    resolve "~1.19.0"
+
+"@microsoft/tsdoc@0.14.2":
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz#c3ec604a0b54b9a9b87e9735dfc59e1a5da6a5fb"
+  integrity sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==
+
 "@next/env@13.4.19":
   version "13.4.19"
   resolved "https://registry.yarnpkg.com/@next/env/-/env-13.4.19.tgz#46905b4e6f62da825b040343cbc233144e9578d3"
@@ -1536,10 +1583,50 @@
   resolved "https://registry.yarnpkg.com/@repeaterjs/repeater/-/repeater-3.0.4.tgz#a04d63f4d1bf5540a41b01a921c9a7fddc3bd1ca"
   integrity sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA==
 
+"@rollup/pluginutils@^5.0.5":
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.0.5.tgz#bbb4c175e19ebfeeb8c132c2eea0ecb89941a66c"
+  integrity sha512-6aEYR910NyP73oHiJglti74iRyOwgFU4x3meH/H8OJx6Ry0j6cOVZ5X/wTvub7G7Ao6qaHBEaNsV3GLJkSsF+Q==
+  dependencies:
+    "@types/estree" "^1.0.0"
+    estree-walker "^2.0.2"
+    picomatch "^2.3.1"
+
 "@rushstack/eslint-patch@^1.3.3":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.5.0.tgz#5143b0da9c536bfe8beddfeb68bb8b5d647cc7a3"
   integrity sha512-EF3948ckf3f5uPgYbQ6GhyA56Dmv8yg0+ir+BroRjwdxyZJsekhZzawOecC2rOTPCz173t7ZcR1HHZu0dZgOCw==
+
+"@rushstack/node-core-library@3.61.0":
+  version "3.61.0"
+  resolved "https://registry.yarnpkg.com/@rushstack/node-core-library/-/node-core-library-3.61.0.tgz#7441a0d2ae5268b758a7a49588a78cd55af57e66"
+  integrity sha512-tdOjdErme+/YOu4gPed3sFS72GhtWCgNV9oDsHDnoLY5oDfwjKUc9Z+JOZZ37uAxcm/OCahDHfuu2ugqrfWAVQ==
+  dependencies:
+    colors "~1.2.1"
+    fs-extra "~7.0.1"
+    import-lazy "~4.0.0"
+    jju "~1.4.0"
+    resolve "~1.22.1"
+    semver "~7.5.4"
+    z-schema "~5.0.2"
+
+"@rushstack/rig-package@0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@rushstack/rig-package/-/rig-package-0.5.1.tgz#6c9c283cc96b5bb1eae9875946d974ac5429bb21"
+  integrity sha512-pXRYSe29TjRw7rqxD4WS3HN/sRSbfr+tJs4a9uuaSIBAITbUggygdhuG0VrO0EO+QqH91GhYMN4S6KRtOEmGVA==
+  dependencies:
+    resolve "~1.22.1"
+    strip-json-comments "~3.1.1"
+
+"@rushstack/ts-command-line@4.17.1":
+  version "4.17.1"
+  resolved "https://registry.yarnpkg.com/@rushstack/ts-command-line/-/ts-command-line-4.17.1.tgz#c78db928ce5b93f2e98fd9e14c24f3f3876e57f1"
+  integrity sha512-2jweO1O57BYP5qdBGl6apJLB+aRIn5ccIRTPDyULh0KMwVzFqWtw6IZWt1qtUoZD/pD2RNkIOosH6Cq45rIYeg==
+  dependencies:
+    "@types/argparse" "1.0.38"
+    argparse "~1.0.9"
+    colors "~1.2.1"
+    string-argv "~0.3.1"
 
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"
@@ -1602,6 +1689,11 @@
   resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.5.1.tgz#27337d72046d5236b32fd977edee3f74c71d332f"
   integrity sha512-UCcUKrUYGj7ClomOo2SpNVvx4/fkd/2BbIHDCle8A0ax+P3bU7yJwDBDrS6ZwdTMARWTGODX1hEsCcO+7beJjg==
 
+"@types/argparse@1.0.38":
+  version "1.0.38"
+  resolved "https://registry.yarnpkg.com/@types/argparse/-/argparse-1.0.38.tgz#a81fd8606d481f873a3800c6ebae4f1d768a56a9"
+  integrity sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==
+
 "@types/aria-query@^5.0.1":
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.2.tgz#6f1225829d89794fd9f891989c9ce667422d7f64"
@@ -1663,6 +1755,11 @@
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
   integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
+
+"@types/estree@^1.0.0":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
+  integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
 
 "@types/geojson@*":
   version "7946.0.11"
@@ -1889,6 +1986,65 @@
     loupe "^2.3.6"
     pretty-format "^29.5.0"
 
+"@volar/language-core@1.10.10", "@volar/language-core@~1.10.5":
+  version "1.10.10"
+  resolved "https://registry.yarnpkg.com/@volar/language-core/-/language-core-1.10.10.tgz#9c240a36dd4007b9c4f00739f6cecb81da54a49e"
+  integrity sha512-nsV1o3AZ5n5jaEAObrS3MWLBWaGwUj/vAsc15FVNIv+DbpizQRISg9wzygsHBr56ELRH8r4K75vkYNMtsSNNWw==
+  dependencies:
+    "@volar/source-map" "1.10.10"
+
+"@volar/source-map@1.10.10", "@volar/source-map@~1.10.5":
+  version "1.10.10"
+  resolved "https://registry.yarnpkg.com/@volar/source-map/-/source-map-1.10.10.tgz#ec807fe60b8afe29e19bf6d1c90d2e76502df541"
+  integrity sha512-GVKjLnifV4voJ9F0vhP56p4+F3WGf+gXlRtjFZsv6v3WxBTWU3ZVeaRaEHJmWrcv5LXmoYYpk/SC25BKemPRkg==
+  dependencies:
+    muggle-string "^0.3.1"
+
+"@volar/typescript@~1.10.5":
+  version "1.10.10"
+  resolved "https://registry.yarnpkg.com/@volar/typescript/-/typescript-1.10.10.tgz#1f88202c63988ddfcee154a93050312041b83329"
+  integrity sha512-4a2r5bdUub2m+mYVnLu2wt59fuoYWe7nf0uXtGHU8QQ5LDNfzAR0wK7NgDiQ9rcl2WT3fxT2AA9AylAwFtj50A==
+  dependencies:
+    "@volar/language-core" "1.10.10"
+    path-browserify "^1.0.1"
+
+"@vue/compiler-core@3.3.9":
+  version "3.3.9"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.3.9.tgz#df1fc7947dcef5c2e12d257eae540057707f47d1"
+  integrity sha512-+/Lf68Vr/nFBA6ol4xOtJrW+BQWv3QWKfRwGSm70jtXwfhZNF4R/eRgyVJYoxFRhdCTk/F6g99BP0ffPgZihfQ==
+  dependencies:
+    "@babel/parser" "^7.23.3"
+    "@vue/shared" "3.3.9"
+    estree-walker "^2.0.2"
+    source-map-js "^1.0.2"
+
+"@vue/compiler-dom@^3.3.0":
+  version "3.3.9"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.3.9.tgz#67315ea4193d9d18c7a710889b8f90f7aa3914d2"
+  integrity sha512-nfWubTtLXuT4iBeDSZ5J3m218MjOy42Vp2pmKVuBKo2/BLcrFUX8nCSr/bKRFiJ32R8qbdnnnBgRn9AdU5v0Sg==
+  dependencies:
+    "@vue/compiler-core" "3.3.9"
+    "@vue/shared" "3.3.9"
+
+"@vue/language-core@1.8.22", "@vue/language-core@^1.8.20":
+  version "1.8.22"
+  resolved "https://registry.yarnpkg.com/@vue/language-core/-/language-core-1.8.22.tgz#1ef62645fb9b1f830c6c84a5586e49e74727b1e3"
+  integrity sha512-bsMoJzCrXZqGsxawtUea1cLjUT9dZnDsy5TuZ+l1fxRMzUGQUG9+Ypq4w//CqpWmrx7nIAJpw2JVF/t258miRw==
+  dependencies:
+    "@volar/language-core" "~1.10.5"
+    "@volar/source-map" "~1.10.5"
+    "@vue/compiler-dom" "^3.3.0"
+    "@vue/shared" "^3.3.0"
+    computeds "^0.0.1"
+    minimatch "^9.0.3"
+    muggle-string "^0.3.1"
+    vue-template-compiler "^2.7.14"
+
+"@vue/shared@3.3.9", "@vue/shared@^3.3.0":
+  version "3.3.9"
+  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.3.9.tgz#df740d26d338faf03e09ca662a8031acf66051db"
+  integrity sha512-ZE0VTIR0LmYgeyhurPTpy4KzKsuDyQbMSdM49eKkMnT5X4VfFBLysMzjIZhLEFQYjjOVVfbvUDHckwjDFiO2eA==
+
 "@whatwg-node/events@^0.0.3":
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/@whatwg-node/events/-/events-0.0.3.tgz#13a65dd4f5893f55280f766e29ae48074927acad"
@@ -1998,7 +2154,7 @@ ajv-formats@^2.1.1:
   dependencies:
     ajv "^8.0.0"
 
-ajv@^6.12.4:
+ajv@^6.12.4, ajv@~6.12.6:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -2063,6 +2219,13 @@ argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
+argparse@~1.0.9:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
+  dependencies:
+    sprintf-js "~1.0.2"
 
 aria-query@5.1.3:
   version "5.1.3"
@@ -2602,10 +2765,20 @@ colorette@^2.0.16:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
   integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
 
+colors@~1.2.1:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.2.5.tgz#89c7ad9a374bc030df8013241f68136ed8835afc"
+  integrity sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==
+
 comma-separated-tokens@^1.0.0:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz#632b80b6117867a158f1080ad498b2fbe7e3f5ea"
   integrity sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==
+
+commander@^10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
+  integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
 
 commander@^9.4.0:
   version "9.5.0"
@@ -2621,6 +2794,11 @@ compute-scroll-into-view@^3.0.3:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-3.1.0.tgz#753f11d972596558d8fe7c6bcbc8497690ab4c87"
   integrity sha512-rj8l8pD4bJ1nx+dAkMhV1xB5RuZEyVysfxJqB1pRchh1KVvwOv9b7CGB8ZfjTImVv2oF+sYMUkMZq6Na5Ftmbg==
+
+computeds@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/computeds/-/computeds-0.0.1.tgz#215b08a4ba3e08a11ff6eee5d6d8d7166a97ce2e"
+  integrity sha512-7CEBgcMjVmitjYo5q8JTJVra6X5mQ20uTThdK+0kR7UEaDrAWEQcRiBtWJzga4eRpP6afNwwLsX2SET2JhVB1Q==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -2712,6 +2890,11 @@ date-fns@^2.30.0:
   integrity sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==
   dependencies:
     "@babel/runtime" "^7.21.0"
+
+de-indent@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
+  integrity sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==
 
 debounce@^1.2.0:
   version "1.2.1"
@@ -3293,6 +3476,11 @@ estraverse@^5.1.0, estraverse@^5.2.0, estraverse@^5.3.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
+estree-walker@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
+  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -3475,6 +3663,15 @@ framer-motion@^10.16.4:
     tslib "^2.4.0"
   optionalDependencies:
     "@emotion/is-prop-valid" "^0.8.2"
+
+fs-extra@~7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -3679,7 +3876,7 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-graceful-fs@^4.1.2, graceful-fs@^4.2.4:
+graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.4:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -3827,6 +4024,11 @@ haversine-distance@^1.2.1:
   resolved "https://registry.yarnpkg.com/haversine-distance/-/haversine-distance-1.2.1.tgz#3b3a053890504925505273e96eba359042dc514b"
   integrity sha512-rQpG89d6NlAis0eqOSFXDqNU/GZcMPlHNVMqTSzD16niD9s1fDK8T6kwrK0WJ7OMU+iRNy3cgGYnNQihMqmaHg==
 
+he@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
 header-case@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/header-case/-/header-case-2.0.4.tgz#5a42e63b55177349cf405beb8d775acabb92c063"
@@ -3926,6 +4128,11 @@ import-from@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/import-from/-/import-from-4.0.0.tgz#2710b8d66817d232e16f4166e319248d3d5492e2"
   integrity sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==
+
+import-lazy@~4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-4.0.0.tgz#e8eb627483a0a43da3c03f3e35548be5cb0cc153"
+  integrity sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -4057,19 +4264,19 @@ is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.7:
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
   integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
 
+is-core-module@^2.1.0, is-core-module@^2.5.0:
+  version "2.13.1"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.13.1.tgz#ad0d7532c6fea9da1ebdc82742d74525c6273384"
+  integrity sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==
+  dependencies:
+    hasown "^2.0.0"
+
 is-core-module@^2.11.0, is-core-module@^2.13.0, is-core-module@^2.9.0:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.13.0.tgz#bb52aa6e2cbd49a30c2ba68c42bf3435ba6072db"
   integrity sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==
   dependencies:
     has "^1.0.3"
-
-is-core-module@^2.5.0:
-  version "2.13.1"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.13.1.tgz#ad0d7532c6fea9da1ebdc82742d74525c6273384"
-  integrity sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==
-  dependencies:
-    hasown "^2.0.0"
 
 is-date-object@^1.0.1, is-date-object@^1.0.5:
   version "1.0.5"
@@ -4295,6 +4502,11 @@ jiti@^1.17.1, jiti@^1.18.2:
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.20.0.tgz#2d823b5852ee8963585c8dd8b7992ffc1ae83b42"
   integrity sha512-3TV69ZbrvV6U5DfQimop50jE9Dl6J8O1ja1dvBbMba/sZ3YBEQqJ2VZRoQPVnhlzjNtU1vaXRZVrVjU4qtm8yA==
 
+jju@~1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/jju/-/jju-1.4.0.tgz#a3abe2718af241a2b2904f84a625970f389ae32a"
+  integrity sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==
+
 jose@^4.11.4:
   version "4.14.6"
   resolved "https://registry.yarnpkg.com/jose/-/jose-4.14.6.tgz#94dca1d04a0ad8c6bff0998cdb51220d473cc3af"
@@ -4374,6 +4586,13 @@ jsonc-parser@^3.2.0:
   resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.2.0.tgz#31ff3f4c2b9793f89c67212627c51c6394f88e76"
   integrity sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==
 
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  integrity sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 jsonify@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.1.tgz#2aa3111dae3d34a0f151c63f3a45d995d9420978"
@@ -4405,6 +4624,11 @@ kind-of@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+
+kolorist@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/kolorist/-/kolorist-1.8.0.tgz#edddbbbc7894bc13302cdf740af6374d4a04743c"
+  integrity sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==
 
 language-subtag-registry@~0.3.2:
   version "0.3.22"
@@ -4464,12 +4688,22 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
+
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@~4.17.0:
+lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@~4.17.0, lodash@~4.17.15:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -4669,7 +4903,7 @@ minimatch@^8.0.2:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@^9.0.1:
+minimatch@^9.0.1, minimatch@^9.0.3:
   version "9.0.3"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.3.tgz#a6e00c3de44c3a542bfaae70abfc22420a6da825"
   integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
@@ -4731,6 +4965,11 @@ ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+muggle-string@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/muggle-string/-/muggle-string-0.3.1.tgz#e524312eb1728c63dd0b2ac49e3282e6ed85963a"
+  integrity sha512-ckmWDJjphvd/FvZawgygcUeQCxzvohjFO5RxTjj4eq8kw359gFF3E1brjfI+viLMxss5JrHTDRHZvu2/tuy0Qg==
 
 murmurhash-js@^1.0.0:
   version "1.0.0"
@@ -5096,6 +5335,11 @@ pascal-case@^3.1.2:
     no-case "^3.0.4"
     tslib "^2.0.3"
 
+path-browserify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-1.0.1.tgz#d98454a9c3753d5790860f16f68867b9e46be1fd"
+  integrity sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==
+
 path-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/path-case/-/path-case-3.0.4.tgz#9168645334eb942658375c56f80b4c0cb5f82c6f"
@@ -5119,7 +5363,7 @@ path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-path-parse@^1.0.7:
+path-parse@^1.0.6, path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
@@ -5490,7 +5734,7 @@ resolve-protobuf-schema@^2.1.0:
   dependencies:
     protocol-buffers-schema "^3.3.1"
 
-resolve@^1.10.0:
+resolve@^1.10.0, resolve@~1.22.1:
   version "1.22.8"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.8.tgz#b6c87a9f2aa06dfab52e3d70ac8cde321fa5a48d"
   integrity sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==
@@ -5516,6 +5760,14 @@ resolve@^2.0.0-next.4:
     is-core-module "^2.9.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
+
+resolve@~1.19.0:
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.19.0.tgz#1af5bf630409734a067cae29318aac7fa29a267c"
+  integrity sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==
+  dependencies:
+    is-core-module "^2.1.0"
+    path-parse "^1.0.6"
 
 response-iterator@^0.2.6:
   version "0.2.6"
@@ -5648,7 +5900,7 @@ semver@^6.3.0, semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.3.4, semver@^7.5.4:
+semver@^7.3.4, semver@^7.5.4, semver@~7.5.4:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
@@ -5765,6 +6017,11 @@ source-map-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
+source-map@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
 space-separated-tokens@^1.0.0:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz#85f32c3d10d9682007e917414ddc5c26d1aa6899"
@@ -5803,6 +6060,11 @@ sponge-case@^1.0.1:
   dependencies:
     tslib "^2.0.3"
 
+sprintf-js@~1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+  integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
+
 stackback@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
@@ -5829,6 +6091,11 @@ streamsearch@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
+
+string-argv@~0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
+  integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
 string-env-interpolation@^1.0.1:
   version "1.0.1"
@@ -5928,7 +6195,7 @@ strip-indent@^3.0.0:
   dependencies:
     min-indent "^1.0.0"
 
-strip-json-comments@^3.1.1:
+strip-json-comments@^3.1.1, strip-json-comments@~3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
@@ -6192,6 +6459,11 @@ typescript@5.2.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
   integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
+typescript@~5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
+  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
+
 ua-parser-js@^1.0.35:
   version "1.0.36"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-1.0.36.tgz#a9ab6b9bd3a8efb90bb0816674b412717b7c428c"
@@ -6216,6 +6488,11 @@ unc-path-regex@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
   integrity sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==
+
+universalify@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
+  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
 unixify@^1.0.0:
   version "1.0.0"
@@ -6286,6 +6563,11 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
+validator@^13.7.0:
+  version "13.11.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.11.0.tgz#23ab3fd59290c61248364eabf4067f04955fbb1b"
+  integrity sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==
+
 value-or-promise@^1.0.11, value-or-promise@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/value-or-promise/-/value-or-promise-1.0.12.tgz#0e5abfeec70148c78460a849f6b003ea7986f15c"
@@ -6302,6 +6584,18 @@ vite-node@0.34.6:
     pathe "^1.1.1"
     picocolors "^1.0.0"
     vite "^3.0.0 || ^4.0.0 || ^5.0.0-0"
+
+vite-plugin-dts@^3.6.3:
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/vite-plugin-dts/-/vite-plugin-dts-3.6.3.tgz#7d79f2fe9352841f3b76cc38e8c16be957c9cdcb"
+  integrity sha512-NyRvgobl15rYj65coi/gH7UAEH+CpSjh539DbGb40DfOTZSvDLNYTzc8CK4460W+LqXuMK7+U3JAxRB3ksrNPw==
+  dependencies:
+    "@microsoft/api-extractor" "^7.38.0"
+    "@rollup/pluginutils" "^5.0.5"
+    "@vue/language-core" "^1.8.20"
+    debug "^4.3.4"
+    kolorist "^1.8.0"
+    vue-tsc "^1.8.20"
 
 "vite@^3.0.0 || ^4.0.0 || ^5.0.0-0", "vite@^3.1.0 || ^4.0.0 || ^5.0.0-0", vite@^4.4.9:
   version "4.4.9"
@@ -6352,6 +6646,23 @@ vt-pbf@^3.1.3:
     "@mapbox/point-geometry" "0.1.0"
     "@mapbox/vector-tile" "^1.3.1"
     pbf "^3.2.1"
+
+vue-template-compiler@^2.7.14:
+  version "2.7.15"
+  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.7.15.tgz#ec88ba8ceafe0f17a528b89c57e01e02da92b0de"
+  integrity sha512-yQxjxMptBL7UAog00O8sANud99C6wJF+7kgbcwqkvA38vCGF7HWE66w0ZFnS/kX5gSoJr/PQ4/oS3Ne2pW37Og==
+  dependencies:
+    de-indent "^1.0.2"
+    he "^1.2.0"
+
+vue-tsc@^1.8.20:
+  version "1.8.22"
+  resolved "https://registry.yarnpkg.com/vue-tsc/-/vue-tsc-1.8.22.tgz#421e73c38b50802a6716ca32ed87b5970c867323"
+  integrity sha512-j9P4kHtW6eEE08aS5McFZE/ivmipXy0JzrnTgbomfABMaVKx37kNBw//irL3+LlE3kOo63XpnRigyPC3w7+z+A==
+  dependencies:
+    "@volar/typescript" "~1.10.5"
+    "@vue/language-core" "1.8.22"
+    semver "^7.5.4"
 
 watchpack@2.4.0:
   version "2.4.0"
@@ -6618,6 +6929,17 @@ yocto-queue@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
   integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
+
+z-schema@~5.0.2:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/z-schema/-/z-schema-5.0.6.tgz#46d6a687b15e4a4369e18d6cb1c7b8618fc256c5"
+  integrity sha512-+XR1GhnWklYdfr8YaZv/iu+vY+ux7V5DS5zH1DQf6bO5ufrt/5cgNhVO5qyhsjFXvsqQb/f08DWE9b6uPscyAg==
+  dependencies:
+    lodash.get "^4.4.2"
+    lodash.isequal "^4.5.0"
+    validator "^13.7.0"
+  optionalDependencies:
+    commander "^10.0.0"
 
 zen-observable-ts@^1.2.5:
   version "1.2.5"


### PR DESCRIPTION
New example of usage:

```
  // Ensure that url base is same origin as the page where widget is loaded and the travel planner API
  const widget = window.PlannerWeb.createWidget({
    urlBase: 'https://reiseplanlegger.example.no/',
  });

  // After loading JS and CSS file it can be initialized using the following code:
  widget.init();

```


This simplifies build and allow us to bundle same asset files to staging and production. Integration strategy remains the same.


Part of https://github.com/AtB-AS/kundevendt/issues/14939