### PR TITLE
fix: message box colors for dark mode

### DIFF
--- a/src/modules/situations/situation-message-box.tsx
+++ b/src/modules/situations/situation-message-box.tsx
@@ -110,6 +110,7 @@ export const MessageBox = ({
   const { t } = useTranslation();
   const backgroundColorStyle = {
     backgroundColor: staticColors['status'][type].background,
+    color: staticColors['status'][type].text,
   };
 
   return (

--- a/src/modules/situations/situation.module.css
+++ b/src/modules/situations/situation.module.css
@@ -33,6 +33,7 @@
   border: none;
   border-radius: var(--border-radius-circle);
   background-color: var(--static-background-background_1-background);
+  color: var(--static-background-background_1-text);
 }
 
 .dialog::backdrop {
@@ -50,6 +51,7 @@
   gap: var(--spacings-medium);
   padding: var(--spacings-large);
   background-color: var(--static-background-background_0-background);
+  color: var(--static-background-background_0-text);
   border-radius: var(--border-radius-regular);
 }
 .dialog__button {


### PR DESCRIPTION
This PR adds the correct text color to the `MessageBox` component. 

![image](https://github.com/AtB-AS/planner-web/assets/43166974/8b61fb70-60e7-4dfb-b918-8cfb0f63d5c2)

![image](https://github.com/AtB-AS/planner-web/assets/43166974/6210c82c-b88c-4cc7-a661-1d42af09dafb)

Fixes https://github.com/AtB-AS/kundevendt/issues/15671