### PR TITLE
fix: set overrideMode for icon in MessageBox

### DIFF
--- a/src/components/message-box/index.tsx
+++ b/src/components/message-box/index.tsx
@@ -2,16 +2,19 @@ import { useTranslation } from '@atb/translations';
 import { Theme } from '@atb-as/theme';
 import { useTheme } from '@atb/modules/theme';
 import { andIf } from '@atb/utils/css';
-import { MonoIcon } from '@atb/components/icon';
+import { MonoIcon, MonoIconProps } from '@atb/components/icon';
 import { messageTypeToMonoIcon } from '@atb/modules/situations';
 import { Button } from '@atb/components/button';
 import dictionary from '@atb/translations/dictionary';
 import { Typo } from '@atb/components/typography';
 
 import style from './message-box.module.css';
+import { colorToOverrideMode } from '@atb/utils/color';
+
+export type MessageMode = keyof Theme['static']['status'];
 
 export type MessageBoxProps = {
-  type: keyof Theme['static']['status'];
+  type: MessageMode;
   title?: string;
   message: string;
   noStatusIcon?: boolean;
@@ -33,6 +36,7 @@ export const MessageBox = ({
     backgroundColor: staticColors['status'][type].background,
     color: staticColors['status'][type].text,
   };
+  const overrideMode = useStatusThemeColor(type);
 
   return (
     <div
@@ -43,7 +47,11 @@ export const MessageBox = ({
       style={backgroundColorStyle}
     >
       {!noStatusIcon && (
-        <MonoIcon className={style.icon} icon={messageTypeToMonoIcon(type)} />
+        <MonoIcon
+          className={style.icon}
+          icon={messageTypeToMonoIcon(type)}
+          overrideMode={overrideMode}
+        />
       )}
       <div className={style.content}>
         {title && (
@@ -67,3 +75,28 @@ export const MessageBox = ({
     </div>
   );
 };
+
+function useStatusThemeColor(mode: MessageMode): MonoIconProps['overrideMode'] {
+  const {
+    static: { status },
+  } = useTheme();
+
+  let overrideColor: MonoIconProps['overrideMode'] = undefined;
+
+  switch (mode) {
+    case 'error':
+      overrideColor = colorToOverrideMode(status.error.text);
+      break;
+    case 'valid':
+      overrideColor = colorToOverrideMode(status.valid.text);
+      break;
+    case 'warning':
+      overrideColor = colorToOverrideMode(status.warning.text);
+      break;
+    case 'info':
+      overrideColor = colorToOverrideMode(status.info.text);
+      break;
+  }
+
+  return overrideColor;
+}


### PR DESCRIPTION
Fixes wrong color of icon in light mode.

https://github.com/AtB-AS/kundevendt/issues/15347