### PR TITLE
feat: support from / to individually from URL

### DIFF
--- a/src/components/map/map-header.tsx
+++ b/src/components/map/map-header.tsx
@@ -59,13 +59,13 @@ export function MapHeader({ id, name, layer, transportModes }: MapHeaderProps) {
         <div className={style.header__buttons}>
           <ButtonLink
             mode="interactive_0"
-            href={`/?travelFrom=${id}`}
+            href={`/planner?travelFrom=${id}`}
             title={t(ComponentText.Map.button.travelFrom)}
             className={style.header__button}
           />
           <ButtonLink
             mode="interactive_0"
-            href={`/?travelTo=${id}`}
+            href={`/planner?travelTo=${id}`}
             title={t(ComponentText.Map.button.travelTo)}
             className={style.header__button}
           />

--- a/src/components/map/map-header.tsx
+++ b/src/components/map/map-header.tsx
@@ -59,13 +59,13 @@ export function MapHeader({ id, name, layer, transportModes }: MapHeaderProps) {
         <div className={style.header__buttons}>
           <ButtonLink
             mode="interactive_0"
-            href={`/planner?travelFrom=${id}`}
+            href={`/?travelFrom=${id}`}
             title={t(ComponentText.Map.button.travelFrom)}
             className={style.header__button}
           />
           <ButtonLink
             mode="interactive_0"
-            href={`/planner?travelTo=${id}`}
+            href={`/?travelTo=${id}`}
             title={t(ComponentText.Map.button.travelTo)}
             className={style.header__button}
           />

--- a/src/modules/api-server/external-client.ts
+++ b/src/modules/api-server/external-client.ts
@@ -29,12 +29,6 @@ type HttpPropGetter<
 export type ExternalClient<U extends AllEndpoints, T> = T & {
   client: ConditionalRequester<U>;
 };
-export type ComposeExternalClient<
-  U1 extends AllEndpoints,
-  T1,
-  U2 extends AllEndpoints,
-  T2,
-> = ExternalClient<U1, T1> & ExternalClient<U2, T2>;
 
 export type ExternalClientFactory<U extends AllEndpoints, T> = (
   req?: IncomingMessage,

--- a/src/modules/api-server/external-client.ts
+++ b/src/modules/api-server/external-client.ts
@@ -29,6 +29,13 @@ type HttpPropGetter<
 export type ExternalClient<U extends AllEndpoints, T> = T & {
   client: ConditionalRequester<U>;
 };
+export type ComposeExternalClient<
+  U1 extends AllEndpoints,
+  T1,
+  U2 extends AllEndpoints,
+  T2,
+> = ExternalClient<U1, T1> & ExternalClient<U2, T2>;
+
 export type ExternalClientFactory<U extends AllEndpoints, T> = (
   req?: IncomingMessage,
 ) => ExternalClient<U, T>;

--- a/src/page-modules/assistant/__tests__/assistant.test.tsx
+++ b/src/page-modules/assistant/__tests__/assistant.test.tsx
@@ -3,7 +3,11 @@ import mockRouter from 'next-router-mock';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ExternalClient } from '@atb/modules/api-server';
 import { JourneyPlannerApi } from '../server/journey-planner';
-import { getServerSideProps } from '@atb/pages/assistant';
+import {
+  AssistantContentProps,
+  AssistantPageProps,
+  getServerSideProps,
+} from '@atb/pages/assistant';
 import { expectProps } from '@atb/tests/utils';
 import { createDynamicRouteParser } from 'next-router-mock/dynamic-routes';
 import { GeocoderApi } from '@atb/page-modules/departures/server/geocoder';
@@ -72,12 +76,16 @@ describe('assistant page', function () {
       ...context,
     } as any);
 
-    (await expectProps(result)).toMatchObject({
-      initialFromFeature: fromFeature,
-      initialToFeature: toFeature,
-      initialSearchTime: {
-        mode: 'departBy',
-        dateTime: 123,
+    (await expectProps(result)).toMatchObject<AssistantContentProps>({
+      tripQuery: {
+        from: fromFeature,
+        to: toFeature,
+        searchTime: {
+          mode: 'departBy',
+          dateTime: 123,
+        },
+        transportModeFilter: null,
+        cursor: null,
       },
       trip: tripResult,
       nonTransitTrips: nonTransitTripResult,

--- a/src/page-modules/assistant/__tests__/assistant.test.tsx
+++ b/src/page-modules/assistant/__tests__/assistant.test.tsx
@@ -93,7 +93,17 @@ describe('assistant page', function () {
   });
 
   it('should render assistant page header', () => {
-    render(<AssistantLayout />);
+    render(
+      <AssistantLayout
+        tripQuery={{
+          from: null,
+          to: null,
+          searchTime: { mode: 'now' },
+          cursor: null,
+          transportModeFilter: null,
+        }}
+      />,
+    );
 
     expect(screen.getByText('Fra')).toBeInTheDocument();
     expect(screen.getByText('Til')).toBeInTheDocument();
@@ -115,12 +125,15 @@ describe('assistant page', function () {
   it('should render empty search results', () => {
     const output = render(
       <Trip
-        initialFromFeature={fromFeature}
-        initialToFeature={toFeature}
+        tripQuery={{
+          from: fromFeature,
+          to: toFeature,
+          searchTime: { mode: 'departBy', dateTime: Date.now() },
+          transportModeFilter: null,
+          cursor: null,
+        }}
         trip={{ ...tripResult, tripPatterns: [] }}
-        initialSearchTime={{ mode: 'departBy', dateTime: Date.now() }}
         nonTransitTrips={nonTransitTripResult}
-        initialTransportModesFilter={null}
       />,
     );
 
@@ -136,12 +149,15 @@ describe('assistant page', function () {
   it('should render empty search results with filter details', () => {
     const output = render(
       <Trip
-        initialFromFeature={fromFeature}
-        initialToFeature={toFeature}
+        tripQuery={{
+          from: fromFeature,
+          to: toFeature,
+          searchTime: { mode: 'departBy', dateTime: Date.now() },
+          transportModeFilter: ['bus'],
+          cursor: null,
+        }}
         trip={{ ...tripResult, tripPatterns: [] }}
-        initialSearchTime={{ mode: 'departBy', dateTime: Date.now() }}
         nonTransitTrips={nonTransitTripResult}
-        initialTransportModesFilter={['bus']}
       />,
     );
 

--- a/src/page-modules/assistant/index.ts
+++ b/src/page-modules/assistant/index.ts
@@ -1,9 +1,6 @@
 export * from './types';
 export { parseTripQuery } from './utils';
-export {
-  fetchFromToTripQuery,
-  type FromToTripQuery,
-} from './trip-query-fetcher';
+export { fetchFromToTripQuery } from './trip-query-fetcher';
 export type { AssistantLayoutProps } from './layout';
 export { default as AssistantLayout } from './layout';
 

--- a/src/page-modules/assistant/index.ts
+++ b/src/page-modules/assistant/index.ts
@@ -1,5 +1,9 @@
 export * from './types';
-export { parseTripQuery, createTripQuery } from './utils';
+export { parseTripQuery } from './utils';
+export {
+  fetchFromToTripQuery,
+  type FromToTripQuery,
+} from './trip-query-fetcher';
 export type { AssistantLayoutProps } from './layout';
 export { default as AssistantLayout } from './layout';
 

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@atb/components/button';
-import EmptySearch from '@atb/components/loading-empty-results';
 import { MonoIcon } from '@atb/components/icon';
+import EmptySearch from '@atb/components/loading-empty-results';
+import { MessageBox } from '@atb/components/message-box';
 import Search, { GeolocationButton, SwapButton } from '@atb/components/search';
 import { Typo } from '@atb/components/typography';
 import type { SearchTime } from '@atb/modules/search-time';
@@ -8,7 +9,6 @@ import SearchTimeSelector from '@atb/modules/search-time/selector';
 import {
   TransportModeFilter,
   getInitialTransportModeFilter,
-  type TransportModeFilterOption,
 } from '@atb/modules/transport-mode';
 import type { GeocoderFeature } from '@atb/page-modules/departures';
 import { PageText, useTranslation } from '@atb/translations';
@@ -17,9 +17,8 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { useRouter } from 'next/router';
 import { FormEventHandler, PropsWithChildren, useState } from 'react';
 import style from './assistant.module.css';
-import { createTripQuery } from './utils';
-import { MessageBox } from '@atb/components/message-box';
 import { FromToTripQuery } from './trip-query-fetcher';
+import { createTripQuery } from './utils';
 
 export type AssistantLayoutProps = PropsWithChildren<{
   tripQuery: FromToTripQuery;

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -19,36 +19,28 @@ import { FormEventHandler, PropsWithChildren, useState } from 'react';
 import style from './assistant.module.css';
 import { createTripQuery } from './utils';
 import { MessageBox } from '@atb/components/message-box';
+import { FromToTripQuery } from './trip-query-fetcher';
 
 export type AssistantLayoutProps = PropsWithChildren<{
-  initialFromFeature?: GeocoderFeature;
-  initialToFeature?: GeocoderFeature;
-  initialTransportModesFilter?: TransportModeFilterOption[] | null;
-  initialSearchTime?: SearchTime;
+  tripQuery: FromToTripQuery;
 }>;
 
-function AssistantLayout({
-  children,
-  initialFromFeature,
-  initialToFeature,
-  initialTransportModesFilter,
-  initialSearchTime,
-}: AssistantLayoutProps) {
+function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
   const { t } = useTranslation();
   const router = useRouter();
 
   const [showAlternatives, setShowAlternatives] = useState(false);
   const [selectedFromFeature, setSelectedFromFeature] = useState<
     GeocoderFeature | undefined
-  >(initialFromFeature);
+  >(tripQuery.from ?? undefined);
   const [selectedToFeature, setSelectedToFeature] = useState<
     GeocoderFeature | undefined
-  >(initialToFeature);
+  >(tripQuery.to ?? undefined);
   const [searchTime, setSearchTime] = useState<SearchTime>(
-    initialSearchTime ?? { mode: 'now' },
+    tripQuery.searchTime,
   );
   const [transportModeFilter, setTransportModeFilter] = useState(
-    getInitialTransportModeFilter(initialTransportModesFilter),
+    getInitialTransportModeFilter(tripQuery.transportModeFilter),
   );
   const [isSwapping, setIsSwapping] = useState(false);
   const [isSearching, setIsSearching] = useState(false);
@@ -104,7 +96,7 @@ function AssistantLayout({
             <Search
               label={t(PageText.Assistant.search.input.from)}
               onChange={setSelectedFromFeature}
-              initialFeature={initialFromFeature}
+              initialFeature={tripQuery.from ?? undefined}
               selectedItem={selectedFromFeature}
               button={
                 <GeolocationButton
@@ -117,7 +109,7 @@ function AssistantLayout({
             <Search
               label={t(PageText.Assistant.search.input.to)}
               onChange={setSelectedToFeature}
-              initialFeature={initialToFeature}
+              initialFeature={tripQuery.to ?? undefined}
               selectedItem={selectedToFeature}
               button={
                 <SwapButton

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -17,8 +17,9 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { useRouter } from 'next/router';
 import { FormEventHandler, PropsWithChildren, useState } from 'react';
 import style from './assistant.module.css';
-import { FromToTripQuery } from './trip-query-fetcher';
 import { createTripQuery } from './utils';
+import { FromToTripQuery } from './types';
+import trip from '@atb/pages/api/assistant/trip';
 
 export type AssistantLayoutProps = PropsWithChildren<{
   tripQuery: FromToTripQuery;
@@ -48,12 +49,7 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
   const onSwap = async () => {
     if (!selectedToFeature || !selectedFromFeature) return;
     setIsSwapping(true);
-    const query = createTripQuery(
-      selectedToFeature,
-      selectedFromFeature,
-      searchTime,
-      transportModeFilter,
-    );
+    const query = createTripQuery(tripQuery, transportModeFilter);
     const temp = selectedFromFeature;
     setSelectedFromFeature(selectedToFeature);
     setSelectedToFeature(temp);
@@ -68,12 +64,7 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
     e.preventDefault();
     if (!selectedFromFeature || !selectedToFeature) return;
     setIsSearching(true);
-    const query = createTripQuery(
-      selectedFromFeature,
-      selectedToFeature,
-      searchTime,
-      transportModeFilter,
-    );
+    const query = createTripQuery(tripQuery, transportModeFilter);
     await router.push({ pathname: '/assistant', query });
     setIsSearching(false);
   };

--- a/src/page-modules/assistant/server/index.ts
+++ b/src/page-modules/assistant/server/index.ts
@@ -17,9 +17,10 @@ export const journeyClient = createExternalClient(
   createJourneyApi,
 );
 
-export const withAssistantClient = createWithExternalClientDecorator(
-  composeClientFactories(journeyClient, geocoderClient),
-);
+const composed = composeClientFactories(journeyClient, geocoderClient);
+export const withAssistantClient = createWithExternalClientDecorator(composed);
+
+export type AssistantClient = ReturnType<typeof composed>;
 
 export const handlerWithAssistantClient =
   createWithExternalClientDecoratorForHttpHandlers(

--- a/src/page-modules/assistant/trip-query-fetcher.ts
+++ b/src/page-modules/assistant/trip-query-fetcher.ts
@@ -1,21 +1,12 @@
-import { SearchTime, parseSearchTimeQuery } from '@atb/modules/search-time';
-import {
-  TransportModeFilterOption,
-  parseFilterQuery,
-} from '@atb/modules/transport-mode';
+import { parseSearchTimeQuery } from '@atb/modules/search-time';
+import { parseFilterQuery } from '@atb/modules/transport-mode';
 import { GeocoderFeature } from '@atb/page-modules/departures';
 import { ParsedUrlQuery } from 'querystring';
 import { TripQuery } from '.';
 import { AssistantClient } from './server';
+import { FromToTripQuery } from './types';
 import { parseTripQuery } from './utils';
 
-export type FromToTripQuery = {
-  from: GeocoderFeature | null;
-  to: GeocoderFeature | null;
-  transportModeFilter: TransportModeFilterOption[] | null;
-  searchTime: SearchTime;
-  cursor: string | null;
-};
 export async function fetchFromToTripQuery(
   query: ParsedUrlQuery,
   client: AssistantClient,

--- a/src/page-modules/assistant/trip-query-fetcher.ts
+++ b/src/page-modules/assistant/trip-query-fetcher.ts
@@ -1,0 +1,74 @@
+import { SearchTime, parseSearchTimeQuery } from '@atb/modules/search-time';
+import {
+  TransportModeFilterOption,
+  parseFilterQuery,
+} from '@atb/modules/transport-mode';
+import { GeocoderFeature } from '@atb/page-modules/departures';
+import { ParsedUrlQuery } from 'querystring';
+import { TripQuery } from '.';
+import { AssistantClient } from './server';
+import { parseTripQuery } from './utils';
+
+export type FromToTripQuery = {
+  from: GeocoderFeature | null;
+  to: GeocoderFeature | null;
+  transportModeFilter: TransportModeFilterOption[] | null;
+  searchTime: SearchTime;
+  cursor: string | null;
+};
+export async function fetchFromToTripQuery(
+  query: ParsedUrlQuery,
+  client: AssistantClient,
+): Promise<FromToTripQuery> {
+  const tripQuery = parseTripQuery(query);
+  const cursor = tripQuery?.cursor;
+  const transportModeFilter = parseFilterQuery(tripQuery?.filter);
+  const searchTime = parseSearchTimeQuery(
+    tripQuery?.searchMode,
+    tripQuery?.searchTime,
+  );
+
+  let fromP: Promise<GeocoderFeature | undefined> | undefined = undefined;
+  let toP: Promise<GeocoderFeature | undefined> | undefined = undefined;
+
+  if (!fromP && hasFromLatLon(tripQuery)) {
+    fromP = client.reverse(
+      tripQuery.fromLat,
+      tripQuery.fromLon,
+      tripQuery.fromLayer,
+    );
+  }
+
+  if (hasToLatLon(tripQuery)) {
+    toP = client.reverse(tripQuery.toLat, tripQuery.toLon, tripQuery.toLayer);
+  }
+
+  const [from, to] = await Promise.all([fromP, toP]);
+
+  return {
+    from: from ?? null,
+    to: to ?? null,
+    transportModeFilter,
+    searchTime,
+    cursor: cursor ?? null,
+  };
+}
+
+function hasFromLatLon(
+  query: TripQuery | undefined,
+): query is Required<Pick<TripQuery, 'fromLat' | 'fromLayer' | 'fromLon'>> {
+  return (
+    query?.fromLon !== undefined &&
+    query?.fromLat !== undefined &&
+    query?.fromLayer !== undefined
+  );
+}
+function hasToLatLon(
+  query: TripQuery | undefined,
+): query is Required<Pick<TripQuery, 'toLat' | 'toLayer' | 'toLon'>> {
+  return (
+    query?.toLon !== undefined &&
+    query?.toLat !== undefined &&
+    query?.toLayer !== undefined
+  );
+}

--- a/src/page-modules/assistant/trip/index.tsx
+++ b/src/page-modules/assistant/trip/index.tsx
@@ -30,27 +30,18 @@ import {
   getInitialTransportModeFilter,
   type TransportModeFilterOption,
 } from '@atb/modules/transport-mode';
+import { FromToTripQuery } from '../trip-query-fetcher';
 
 export type TripProps = {
-  initialFromFeature: GeocoderFeature;
-  initialToFeature: GeocoderFeature;
-  initialTransportModesFilter: TransportModeFilterOption[] | null;
-  initialSearchTime: SearchTime;
+  tripQuery: FromToTripQuery;
   trip: TripData;
   nonTransitTrips: NonTransitTripData;
 };
 
-export default function Trip({
-  initialFromFeature,
-  initialToFeature,
-  initialTransportModesFilter,
-  initialSearchTime,
-  trip,
-  nonTransitTrips,
-}: TripProps) {
+export default function Trip({ tripQuery, trip, nonTransitTrips }: TripProps) {
   const { t } = useTranslation();
   const { tripPatterns, fetchNextTripPatterns, isFetchingTripPatterns } =
-    useTripPatterns(trip, initialSearchTime);
+    useTripPatterns(trip, tripQuery.searchTime);
 
   const nonTransits = Object.entries(nonTransitTrips);
 
@@ -61,7 +52,7 @@ export default function Trip({
           PageText.Assistant.trip.emptySearchResults.emptySearchResultsTitle,
         )}
         details={
-          initialTransportModesFilter
+          tripQuery.transportModeFilter
             ? t(
                 PageText.Assistant.trip.emptySearchResults
                   .emptySearchResultsDetailsWithFilters,
@@ -108,9 +99,9 @@ export default function Trip({
         className={style.fetchButton}
         onClick={() =>
           fetchNextTripPatterns(
-            initialFromFeature,
-            initialToFeature,
-            initialTransportModesFilter || undefined,
+            tripQuery.from!,
+            tripQuery.to!,
+            tripQuery.transportModeFilter || undefined,
           )
         }
         title={t(PageText.Assistant.trip.fetchMore)}

--- a/src/page-modules/assistant/trip/index.tsx
+++ b/src/page-modules/assistant/trip/index.tsx
@@ -12,7 +12,7 @@ import { PageText, useTranslation } from '@atb/translations';
 import { Typo } from '@atb/components/typography';
 import { GeocoderFeature } from '@atb/page-modules/departures';
 import { nextTripPatterns } from '../client';
-import { NonTransitTripData } from '../types';
+import { FromToTripQuery, NonTransitTripData } from '../types';
 import {
   createTripQuery,
   filterOutDuplicates,
@@ -30,7 +30,6 @@ import {
   getInitialTransportModeFilter,
   type TransportModeFilterOption,
 } from '@atb/modules/transport-mode';
-import { FromToTripQuery } from '../trip-query-fetcher';
 
 export type TripProps = {
   tripQuery: FromToTripQuery;
@@ -132,11 +131,14 @@ function useTripPatterns(initialTrip: TripData, searchTime: SearchTime) {
   ) => {
     setIsFetchingTripPatterns(true);
     const tripQuery = createTripQuery(
-      from,
-      to,
-      searchTime,
+      {
+        from,
+        to,
+        searchTime,
+        transportModeFilter: [],
+        cursor: cursor,
+      },
       getInitialTransportModeFilter(filter),
-      cursor || undefined,
     );
     const trip = await nextTripPatterns(tripQuery);
     const newTripPatternsWithTransitionDelay = tripPatternsWithTransitionDelay(

--- a/src/page-modules/assistant/types.ts
+++ b/src/page-modules/assistant/types.ts
@@ -16,16 +16,16 @@ export type TripInput = {
 };
 
 export const TripQuerySchema = z.object({
-  fromId: z.string(),
-  fromLon: z.number(),
-  fromLat: z.number(),
-  fromLayer: z.union([z.literal('address'), z.literal('venue')]),
-  toId: z.string(),
-  toLon: z.number(),
-  toLat: z.number(),
-  toLayer: z.union([z.literal('address'), z.literal('venue')]),
+  fromId: z.string().optional(),
+  fromLon: z.number().optional(),
+  fromLat: z.number().optional(),
+  fromLayer: z.union([z.literal('address'), z.literal('venue')]).optional(),
+  toId: z.string().optional(),
+  toLon: z.number().optional(),
+  toLat: z.number().optional(),
+  toLayer: z.union([z.literal('address'), z.literal('venue')]).optional(),
   filter: z.string().optional(),
-  searchMode: searchModeSchema,
+  searchMode: searchModeSchema.optional(),
   searchTime: z.number().optional(),
   cursor: z.string().optional(),
 });

--- a/src/page-modules/assistant/types.ts
+++ b/src/page-modules/assistant/types.ts
@@ -5,7 +5,10 @@ import type {
   TripData,
 } from './server/journey-planner/validators';
 import { searchModeSchema, type SearchTime } from '@atb/modules/search-time';
-import { type TransportModeType } from '@atb/modules/transport-mode';
+import {
+  TransportModeFilterOption,
+  type TransportModeType,
+} from '@atb/modules/transport-mode';
 
 export type TripInput = {
   from: GeocoderFeature;
@@ -13,6 +16,14 @@ export type TripInput = {
   searchTime: SearchTime;
   transportModes?: TransportModeType[];
   cursor?: string;
+};
+
+export type FromToTripQuery = {
+  from: GeocoderFeature | null;
+  to: GeocoderFeature | null;
+  transportModeFilter: TransportModeFilterOption[] | null;
+  searchTime: SearchTime;
+  cursor: string | null;
 };
 
 export const TripQuerySchema = z.object({

--- a/src/page-modules/assistant/utils.ts
+++ b/src/page-modules/assistant/utils.ts
@@ -72,13 +72,13 @@ export function createTripQuery(
 }
 
 export function parseTripQuery(query: any): TripQuery | undefined {
-  const requiredNumericFields = ['fromLat', 'fromLon', 'toLat', 'toLon'];
-  requiredNumericFields.forEach((field) => {
-    if (typeof query[field] === 'string')
-      query[field] = parseFloat(query[field]);
-  });
-
-  const optionalNumericFields = ['searchTime'];
+  const optionalNumericFields = [
+    'fromLat',
+    'fromLon',
+    'toLat',
+    'toLon',
+    'searchTime',
+  ];
   optionalNumericFields.forEach((field) => {
     if (query[field] && typeof query[field] === 'string')
       query[field] = Number(query[field]);

--- a/src/pages/assistant/index.tsx
+++ b/src/pages/assistant/index.tsx
@@ -14,7 +14,7 @@ import {
 import { withAssistantClient } from '@atb/page-modules/assistant/server';
 import type { NextPage } from 'next';
 
-type AssistantContentProps = { tripQuery: FromToTripQuery } | TripProps;
+export type AssistantContentProps = { tripQuery: FromToTripQuery } | TripProps;
 
 export type AssistantPageProps = WithGlobalData<
   AssistantLayoutProps & AssistantContentProps

--- a/src/pages/assistant/index.tsx
+++ b/src/pages/assistant/index.tsx
@@ -1,23 +1,20 @@
 import DefaultLayout from '@atb/layouts/default';
-import { type WithGlobalData, withGlobalData } from '@atb/layouts/global-data';
-import { withAssistantClient } from '@atb/page-modules/assistant/server';
+import { withGlobalData, type WithGlobalData } from '@atb/layouts/global-data';
+import { getAllTransportModesFromFilterOptions } from '@atb/modules/transport-mode';
 import {
   AssistantLayout,
-  type AssistantLayoutProps,
-  parseTripQuery,
+  fetchFromToTripQuery,
   StreetMode,
   Trip,
+  type AssistantLayoutProps,
+  type FromToTripQuery,
   type TripData,
   type TripProps,
 } from '@atb/page-modules/assistant';
+import { withAssistantClient } from '@atb/page-modules/assistant/server';
 import type { NextPage } from 'next';
-import { parseSearchTimeQuery } from '@atb/modules/search-time';
-import {
-  getAllTransportModesFromFilterOptions,
-  parseFilterQuery,
-} from '@atb/modules/transport-mode';
 
-type AssistantContentProps = { empty: true } | TripProps;
+type AssistantContentProps = { tripQuery: FromToTripQuery } | TripProps;
 
 export type AssistantPageProps = WithGlobalData<
   AssistantLayoutProps & AssistantContentProps
@@ -30,7 +27,7 @@ function AssistantContent(props: AssistantContentProps) {
 }
 
 function isTripDataProps(a: any): a is { trip: TripData } {
-  return 'trip' in a;
+  return 'trip' in a && a.trip;
 }
 
 const AssistantPage: NextPage<AssistantPageProps> = (props) => {
@@ -48,59 +45,39 @@ export default AssistantPage;
 export const getServerSideProps = withGlobalData(
   withAssistantClient<AssistantLayoutProps & AssistantContentProps>(
     async function ({ client, query }) {
-      const tripQuery = parseTripQuery(query);
-      if (tripQuery) {
-        const [from, to] = await Promise.all([
-          client.reverse(
-            tripQuery.fromLat,
-            tripQuery.fromLon,
-            tripQuery.fromLayer,
-          ),
-          await client.reverse(
-            tripQuery.toLat,
-            tripQuery.toLon,
-            tripQuery.toLayer,
-          ),
-        ]);
-        const transportModeFilter = parseFilterQuery(tripQuery.filter);
+      const tripQuery = await fetchFromToTripQuery(query, client);
 
-        const searchTime = parseSearchTimeQuery(
-          tripQuery.searchMode,
-          tripQuery.searchTime,
-        );
-
-        if (from && to) {
-          const [trip, nonTransitTrips] = await Promise.all([
-            client.trip({
-              from,
-              to,
-              searchTime,
-              transportModes:
-                getAllTransportModesFromFilterOptions(transportModeFilter),
-            }),
-            client.nonTransitTrips({
-              from,
-              to,
-              searchTime,
-              directModes: [StreetMode.Foot, StreetMode.Bicycle],
-            }),
-          ]);
-
-          return {
-            props: {
-              initialFromFeature: from,
-              initialToFeature: to,
-              initialTransportModesFilter: transportModeFilter,
-              initialSearchTime: searchTime,
-              trip,
-              nonTransitTrips,
-            },
-          };
-        }
+      if (!tripQuery.from || !tripQuery.to) {
+        return {
+          props: {
+            tripQuery,
+          },
+        };
       }
+
+      const { from, to, searchTime, transportModeFilter } = tripQuery;
+
+      const [trip, nonTransitTrips] = await Promise.all([
+        client.trip({
+          from,
+          to,
+          searchTime,
+          transportModes:
+            getAllTransportModesFromFilterOptions(transportModeFilter),
+        }),
+        client.nonTransitTrips({
+          from,
+          to,
+          searchTime,
+          directModes: [StreetMode.Foot, StreetMode.Bicycle],
+        }),
+      ]);
+
       return {
         props: {
-          empty: true,
+          tripQuery,
+          trip,
+          nonTransitTrips,
         },
       };
     },


### PR DESCRIPTION
This adds ability to set from and to independently from the URL. It also refactors and simplifies using from/to in the assistant component as to not using state.

Every time we use URL we should use that as a state also. This simplifies things usually, and will make sure the two states doesn't get out of sync.

More URL navigation also shows the slowness of trip API more. Should definitely move trip search to be client side only.


There is still som type mess here and there that I'm not quite happy about. But didn't take the time to fix it here. E.g. Assistant referencing Departure etc.


Things to test out:

- [ ] Works as expected with search, swap, geolocation.
- [ ] Works as expected with submit
- [ ] Filters
- [ ] Search time
- [ ] Load more
- [ ] Load more when search time
- [ ] Filters and load more