### PR TITLE
refactor: make departure state query handling consistant with assistant

### DIFF
--- a/src/page-modules/departures/__tests__/departure.test.tsx
+++ b/src/page-modules/departures/__tests__/departure.test.tsx
@@ -129,7 +129,15 @@ describe('departure page', function () {
 
   it('should render empty search results', () => {
     const output = render(
-      <NearestStopPlaces activeLocation={undefined} nearestStopPlaces={[]} />,
+      <NearestStopPlaces
+        fromQuery={{
+          searchTime: { mode: 'now' },
+          from: null,
+          isAddress: false,
+          transportModeFilter: null,
+        }}
+        nearestStopPlaces={[]}
+      />,
     );
     expect(
       output.getByText('Finner ingen holdeplasser i nærheten'),

--- a/src/page-modules/departures/fetch-departure-query.ts
+++ b/src/page-modules/departures/fetch-departure-query.ts
@@ -1,0 +1,54 @@
+import { parseSearchTimeQuery } from '@atb/modules/search-time';
+import { parseFilterQuery } from '@atb/modules/transport-mode';
+import type { DepartureClient } from './server';
+import type { FromDepartureQuery } from './types';
+
+export async function fetchFromDepartureQuery(
+  paramId: string[] | undefined,
+  query: any,
+  client: DepartureClient,
+): Promise<FromDepartureQuery> {
+  const id = paramId?.[0];
+  const transportModeFilter = parseFilterQuery(query.filter);
+  const searchTime = parseSearchTimeQuery(
+    query.searchMode,
+    query.searchTime ? Number(query.searchTime) : undefined,
+  );
+
+  if (id) {
+    const stopPlace = await client.stopPlace({ id });
+    const from = await client.reverse(
+      stopPlace.position.lat,
+      stopPlace.position.lon,
+      'venue',
+    );
+
+    return {
+      isAddress: false,
+      transportModeFilter,
+      searchTime,
+      from: from ?? null,
+    };
+  } else if (query.lat && query.lon) {
+    const position = {
+      lat: parseFloat(query.lat.toString()),
+      lon: parseFloat(query.lon.toString()),
+    };
+
+    const from = await client.reverse(position.lat, position.lon, 'address');
+
+    return {
+      isAddress: true,
+      from: from ?? null,
+      transportModeFilter,
+      searchTime,
+    };
+  }
+
+  return {
+    from: null,
+    isAddress: false,
+    transportModeFilter,
+    searchTime,
+  };
+}

--- a/src/page-modules/departures/nearest-stop-places/index.tsx
+++ b/src/page-modules/departures/nearest-stop-places/index.tsx
@@ -1,5 +1,5 @@
 import { MapWithHeader } from '@atb/components/map';
-import { GeocoderFeature } from '../types';
+import { FromDepartureQuery, GeocoderFeature } from '../types';
 import {
   NearestStopPlacesData,
   StopPlaceWithDistance,
@@ -14,13 +14,13 @@ import EmptyMessage from '@atb/components/empty-message';
 import { SituationOrNoticeIcon } from '@atb/modules/situations';
 
 export type NearestStopPlacesProps = {
-  activeLocation: GeocoderFeature | undefined;
+  fromQuery: FromDepartureQuery;
   nearestStopPlaces: NearestStopPlacesData;
 };
 
 export function NearestStopPlaces({
   nearestStopPlaces,
-  activeLocation,
+  fromQuery,
 }: NearestStopPlacesProps) {
   const { t } = useTranslation();
   const router = useRouter();
@@ -42,14 +42,14 @@ export function NearestStopPlaces({
   return (
     <section className={style.nearestContainer}>
       <div className={style.mapContainer}>
-        {activeLocation && (
+        {fromQuery.from && (
           <MapWithHeader
-            id={activeLocation.id}
-            name={activeLocation.name}
+            id={fromQuery.from.id}
+            name={fromQuery.from.name}
             layer="address"
             position={{
-              lon: activeLocation.geometry.coordinates[0],
-              lat: activeLocation.geometry.coordinates[1],
+              lon: fromQuery.from.geometry.coordinates[0],
+              lat: fromQuery.from.geometry.coordinates[1],
             }}
             onSelectStopPlace={(stopPlaceId) =>
               router.push(`/departures/${stopPlaceId}`)

--- a/src/page-modules/departures/server/index.ts
+++ b/src/page-modules/departures/server/index.ts
@@ -17,9 +17,9 @@ export const journeyClient = createExternalClient(
   createJourneyApi,
 );
 
-export const withDepartureClient = createWithExternalClientDecorator(
-  composeClientFactories(departureClient, journeyClient),
-);
+const composed = composeClientFactories(departureClient, journeyClient);
+export const withDepartureClient = createWithExternalClientDecorator(composed);
+export type DepartureClient = ReturnType<typeof composed>;
 
 export const handlerWithDepartureClient =
   createWithExternalClientDecoratorForHttpHandlers(

--- a/src/page-modules/departures/types.ts
+++ b/src/page-modules/departures/types.ts
@@ -1,5 +1,7 @@
-import { FeatureCategory } from '@atb/components/venue-icon';
-import { ServiceJourneyData } from './server/journey-planner/validators';
+import type { FeatureCategory } from '@atb/components/venue-icon';
+import type { ServiceJourneyData } from './server/journey-planner/validators';
+import type { TransportModeFilterOption } from '@atb/modules/transport-mode';
+import type { SearchTime } from '@atb/modules/search-time';
 
 export type GeocoderFeature = {
   id: string;
@@ -11,6 +13,13 @@ export type GeocoderFeature = {
     coordinates: number[];
   };
   street?: string;
+};
+
+export type FromDepartureQuery = {
+  transportModeFilter: TransportModeFilterOption[] | null;
+  searchTime: SearchTime;
+  from: GeocoderFeature | null;
+  isAddress: boolean;
 };
 
 export type EstimatedCallMetadata = {

--- a/src/page-modules/departures/utils.ts
+++ b/src/page-modules/departures/utils.ts
@@ -1,0 +1,60 @@
+import {
+  TransportModeFilterState,
+  filterToQueryString,
+} from '@atb/modules/transport-mode';
+import { FromDepartureQuery } from './types';
+import { searchTimeToQueryString } from '@atb/modules/search-time';
+import { Url } from 'url';
+import { ParsedUrlQueryInput } from 'querystring';
+
+export function createFromQuery(
+  tripQuery: FromDepartureQuery,
+  transportModeFilter: TransportModeFilterState,
+): {
+  pathname: string;
+  query: ParsedUrlQueryInput;
+} {
+  let transportModeFilterQuery = {};
+  if (transportModeFilter) {
+    const filterQueryString = filterToQueryString(transportModeFilter);
+    if (filterQueryString) {
+      transportModeFilterQuery = {
+        filter: filterQueryString,
+      };
+    }
+  }
+
+  const searchTimeQuery = searchTimeToQueryString(tripQuery.searchTime);
+
+  if (tripQuery.from?.layer == 'venue') {
+    return {
+      pathname: '/departures/[[...id]]',
+      query: {
+        id: tripQuery.from.id,
+        ...transportModeFilterQuery,
+        ...searchTimeQuery,
+      },
+    };
+  }
+
+  if (tripQuery.from) {
+    const [lon, lat] = tripQuery.from.geometry.coordinates;
+    return {
+      pathname: '/departures',
+      query: {
+        ...transportModeFilterQuery,
+        ...searchTimeQuery,
+        lon,
+        lat,
+      },
+    };
+  }
+
+  return {
+    pathname: '/departures',
+    query: {
+      ...transportModeFilterQuery,
+      ...searchTimeQuery,
+    },
+  };
+}


### PR DESCRIPTION
Same naming and concept as with assistant to keep it consistent.
Same test plan also.