### PR TITLE
fix: move map fullscreen button to top of page

### DIFF
--- a/src/page-modules/assistant/details/details.module.css
+++ b/src/page-modules/assistant/details/details.module.css
@@ -15,8 +15,8 @@
     grid-template-columns: 1fr;
     grid-template-areas:
       'header'
-      'trip'
-      'map';
+      'map'
+      'trip';
   }
 }
 .headerContainer {

--- a/src/page-modules/departures/details/details.module.css
+++ b/src/page-modules/departures/details/details.module.css
@@ -15,8 +15,8 @@
     grid-template-columns: 1fr;
     grid-template-areas:
       'header'
-      'serviceJourney'
-      'map';
+      'map'
+      'serviceJourney';
   }
 }
 .headerContainer {


### PR DESCRIPTION
Fixes https://github.com/AtB-AS/kundevendt/issues/15756

The "see in map" button was hard to find on smaller screens. This fixes that by moving it to the top of the page. 

![image](https://github.com/AtB-AS/planner-web/assets/43166974/ec5ca1b6-3d91-45a3-9b50-2c9efb7cd1f0)
