### PR TITLE
fix: use transport sub mode color

### DIFF
--- a/src/page-modules/assistant/trip/trip-pattern/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/index.tsx
@@ -80,7 +80,10 @@ export default function TripPattern({
                   <div className={style.legs__leg__icon}>
                     {leg.mode ? (
                       <TransportIconWithLabel
-                        mode={{ mode: leg.mode }}
+                        mode={{
+                          mode: leg.mode,
+                          subMode: leg.transportSubmode ?? undefined,
+                        }}
                         label={leg.line?.publicCode}
                       />
                     ) : (


### PR DESCRIPTION
Fixes https://github.com/AtB-AS/kundevendt/issues/15782

This fixes the issue with the wrong transport icon color for transport sub-modes. 

![image](https://github.com/AtB-AS/planner-web/assets/43166974/723f6a32-b63e-40a4-855d-b1abff294d0b)
 