### PR TITLE
feat: use focus point for autocompletion

### DIFF
--- a/src/components/search/search.tsx
+++ b/src/components/search/search.tsx
@@ -12,6 +12,7 @@ type SearchProps = {
   button?: ReactNode;
   initialFeature?: GeocoderFeature;
   selectedItem?: GeocoderFeature;
+  autocompleteFocusPoint?: GeocoderFeature;
 };
 
 export default function Search({
@@ -20,9 +21,10 @@ export default function Search({
   button,
   initialFeature,
   selectedItem,
+  autocompleteFocusPoint,
 }: SearchProps) {
   const [query, setQuery] = useState('');
-  const { data } = useAutocomplete(query);
+  const { data } = useAutocomplete(query, autocompleteFocusPoint);
 
   return (
     <Downshift<GeocoderFeature>

--- a/src/page-modules/departures/client/geocoder/index.ts
+++ b/src/page-modules/departures/client/geocoder/index.ts
@@ -8,12 +8,19 @@ export type ReverseApiReturnType = GeocoderFeature | undefined;
 
 const DEBOUNCE_TIME_AUTOCOMPLETE_IN_MS = 300;
 
-export function useAutocomplete(q: string) {
+export function useAutocomplete(
+  q: string,
+  autocompleteFocusPoint?: GeocoderFeature,
+) {
   const debouncedQuery = useDebounce(q, DEBOUNCE_TIME_AUTOCOMPLETE_IN_MS);
+
+  const focusQuery = autocompleteFocusPoint
+    ? `&lat=${autocompleteFocusPoint.geometry.coordinates[0]}&lon=${autocompleteFocusPoint.geometry.coordinates[1]}`
+    : '';
 
   return useSWR<AutocompleteApiReturnType>(
     debouncedQuery !== ''
-      ? `/api/departures/autocomplete?q=${debouncedQuery}`
+      ? `/api/departures/autocomplete?q=${debouncedQuery}${focusQuery}`
       : null,
     swrFetcher,
     {

--- a/src/page-modules/departures/server/geocoder/index.ts
+++ b/src/page-modules/departures/server/geocoder/index.ts
@@ -4,8 +4,17 @@ import { GeocoderRoot, geocoderRootSchema } from './encoders';
 import { FeatureCategory } from '@atb/components/venue-icon';
 import { first } from 'lodash';
 
+const FOCUS_WEIGHT = 18;
+const DEFAULT_FOCUS_POINT = { lat: 63.4305, lon: 10.39518 }; // TODO: Replace with configuration.
+
 export type GeocoderApi = {
-  autocomplete(query: string): Promise<GeocoderFeature[]>;
+  autocomplete(
+    query: string,
+    focus?: {
+      lat: number;
+      lon: number;
+    },
+  ): Promise<GeocoderFeature[]>;
   reverse(
     lat: number,
     lon: number,
@@ -17,9 +26,10 @@ export function createGeocoderApi(
   request: HttpRequester<'http-entur'>,
 ): GeocoderApi {
   return {
-    async autocomplete(query) {
+    async autocomplete(query, focus) {
+      const focusQuery = createFocusQuery(focus);
       const result = await request(
-        `/geocoder/v1/autocomplete?text=${query}&size=20&lang=no`,
+        `/geocoder/v1/autocomplete?text=${query}&${focusQuery}&size=10&lang=no`,
       );
 
       const parsed = geocoderRootSchema.safeParse(await result.json());
@@ -45,6 +55,11 @@ export function createGeocoderApi(
       return first(mapGeocoderFeature(parsed.data));
     },
   };
+}
+
+function createFocusQuery(focus?: { lat: number; lon: number }): string {
+  const { lat, lon } = focus ?? DEFAULT_FOCUS_POINT;
+  return `focus.point.lat=${lat}&focus.point.lon=${lon}&focus.weight=${FOCUS_WEIGHT}&focus.function=exp&focus.scale=200km`;
 }
 
 function mapGeocoderFeature(data: GeocoderRoot) {

--- a/src/pages/api/departures/autocomplete.ts
+++ b/src/pages/api/departures/autocomplete.ts
@@ -9,7 +9,10 @@ export default handlerWithDepartureClient<AutocompleteApiReturnType>({
   async GET(req, res, { client, ok }) {
     // Validate input as string
     const query = z.string().safeParse(req.query.q);
-    if (!query.success) {
+    const lat = z.string().optional().safeParse(req.query.lat);
+    const lon = z.string().optional().safeParse(req.query.lon);
+
+    if (!query.success || !lat.success || !lon.success) {
       return errorResultAsJson(
         res,
         constants.HTTP_STATUS_BAD_REQUEST,
@@ -22,8 +25,17 @@ export default handlerWithDepartureClient<AutocompleteApiReturnType>({
       return ok([]);
     }
 
+    let focus: { lat: number; lon: number } | undefined;
+
+    if (!!lat.data && !!lon.data) {
+      focus = {
+        lat: Number(lat.data),
+        lon: Number(lon.data),
+      };
+    }
+
     return tryResult(req, res, async () => {
-      return ok(await client.autocomplete(String(query.data)));
+      return ok(await client.autocomplete(String(query.data), focus));
     });
   },
 });


### PR DESCRIPTION
Use the query parameters `focus.point.lat` and `focus.point.lon` to set a point that the autocomplete search should be based around. I.e. if the focus point is set to Trondheim it is much more likely to get results near Trondheim than e.g. Oslo.

Using the same "settings" the app uses for the weighting, decay function and decay scaling.


## TODO

- Have not implemented configurable default focus point yet. I think we should plumb Firestore and get configuration from there and then use it for the default point.
- Wanted to use geolocation for the focus point _if_ the user has allowed geolocation previously through the geolocation button, but didn't figure out if it's possible to use the location if it is allowed and not prompt the user.

Closes https://github.com/AtB-AS/kundevendt/issues/15748
