### PR TITLE
fix: info icon size for short wait

### DIFF
--- a/src/page-modules/assistant/details/trip-section/wait-section.tsx
+++ b/src/page-modules/assistant/details/trip-section/wait-section.tsx
@@ -44,7 +44,7 @@ export default function WaitSection({ legWaitDetails }: WaitSectionProps) {
         color={unknownTransportationColor.backgroundColor}
       />
       {shortWait && (
-        <TripRow rowLabel={<ColorIcon icon="status/Info" size="small" />}>
+        <TripRow rowLabel={<ColorIcon icon="status/Info" />}>
           <MessageBox
             noStatusIcon
             type="info"


### PR DESCRIPTION
The info icon size for short wait was smaller than intended. 

Fixes https://github.com/AtB-AS/kundevendt/issues/15791

![image](https://github.com/AtB-AS/planner-web/assets/43166974/a2ba456d-27fe-4d1c-9e8e-66824b7d6295)
