### PR TITLE
feat: adds geolocation to widget

### DIFF
--- a/src/widget/widget.module.css
+++ b/src/widget/widget.module.css
@@ -244,3 +244,14 @@
   composes: menu from search;
   left: 0;
 }
+
+.messageBox {
+  background: var(--static-status-error-background);
+  color: var(--static-status-error-text);
+  display: flex;
+  padding: var(--spacings-medium);
+  border-radius: var(--border-radius-regular);
+}
+.messageBox[hidden] {
+  display: none;
+}

--- a/src/widget/widget.ts
+++ b/src/widget/widget.ts
@@ -172,7 +172,6 @@ class MessageBox extends HTMLElement {
     document.addEventListener('pw-errorMessage', function (event) {
       const data = event as CustomEvent<ErrorMessage>;
       self.textContent = data.detail.message;
-      console.log('setting error', data.detail);
       self.hidden = false;
     });
     document.addEventListener('pw-errorMessage-clear', function (event) {

--- a/src/widget/widget.ts
+++ b/src/widget/widget.ts
@@ -504,7 +504,7 @@ function createOutput({ URL_BASE }: SettingConstants) {
                 <input
                   class="${style.search_input}"
                   aria-autocomplete="list"
-                  aria-labelledby="pw-from-1-label"
+                  aria-labelledby="pw-from-2-label"
                   autocomplete="off"
                   name="from"
                   id="pw-from-2-input"

--- a/src/widget/widget.ts
+++ b/src/widget/widget.ts
@@ -407,6 +407,7 @@ function createOutput({ URL_BASE }: SettingConstants) {
                   id="pw-from-1-input"
                   name="from"
                   value=""
+                  placeholder="Søk fra adresse, kai eller holdeplass"
                 />
                 <ul
                   id="from-popup-1"
@@ -456,6 +457,7 @@ function createOutput({ URL_BASE }: SettingConstants) {
                   id="pw-to-1-input"
                   name="to"
                   value=""
+                  placeholder="Søk til adresse, kai eller holdeplass"
                 />
                 <ul
                   id="to-popup-1"
@@ -507,6 +509,7 @@ function createOutput({ URL_BASE }: SettingConstants) {
                   name="from"
                   id="pw-from-2-input"
                   value=""
+                  placeholder="Søk fra adresse, kai eller holdeplass"
                 />
                 <ul
                   id="to-popup-2"


### PR DESCRIPTION
Related to https://github.com/AtB-AS/kundevendt/issues/14939

Adds ability to click to inject from place based on location in browser. Currently not using that as focus point in autocomplete, but this can be added. Will show error if blocked location

## Todo

- [x] Handle errors / permissions