### PR TITLE
feat: show all transport modes for a stop place

### DIFF
--- a/src/components/line-chip/index.tsx
+++ b/src/components/line-chip/index.tsx
@@ -10,7 +10,7 @@ import {
 export type LineChipProps = {
   transportMode: TransportModeType;
   transportSubmode?: TransportSubmodeType;
-  publicCode: string;
+  publicCode: string | null;
 };
 
 export default function LineChip({
@@ -37,9 +37,11 @@ export default function LineChip({
           subMode: transportSubmode,
         }}
       />
-      <Typo.span className={style.publicCode} textType="body__primary--bold">
-        {publicCode}
-      </Typo.span>
+      {publicCode && (
+        <Typo.span className={style.publicCode} textType="body__primary--bold">
+          {publicCode}
+        </Typo.span>
+      )}
     </div>
   );
 }

--- a/src/components/line-chip/line-chip.module.css
+++ b/src/components/line-chip/line-chip.module.css
@@ -1,6 +1,4 @@
 .container {
-  min-width: 4.125rem;
-
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/src/components/search/search.tsx
+++ b/src/components/search/search.tsx
@@ -72,7 +72,7 @@ export default function Search({
                   })}
                 >
                   <div className={style.itemIcon} aria-hidden>
-                    <VenueIcon category={item.category} />
+                    <VenueIcon categories={item.category} />
                   </div>
                   <span className={style.itemName}>
                     {highlightSearchText(inputValue, item.name).map(

--- a/src/components/venue-icon/index.tsx
+++ b/src/components/venue-icon/index.tsx
@@ -1,17 +1,26 @@
 import { ComponentText, useTranslation } from '@atb/translations';
 import { MonoIcon, MonoIconProps } from '@atb/components/icon';
+import { TransportModeType } from '@atb/modules/transport-mode';
 
-export type VenuIconProps = {
-  category: FeatureCategory[];
+export type VenueIconProps = {
+  categories?: FeatureCategory[];
+  transportModes?: TransportModeType[];
   multiple?: boolean;
 } & Omit<MonoIconProps, 'icon'>;
 
 export default function VenueIcon({
-  category,
+  categories,
+  transportModes,
   multiple,
   ...props
-}: VenuIconProps) {
-  const venueIconTypes = getVenueIconTypes(category);
+}: VenueIconProps) {
+  let venueIconTypes: VenueIconType[] = [];
+
+  if (transportModes) {
+    venueIconTypes = transportModes as VenueIconType[];
+  } else if (categories) {
+    venueIconTypes = getVenueIconTypes(categories);
+  }
 
   if (!venueIconTypes.length) {
     return <MonoIcon icon="map/Pin" key="unknown" {...props} />;
@@ -53,7 +62,7 @@ export enum FeatureCategory {
   OTHER = 'other',
 }
 
-type VenueIconType = 'bus' | 'tram' | 'rail' | 'airport' | 'boat' | 'unknown';
+type VenueIconType = 'bus' | 'tram' | 'rail' | 'air' | 'water' | 'unknown';
 type IconComponentProps = {
   iconType: VenueIconType;
 } & Omit<MonoIconProps, 'icon'>;
@@ -90,7 +99,7 @@ function IconComponent({ iconType, ...props }: IconComponentProps) {
           {...props}
         />
       );
-    case 'airport':
+    case 'air':
       return (
         <MonoIcon
           icon="transportation-entur/Plane"
@@ -100,7 +109,7 @@ function IconComponent({ iconType, ...props }: IconComponentProps) {
           {...props}
         />
       );
-    case 'boat':
+    case 'water':
       return (
         <MonoIcon
           icon="transportation-entur/Ferry"
@@ -145,11 +154,11 @@ function mapLocationCategoryToVenueType(
     case 'metroStation':
       return 'rail';
     case 'airport':
-      return 'airport';
+      return 'air';
     case 'harbourPort':
     case 'ferryPort':
     case 'ferryStop':
-      return 'boat';
+      return 'water';
     default:
       return 'unknown';
   }

--- a/src/components/venue-icon/index.tsx
+++ b/src/components/venue-icon/index.tsx
@@ -3,23 +3,21 @@ import { MonoIcon, MonoIconProps } from '@atb/components/icon';
 import { TransportModeType } from '@atb/modules/transport-mode';
 
 export type VenueIconProps = {
-  categories?: FeatureCategory[];
-  transportModes?: TransportModeType[];
+  categories: FeatureCategory[] | TransportModeType[];
   multiple?: boolean;
 } & Omit<MonoIconProps, 'icon'>;
 
 export default function VenueIcon({
   categories,
-  transportModes,
   multiple,
   ...props
 }: VenueIconProps) {
   let venueIconTypes: VenueIconType[] = [];
 
-  if (transportModes) {
-    venueIconTypes = transportModes as VenueIconType[];
-  } else if (categories) {
+  if (isFeatureCategory(categories)) {
     venueIconTypes = getVenueIconTypes(categories);
+  } else {
+    venueIconTypes = categories as VenueIconType[];
   }
 
   if (!venueIconTypes.length) {
@@ -60,6 +58,12 @@ export enum FeatureCategory {
   TETTSTEDDEL = 'tettsteddel',
   BYDEL = 'bydel',
   OTHER = 'other',
+}
+
+function isFeatureCategory(categories: any): categories is FeatureCategory[] {
+  return categories.every((c: FeatureCategory) =>
+    Object.values(FeatureCategory).includes(c),
+  );
 }
 
 type VenueIconType = 'bus' | 'tram' | 'rail' | 'air' | 'water' | 'unknown';

--- a/src/page-modules/assistant/details/trip-section/interchange-section.tsx
+++ b/src/page-modules/assistant/details/trip-section/interchange-section.tsx
@@ -15,7 +15,7 @@ export type InterchangeDetails = {
 
 export type InterchangeSectionProps = {
   interchangeDetails: InterchangeDetails;
-  publicCode?: string;
+  publicCode?: string | null;
 };
 
 export function InterchangeSection({

--- a/src/page-modules/assistant/details/utils.ts
+++ b/src/page-modules/assistant/details/utils.ts
@@ -7,7 +7,7 @@ export function formatQuayName(quayName?: string, publicCode?: string | null) {
 export function getPlaceName(
   placeName?: string,
   quayName?: string,
-  publicCode?: string,
+  publicCode?: string | null,
 ): string {
   const fallback = placeName ?? '';
   return quayName ? formatQuayName(quayName, publicCode) ?? fallback : fallback;
@@ -16,7 +16,7 @@ export function getPlaceName(
 export function formatLineName(
   frontText?: string,
   lineName?: string,
-  publicCode?: string,
+  publicCode?: string | null,
 ): string {
   const name = frontText ?? lineName ?? '';
   return publicCode ? `${publicCode} ${name}` : name;

--- a/src/page-modules/assistant/server/journey-planner/validators.ts
+++ b/src/page-modules/assistant/server/journey-planner/validators.ts
@@ -98,7 +98,7 @@ export const tripPatternWithDetailsSchema = z.object({
       line: z
         .object({
           name: z.string(),
-          publicCode: z.string(),
+          publicCode: z.string().nullable(),
         })
         .nullable(), // line is null for legs with transportMode = foot
       fromPlace: z.object({
@@ -108,7 +108,7 @@ export const tripPatternWithDetailsSchema = z.object({
         quay: z
           .object({
             name: z.string(),
-            publicCode: z.string(),
+            publicCode: z.string().nullable(),
           })
           .nullable(), // quay is null when fromPlace is a POI (e.g. address)
       }),
@@ -117,7 +117,7 @@ export const tripPatternWithDetailsSchema = z.object({
         quay: z
           .object({
             name: z.string(),
-            publicCode: z.string(),
+            publicCode: z.string().nullable(),
           })
           .nullable(), // quay is null when toPlace is a POI (e.g. address)
       }),

--- a/src/page-modules/departures/nearest-stop-places/index.tsx
+++ b/src/page-modules/departures/nearest-stop-places/index.tsx
@@ -102,11 +102,7 @@ export default function StopPlaceItem({ item }: StopPlaceItemProps) {
           <SituationOrNoticeIcon situations={item.stopPlace.situations} />
         )}
         {item.stopPlace.transportMode?.map((mode) => (
-          <VenueIcon
-            key={item.stopPlace.id}
-            transportModes={[mode]}
-            size="large"
-          />
+          <VenueIcon key={item.stopPlace.id} categories={[mode]} size="large" />
         ))}
       </div>
     </Link>

--- a/src/page-modules/departures/nearest-stop-places/index.tsx
+++ b/src/page-modules/departures/nearest-stop-places/index.tsx
@@ -101,7 +101,13 @@ export default function StopPlaceItem({ item }: StopPlaceItemProps) {
         {item.stopPlace.situations.length > 0 && (
           <SituationOrNoticeIcon situations={item.stopPlace.situations} />
         )}
-        <VenueIcon category={[FeatureCategory.BUS_STATION]} size="large" />
+        {item.stopPlace.transportMode?.map((mode) => (
+          <VenueIcon
+            key={item.stopPlace.id}
+            transportModes={[mode]}
+            size="large"
+          />
+        ))}
       </div>
     </Link>
   );

--- a/src/page-modules/departures/server/journey-planner/index.ts
+++ b/src/page-modules/departures/server/journey-planner/index.ts
@@ -249,6 +249,9 @@ export function createJourneyApi(
               situations: mapAndFilterDuplicateGraphQlSituations(
                 situations as GraphQlSituation[],
               ),
+              transportMode: filterGraphQlTransportModes(
+                edge.node?.place.transportMode,
+              ),
             },
             distance: edge.node.distance,
           });

--- a/src/page-modules/departures/server/journey-planner/journey-gql/nearest-stop-places.gql
+++ b/src/page-modules/departures/server/journey-planner/journey-gql/nearest-stop-places.gql
@@ -35,6 +35,7 @@ query nearestStopPlaces(
               publicCode
               stopPlace {
                 id
+                transportMode
               }
               situations {
                 ...situation

--- a/src/page-modules/departures/server/journey-planner/validators.ts
+++ b/src/page-modules/departures/server/journey-planner/validators.ts
@@ -23,7 +23,7 @@ export const stopPlaceSchema = z.object({
 export const departureSchema = z.object({
   id: z.string(),
   name: z.string(),
-  publicCode: z.string(),
+  publicCode: z.string().nullable(),
   date: z.string(),
   aimedDepartureTime: z.string(),
   expectedDepartureTime: z.string(),
@@ -65,7 +65,7 @@ export const serviceJourneySchema = z.object({
   transportMode: transportModeSchema,
   transportSubmode: transportSubmodeSchema.optional(),
   line: z.object({
-    publicCode: z.string(),
+    publicCode: z.string().nullable(),
     notices: z.array(noticeSchema),
   }),
   mapLegs: z.array(mapLegSchema),


### PR DESCRIPTION
This PR introduces a significant feature enhancement to our application. Specifically, it extends the functionality to show all modes of transport available for a given stop place.

Prior to this update, our application may not have provided comprehensive transport mode information for each stop place, limiting its overall utility for end-users. With the implementation of this feature, we can now present complete and valuable information on all transport modes for any given stop place, thereby significantly improving the user experience.

The code modifications encompassed by this commit include updates to both the display logic and the data handling components of our application. These changes ensure that our system can retrieve, process, and render all transport mode data associated with each stop place.

In addition to the major feature enhancement, other modifications were made to improve the overall code quality and maintainability. Whilst these changes may not result in noticeable functional differences, they play a crucial role in ensuring that our codebase remains robust, clean and easy to maintain for our development team.

In conclusion, this PR represents a notable improvement to the application. By enhancing the information accuracy provided to the users and improving the underlying code quality, it makes a significant contribution towards our ongoing efforts to deliver an outstanding user experience.

<details><summary>Screenshots</summary>
<p>

![2023-11-30 at 18 43 25](https://github.com/AtB-AS/planner-web/assets/14045515/98af42d2-1a3f-4f38-a1d1-637dd9d7c119)



</p>
</details> 

Closes https://github.com/AtB-AS/kundevendt/issues/15784