### PR TITLE
fix: revalidation on connect for autocomplete

### DIFF
--- a/src/page-modules/departures/client/geocoder/index.ts
+++ b/src/page-modules/departures/client/geocoder/index.ts
@@ -26,7 +26,6 @@ export function useAutocomplete(
     {
       revalidateOnFocus: false,
       revalidateOnReconnect: false,
-      revalidateOnMount: false,
     },
   );
 }


### PR DESCRIPTION
Some cases happening where it doesn't search due to debounce. ensure revalidate on connect to avoid