### PR TITLE
refactor: filter button

### DIFF
--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -174,7 +174,7 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
                 : t(PageText.Assistant.search.buttons.alternatives.more)
             }
             className={style.button}
-            mode={showAlternatives ? 'interactive_3' : 'interactive_2'}
+            mode="interactive_2"
             onClick={() => setShowAlternatives(!showAlternatives)}
             icon={{ right: <MonoIcon icon="actions/Adjust" /> }}
           />

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -168,9 +168,13 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
 
         <div className={style.buttons}>
           <Button
-            title={t(PageText.Assistant.search.buttons.alternatives.title)}
+            title={
+              showAlternatives
+                ? t(PageText.Assistant.search.buttons.alternatives.less)
+                : t(PageText.Assistant.search.buttons.alternatives.more)
+            }
             className={style.button}
-            mode="interactive_2"
+            mode={showAlternatives ? 'interactive_3' : 'interactive_2'}
             onClick={() => setShowAlternatives(!showAlternatives)}
             icon={{ right: <MonoIcon icon="actions/Adjust" /> }}
           />

--- a/src/page-modules/departures/layout.tsx
+++ b/src/page-modules/departures/layout.tsx
@@ -146,7 +146,7 @@ function DeparturesLayout({ children, fromQuery }: DeparturesLayoutProps) {
                 : t(PageText.Departures.search.buttons.alternatives.more)
             }
             className={style.button}
-            mode={showAlternatives ? 'interactive_3' : 'interactive_2'}
+            mode="interactive_2"
             onClick={() => setShowAlternatives(!showAlternatives)}
             icon={{ right: <MonoIcon icon="actions/Adjust" /> }}
           />

--- a/src/page-modules/departures/layout.tsx
+++ b/src/page-modules/departures/layout.tsx
@@ -140,7 +140,11 @@ function DeparturesLayout({ children, fromQuery }: DeparturesLayoutProps) {
 
         <div className={style.buttons}>
           <Button
-            title={t(PageText.Departures.search.buttons.alternatives.title)}
+            title={
+              showAlternatives
+                ? t(PageText.Departures.search.buttons.alternatives.less)
+                : t(PageText.Departures.search.buttons.alternatives.more)
+            }
             className={style.button}
             mode={showAlternatives ? 'interactive_3' : 'interactive_2'}
             onClick={() => setShowAlternatives(!showAlternatives)}

--- a/src/translations/pages/assistant.ts
+++ b/src/translations/pages/assistant.ts
@@ -33,7 +33,8 @@ export const Assistant = {
         title: _('Finn avganger', 'Find departures', 'Finn avganger'),
       },
       alternatives: {
-        title: _('Flere valg', 'More choices', 'Fleire val'),
+        more: _('Flere valg', 'More choices', 'Fleire val'),
+        less: _('Færre valg', 'Less choices', 'Færre val'),
       },
     },
   },

--- a/src/translations/pages/departures.ts
+++ b/src/translations/pages/departures.ts
@@ -31,7 +31,8 @@ export const Departures = {
         title: _('Finn avganger', 'Find departures', 'Finn avganger'),
       },
       alternatives: {
-        title: _('Flere valg', 'More choices', 'Fleire val'),
+        more: _('Flere valg', 'More choices', 'Fleire val'),
+        less: _('Færre valg', 'Less choices', 'Færre val'),
       },
     },
   },


### PR DESCRIPTION
I was working on https://github.com/AtB-AS/kundevendt/issues/12072 and had a chat with Christian about this button. The buttons used in the Figma sketches for the planner-web are from the app design-system and we've reused the webshop design-system buttons. 

AtB wants to redo these components to look more the same, but haven't had time to prioritize this. The components are missing states and are therefore hard to implement for now. I tried to implement a new mode, `transparent--bordered`, as a temporary solution, but using the `text-colors-primary` color as a border (as is done for the component in Figma) would give us contrast issues. The button in the travel planner web Figma sketches has overwritten these colors with #FFFFFF which would cause issues elsewhere in the app. 

I personally think it's not a good idea to expand the button component to have a new mode that only works in certain scenarios to match the Figma sketches and that we should consider revisiting the sketches instead. I tweaked the button behavior to match what it actually does and made sure the colors match between the assistant and departures pages. I think this is an improvement at least. 

Let me know if you think we should make AtB prioritize redoing the button components in Figma, but I doubt they will have time before the release. Or if you think we should add the new mode

<details>
<summary>screenshots</summary>

![image](https://github.com/AtB-AS/planner-web/assets/43166974/72af6851-96cc-4a8b-988b-8ff91d89615b)

![image](https://github.com/AtB-AS/planner-web/assets/43166974/e3481c65-212b-4eb5-ba09-84b766629992)

![image](https://github.com/AtB-AS/planner-web/assets/43166974/d3ca82d0-39e4-446d-82a2-15906fa48208)

![image](https://github.com/AtB-AS/planner-web/assets/43166974/1e4d0ceb-7d32-48dd-b46d-804a4b994eec)

</details>