### PR TITLE
feat: show dotted line for foot legs

### DIFF
--- a/src/components/map/use-map-legs.ts
+++ b/src/components/map/use-map-legs.ts
@@ -26,6 +26,7 @@ export const useMapLegs = (
       const lineColor = mapLeg.faded
         ? hexToRgba(transportColor.background, 0.5)
         : transportColor.background;
+      const isDotted = mapLeg.transportMode === 'foot';
 
       const routeLine = createRouteFeature(
         mapLeg.points.map((pair) => [...pair].reverse()),
@@ -36,7 +37,7 @@ export const useMapLegs = (
       );
       map.addSource(`route-${id}`, routeLine);
       map.addSource(`route-${id}-start-end`, startEndCircles);
-      map.addLayer(createRouteLayer(id, lineColor));
+      map.addLayer(createRouteLayer(id, lineColor, isDotted));
       map.addLayer(createStartEndLayer(id, lineColor));
     },
     [transport],
@@ -122,16 +123,34 @@ const createRouteFeature = (points: number[][]): mapboxgl.AnySourceData => ({
 const createRouteLayer = (
   id: number | string,
   color: string,
-): mapboxgl.AnyLayer => ({
-  id: `route-layer-${id}`,
-  type: 'line',
-  source: `route-${id}`,
-  paint: {
-    'line-color': color,
-    'line-width': 4,
-    'line-offset': -1,
-  },
-});
+  isDotted?: boolean,
+): mapboxgl.AnyLayer => {
+  let paint = {};
+  let layout = {};
+
+  if (isDotted) {
+    paint = {
+      'line-dasharray': [0, 2],
+    };
+    layout = {
+      'line-cap': 'round',
+      'line-join': 'round',
+    };
+  }
+
+  return {
+    id: `route-layer-${id}`,
+    type: 'line',
+    source: `route-${id}`,
+    paint: {
+      'line-color': color,
+      'line-width': 4,
+      'line-offset': -1,
+      ...paint,
+    },
+    layout,
+  };
+};
 
 const createStartEndCircle = (
   startPoint: number[],

--- a/src/pages/assistant/index.tsx
+++ b/src/pages/assistant/index.tsx
@@ -14,7 +14,9 @@ import {
 import { withAssistantClient } from '@atb/page-modules/assistant/server';
 import type { NextPage } from 'next';
 
-export type AssistantContentProps = { tripQuery: FromToTripQuery } | TripProps;
+export type AssistantContentProps =
+  | { tripQuery: FromToTripQuery; empty: true }
+  | TripProps;
 
 export type AssistantPageProps = WithGlobalData<
   AssistantLayoutProps & AssistantContentProps
@@ -51,6 +53,7 @@ export const getServerSideProps = withGlobalData(
         return {
           props: {
             tripQuery,
+            empty: true,
           },
         };
       }


### PR DESCRIPTION
Show dotted line for foot legs, instead of solid lines, to have the same behaviour as in the app.

<details><summary>Screenshots</summary>
<p>

<img width="593" alt="image" src="https://github.com/AtB-AS/planner-web/assets/14045515/526146a2-ee95-4c29-93be-c93ce1a332e1">
<img width="605" alt="image" src="https://github.com/AtB-AS/planner-web/assets/14045515/743834bb-a1a7-4556-a9cf-dc8f2a89d38d">


</p>
</details> 

Fixes https://github.com/AtB-AS/kundevendt/issues/15858