### PR TITLE
feat: sort quays

### DIFF
--- a/src/page-modules/departures/server/journey-planner/index.ts
+++ b/src/page-modules/departures/server/journey-planner/index.ts
@@ -166,6 +166,21 @@ export function createJourneyApi(
         throw validated.error;
       }
 
+      validated.data.quays.sort((a, b) => {
+        // Place quays with no departures at the end
+        if (a.departures.length === 0) return 1;
+        if (b.departures.length === 0) return -1;
+
+        if (!a.publicCode) return 1;
+        if (!b.publicCode) return -1;
+
+        if (parseInt(a.publicCode) && parseInt(b.publicCode)) {
+          return parseInt(a.publicCode) - parseInt(b.publicCode);
+        }
+
+        return a.publicCode.localeCompare(b.publicCode);
+      });
+
       return validated.data;
     },
 


### PR DESCRIPTION
This adds sorting of quays by public code and departures. A quay with no departures are placed at the bottom. 

<img width="727" alt="image" src="https://github.com/AtB-AS/planner-web/assets/43166974/2eed3fdb-07d9-43e3-8d05-9cc835f24a42">

Closes https://github.com/AtB-AS/kundevendt/issues/15926
Closes https://github.com/AtB-AS/kundevendt/issues/15894