### PR TITLE
refactor: transport mode filter behavior

### DIFF
--- a/src/modules/transport-mode/filter/__tests__/filter.test.tsx
+++ b/src/modules/transport-mode/filter/__tests__/filter.test.tsx
@@ -87,12 +87,17 @@ describe('transport mode filter', () => {
     expect(onChange).toHaveBeenCalledWith(expected);
   });
 
-  it('should only uncheck "Bus"', () => {
+  it('should only check "Bus" when "All" is selected', () => {
     const onChange = vi.fn();
     const initialState = getInitialTransportModeFilter();
     const expected: TransportModeFilterState = {
-      ...initialState,
-      bus: false,
+      air: false,
+      airportbus: false,
+      bus: true,
+      expressboat: false,
+      ferry: false,
+      other: false,
+      rail: false,
     };
 
     render(

--- a/src/modules/transport-mode/filter/__tests__/filter.test.tsx
+++ b/src/modules/transport-mode/filter/__tests__/filter.test.tsx
@@ -111,6 +111,38 @@ describe('transport mode filter', () => {
     expect(onChange).toHaveBeenCalledWith(expected);
   });
 
+  it('should check "Rail" when only "Bus" is selected', () => {
+    const onChange = vi.fn();
+    const initialState: TransportModeFilterState = {
+      air: false,
+      airportbus: false,
+      bus: true,
+      expressboat: false,
+      ferry: false,
+      other: false,
+      rail: false,
+    };
+    const expected: TransportModeFilterState = {
+      air: false,
+      airportbus: false,
+      bus: true,
+      expressboat: false,
+      ferry: false,
+      other: false,
+      rail: true,
+    };
+
+    render(
+      <TransportModeFilter
+        filterState={initialState}
+        onFilterChange={onChange}
+      />,
+    );
+
+    screen.getByRole('checkbox', { name: /^tog$/i }).click();
+    expect(onChange).toHaveBeenCalledWith(expected);
+  });
+
   it('should check all when all initially are unchecked', async () => {
     const onChange = vi.fn();
 

--- a/src/modules/transport-mode/filter/filter.tsx
+++ b/src/modules/transport-mode/filter/filter.tsx
@@ -56,11 +56,9 @@ export default function TransportModeFilter({
                 checked={selected}
                 onChange={(event) => {
                   if (Object.values(filterState).every(Boolean)) {
-                    Object.keys(filterState).forEach((k) => {
-                      filterState[k as keyof TransportModeFilterState] = false;
-                    });
+                    const newState = setAllValues(filterState, false);
                     onFilterChange({
-                      ...filterState,
+                      ...(newState as TransportModeFilterState),
                       [key]: true,
                     });
                   } else {

--- a/src/modules/transport-mode/filter/filter.tsx
+++ b/src/modules/transport-mode/filter/filter.tsx
@@ -6,9 +6,8 @@ import { TransportModeFilterOption, TransportModeFilterState } from './types';
 import { Typo } from '@atb/components/typography';
 import { getTransportModeIcon } from '../icon';
 import { filterOptionsWithTransportModes, setAllValues } from './utils';
-import { useTheme } from '@atb/modules/theme';
 import { TransportModeFilterOptionType } from '@atb-as/config-specs';
-import { ChangeEventHandler, useState } from 'react';
+import { ChangeEventHandler } from 'react';
 
 type TransportModeFilterProps = {
   filterState: TransportModeFilterState;
@@ -56,10 +55,20 @@ export default function TransportModeFilter({
                 option={option}
                 checked={selected}
                 onChange={(event) => {
-                  onFilterChange({
-                    ...filterState,
-                    [key]: event.target.checked,
-                  });
+                  if (Object.values(filterState).every(Boolean)) {
+                    Object.keys(filterState).forEach((k) => {
+                      filterState[k as keyof TransportModeFilterState] = false;
+                    });
+                    onFilterChange({
+                      ...filterState,
+                      [key]: true,
+                    });
+                  } else {
+                    onFilterChange({
+                      ...filterState,
+                      [key]: event.target.checked,
+                    });
+                  }
                 }}
               />
 


### PR DESCRIPTION
This changes the behavior of the transport mode filter so that when "All" is selected and the user clicks another transport mode, only the selected transport mode is selected. 

Closes https://github.com/AtB-AS/kundevendt/issues/15923