### PR TITLE
feat: show details for a non-transit trip

### DIFF
--- a/src/page-modules/assistant/__tests__/assistant-data.fixture.ts
+++ b/src/page-modules/assistant/__tests__/assistant-data.fixture.ts
@@ -33,5 +33,6 @@ export const nonTransitTripResult: NonTransitTripData = {
     duration: 0,
     mode: 'bus',
     rentedBike: false,
+    compressedQuery: '',
   },
 };

--- a/src/page-modules/assistant/non-transit-pill/index.tsx
+++ b/src/page-modules/assistant/non-transit-pill/index.tsx
@@ -12,6 +12,7 @@ type NonTransitTripProps = {
     mode: TransportModeType;
     rentedBike: boolean;
     duration: number;
+    compressedQuery: string;
   };
 };
 export function NonTransitTrip({ nonTransit }: NonTransitTripProps) {
@@ -28,7 +29,7 @@ export function NonTransitTrip({ nonTransit }: NonTransitTripProps) {
     <ButtonLink
       radiusSize="circular"
       size="pill"
-      href="/assistant"
+      href={`/assistant/${nonTransit.compressedQuery}`}
       title={`${modeText} ${durationShort}`}
       icon={{
         left: <TransportMonoIcon mode={{ mode }} />,

--- a/src/page-modules/assistant/server/journey-planner/index.ts
+++ b/src/page-modules/assistant/server/journey-planner/index.ts
@@ -526,7 +526,6 @@ function parseTripQueryString(
   compressedQueryString: string,
 ): { query: TripsQueryVariables; journeyIds: string[] } | undefined {
   const queryString = decompressFromEncodedURIComponent(compressedQueryString);
-  console.log('queryString', queryString);
   if (!queryString) return;
 
   const queryFields = JSON.parse(queryString);

--- a/src/page-modules/assistant/server/journey-planner/index.ts
+++ b/src/page-modules/assistant/server/journey-planner/index.ts
@@ -71,22 +71,24 @@ export function createJourneyApi(
           ? new Date(input.searchTime.dateTime)
           : new Date();
 
+      const queryVariables = {
+        from,
+        to,
+        arriveBy: input.searchTime.mode === 'arriveBy',
+        when,
+        walkSpeed: 1.3,
+
+        includeFoot: input.directModes.includes(StreetMode.Foot),
+        includeBicycle: input.directModes.includes(StreetMode.Bicycle),
+        includeBikeRental: input.directModes.includes(StreetMode.BikeRental),
+      };
+
       const result = await client.query<
         TripsNonTransitQuery,
         TripsNonTransitQueryVariables
       >({
         query: TripsNonTransitDocument,
-        variables: {
-          from,
-          to,
-          arriveBy: input.searchTime.mode === 'arriveBy',
-          when,
-          walkSpeed: 1.3,
-
-          includeFoot: input.directModes.includes(StreetMode.Foot),
-          includeBicycle: input.directModes.includes(StreetMode.Bicycle),
-          includeBikeRental: input.directModes.includes(StreetMode.BikeRental),
-        },
+        variables: queryVariables,
       });
 
       if (result.error || result.errors) {
@@ -103,10 +105,29 @@ export function createJourneyApi(
           continue;
         }
 
+        const modes = { directMode: StreetMode.Foot, transportModes: [] };
+
+        switch (legType) {
+          case 'footTrip':
+            modes.directMode = StreetMode.Foot;
+            break;
+          case 'bicycleTrip':
+            modes.directMode = StreetMode.Bicycle;
+            break;
+          case 'bikeRentalTrip':
+            modes.directMode = StreetMode.BikeRental;
+            break;
+        }
+
         const data: Partial<NonTransitData> = {
           duration: tripPattern.duration,
           mode: tripPattern.legs[0]?.mode as any,
           rentedBike: tripPattern.legs?.some((leg) => leg.rentedBike) ?? false,
+          compressedQuery: generateSingleTripQueryString(
+            [],
+            tripPattern.legs[0].aimedStartTime,
+            { ...queryVariables, modes },
+          ),
         };
 
         const validated = nonTransitSchema.safeParse(data);
@@ -487,26 +508,12 @@ function generateSingleTripQueryString(
   queryVariables: TripsQueryVariables,
 ) {
   const when = getPaddedStartTime(aimedStartTime);
-  const {
-    from,
-    to,
-    transferPenalty,
-    waitReluctance,
-    walkReluctance,
-    walkSpeed,
-    modes,
-  } = queryVariables;
   const arriveBy = false;
+
   const singleTripQuery: TripsQueryVariables = {
+    ...queryVariables,
     when,
-    from,
-    to,
-    transferPenalty,
-    waitReluctance,
-    walkReluctance,
-    walkSpeed,
     arriveBy,
-    modes,
   };
 
   // encode to string
@@ -519,11 +526,11 @@ function parseTripQueryString(
   compressedQueryString: string,
 ): { query: TripsQueryVariables; journeyIds: string[] } | undefined {
   const queryString = decompressFromEncodedURIComponent(compressedQueryString);
+  console.log('queryString', queryString);
   if (!queryString) return;
 
   const queryFields = JSON.parse(queryString);
-  if (isTripsQueryVariables(queryFields.query) && 'journeyIds' in queryFields)
-    return queryFields;
+  if (isTripsQueryVariables(queryFields.query)) return queryFields;
   return;
 }
 

--- a/src/page-modules/assistant/server/journey-planner/journey-gql/trip.gql
+++ b/src/page-modules/assistant/server/journey-planner/journey-gql/trip.gql
@@ -49,11 +49,7 @@ query TripsNonTransit(
     modes: { directMode: foot, transportModes: [] }
   ) @include(if: $includeFoot) {
     tripPatterns {
-      duration
-      legs {
-        mode
-        rentedBike
-      }
+      ...nonTransitTrip
     }
   }
   bikeRentalTrip: trip(
@@ -66,11 +62,7 @@ query TripsNonTransit(
     modes: { directMode: bike_rental, transportModes: [] }
   ) @include(if: $includeBikeRental) {
     tripPatterns {
-      duration
-      legs {
-        mode
-        rentedBike
-      }
+      ...nonTransitTrip
     }
   }
   bicycleTrip: trip(
@@ -83,11 +75,7 @@ query TripsNonTransit(
     modes: { directMode: bicycle, transportModes: [] }
   ) @include(if: $includeBicycle) {
     tripPatterns {
-      duration
-      legs {
-        mode
-        rentedBike
-      }
+      ...nonTransitTrip
     }
   }
 }
@@ -217,4 +205,13 @@ fragment infoLink on infoLink {
 fragment validityPeriod on ValidityPeriod {
   startTime
   endTime
+}
+
+fragment nonTransitTrip on TripPattern {
+  duration
+  legs {
+    mode
+    rentedBike
+    aimedStartTime
+  }
 }

--- a/src/page-modules/assistant/server/journey-planner/validators.ts
+++ b/src/page-modules/assistant/server/journey-planner/validators.ts
@@ -77,6 +77,7 @@ export const nonTransitSchema = z.object({
   mode: transportModeSchema,
   rentedBike: z.boolean(),
   duration: z.number(),
+  compressedQuery: z.string(),
 });
 
 export const tripPatternWithDetailsSchema = z.object({


### PR DESCRIPTION
This PR introduces a new feature that expands the functionality of our trip information display. Previously, our system only provided specific details for transit-based trips. Now, with this update, users can also access detailed information for non-transit trips. This includes details about the trip's origin, destination, duration, distance, and path. This improvement aims to offer a more comprehensive and convenient experience for users, allowing them to effectively plan their trips regardless of the transportation mode.

<details><summary>Screenshots</summary>
<p>

<img width="964" alt="image" src="https://github.com/AtB-AS/planner-web/assets/14045515/066d263e-9bb5-48fc-ab83-062aae9add5a">
<img width="964" alt="image" src="https://github.com/AtB-AS/planner-web/assets/14045515/57dfd29c-e8e4-4cf5-9246-8f7ff52286e5">


</p>
</details> 

Closes https://github.com/AtB-AS/kundevendt/issues/15873