### PR TITLE
fix: update meta description

### DIFF
--- a/src/translations/common/layout.ts
+++ b/src/translations/common/layout.ts
@@ -15,18 +15,18 @@ export const Layout = orgSpecificTranslations(LayoutInternal, {
   nfk: {
     meta: {
       defaultDescription: _(
-        'Finn rutetider, holdeplasser og tilbud for buss, trikk, båt og tog i Nordland med reiseplanleggeren.',
-        'Find timetables, stops and offers for bus, tram, boat and train in Nordland with the travel planner.',
-        'Finn rutetider, haldeplassar og tilbod for buss, trikk, båt og tog i Nordland med reiseplanleggjaren.',
+        'Finn rutetider, holdeplasser og tilbud for buss, båt og tog i Nordland med reiseplanleggeren.',
+        'Find timetables, stops and offers for bus, boat and train in Nordland with the travel planner.',
+        'Finn rutetider, haldeplassar og tilbod for buss, båt og tog i Nordland med reiseplanleggjaren.',
       ),
     },
   },
   fram: {
     meta: {
       defaultDescription: _(
-        'Finn rutetider, holdeplasser og tilbud for buss, trikk, båt og tog i Møre og Romsdal med reiseplanleggeren.',
-        'Find timetables, stops and offers for bus, tram, boat and train in Møre og Romsdal with the travel planner.',
-        'Finn rutetider, haldeplassar og tilbod for buss, trikk, båt og tog i Møre og Romsdal med reiseplanleggjaren.',
+        'Finn rutetider, holdeplasser, kaier og tilbud for buss, hurtigbåt og ferge i Møre og Romsdal med reiseplanleggeren.',
+        'Find timetables, stops and offers for bus, boat and ferry in Møre og Romsdal with the travel planner.',
+        'Finn rutetider, haldeplassar, kaier og tilbod for buss, hurtigbåt og ferje i Møre og Romsdal med reiseplanleggjaren.',
       ),
     },
   },

--- a/src/translations/common/layout.ts
+++ b/src/translations/common/layout.ts
@@ -1,7 +1,33 @@
 import { translation as _ } from '@atb/translations/commons';
+import { orgSpecificTranslations } from '@atb/translations/utils';
 
-export const Layout = {
+const LayoutInternal = {
   meta: {
-    defaultDescription: _('AtB desc', 'AtB desc', 'AtB desc'),
+    defaultDescription: _(
+      'Finn rutetider, holdeplasser og tilbud for buss, trikk, båt og tog i Trøndelag med reiseplanleggeren.',
+      'Find timetables, stops and offers for bus, tram, boat and train in Trøndelag with the travel planner.',
+      'Finn rutetider, haldeplassar og tilbod for buss, trikk, båt og tog i Trøndelag med reiseplanleggjaren.',
+    ),
   },
 };
+
+export const Layout = orgSpecificTranslations(LayoutInternal, {
+  nfk: {
+    meta: {
+      defaultDescription: _(
+        'Finn rutetider, holdeplasser og tilbud for buss, trikk, båt og tog i Nordland med reiseplanleggeren.',
+        'Find timetables, stops and offers for bus, tram, boat and train in Nordland with the travel planner.',
+        'Finn rutetider, haldeplassar og tilbod for buss, trikk, båt og tog i Nordland med reiseplanleggjaren.',
+      ),
+    },
+  },
+  fram: {
+    meta: {
+      defaultDescription: _(
+        'Finn rutetider, holdeplasser og tilbud for buss, trikk, båt og tog i Møre og Romsdal med reiseplanleggeren.',
+        'Find timetables, stops and offers for bus, tram, boat and train in Møre og Romsdal with the travel planner.',
+        'Finn rutetider, haldeplassar og tilbod for buss, trikk, båt og tog i Møre og Romsdal med reiseplanleggjaren.',
+      ),
+    },
+  },
+});


### PR DESCRIPTION
Updated the meta description to not be "AtB desc" any more.

The current text is most likely temporary. Have asked Christoffer in FRAM what the text should be.

Closes https://github.com/AtB-AS/kundevendt/issues/15929