### PR TITLE
fix: show correct trip duration based on rounded times

### DIFF
--- a/src/page-modules/assistant/details/details-header/index.tsx
+++ b/src/page-modules/assistant/details/details-header/index.tsx
@@ -1,10 +1,9 @@
 import { PageText, useTranslation } from '@atb/translations';
 import { TripPatternWithDetails } from '../../server/journey-planner/validators';
 import {
-  formatSimpleTime,
   formatToSimpleDate,
   formatToWeekday,
-  secondsToDuration,
+  formatTripDuration,
 } from '@atb/utils/date';
 import { MonoIcon } from '@atb/components/icon';
 import { Typo } from '@atb/components/typography';
@@ -25,11 +24,17 @@ export default function DetailsHeader({ tripPattern }: DetailsHeaderProps) {
     'EEEE',
   )} ${formatToSimpleDate(tripPattern.expectedStartTime, language)}`;
 
-  const timeRange = `${formatSimpleTime(
+  const {
+    duration: tripDuration,
+    departure,
+    arrival,
+  } = formatTripDuration(
     tripPattern.expectedStartTime,
-  )} - ${formatSimpleTime(tripPattern.expectedEndTime)}`;
+    tripPattern.expectedEndTime,
+    language,
+  );
 
-  const tripDuration = secondsToDuration(tripPattern.duration, language);
+  const timeRange = `${departure} - ${arrival}`;
 
   return (
     <div className={style.container}>

--- a/src/page-modules/assistant/details/index.tsx
+++ b/src/page-modules/assistant/details/index.tsx
@@ -6,7 +6,7 @@ import style from './details.module.css';
 import DetailsHeader from './details-header';
 import { ButtonLink } from '@atb/components/button';
 import { Map } from '@atb/components/map';
-import { secondsToDuration } from '@atb/utils/date';
+import { formatTripDuration } from '@atb/utils/date';
 import { Typo } from '@atb/components/typography';
 import { getInterchangeDetails } from './trip-section/interchange-section';
 import { getLegWaitDetails } from './trip-section/wait-section';
@@ -19,6 +19,12 @@ export function AssistantDetails({ tripPattern }: AssistantDetailsProps) {
   const { t, language } = useTranslation();
 
   const mapLegs = tripPattern.legs.map((leg) => leg.mapLegs).flat();
+  const { duration } = formatTripDuration(
+    tripPattern.expectedStartTime,
+    tripPattern.expectedEndTime,
+    language,
+  );
+
   return (
     <div className={style.container}>
       <div className={style.headerContainer}>
@@ -47,11 +53,7 @@ export function AssistantDetails({ tripPattern }: AssistantDetailsProps) {
           <div className={style.duration}>
             <MonoIcon icon="time/Duration" />
             <Typo.p textType="body__primary">
-              {t(
-                PageText.Assistant.details.mapSection.travelTime(
-                  secondsToDuration(tripPattern.duration, language),
-                ),
-              )}
+              {t(PageText.Assistant.details.mapSection.travelTime(duration))}
             </Typo.p>
           </div>
           <div className={style.walkDistance}>

--- a/src/page-modules/assistant/details/trip-section/index.tsx
+++ b/src/page-modules/assistant/details/trip-section/index.tsx
@@ -44,8 +44,8 @@ export default function TripSection({
     subMode: leg.transportSubmode,
   });
 
-  const showFrom = !isWalkSection || !!(isFirst && isWalkSection);
-  const showTo = !isWalkSection || !!(isLast && isWalkSection);
+  const showFrom = !isWalkSection || (isFirst && isWalkSection);
+  const showTo = !isWalkSection || (isLast && isWalkSection);
 
   const showInterchangeSection =
     interchangeDetails && leg.interchangeTo?.guaranteed && leg.line;

--- a/src/page-modules/assistant/server/journey-planner/index.ts
+++ b/src/page-modules/assistant/server/journey-planner/index.ts
@@ -252,7 +252,6 @@ export function createJourneyApi(
       const data: RecursivePartial<TripPatternWithDetails> = {
         expectedStartTime: singleTripPattern?.expectedStartTime,
         expectedEndTime: singleTripPattern?.expectedEndTime,
-        duration: singleTripPattern?.duration ?? 0,
         walkDistance: singleTripPattern?.streetDistance ?? 0,
         legs: singleTripPattern?.legs.map((leg) => ({
           mode: isTransportModeType(leg.mode) ? leg.mode : 'unknown',
@@ -388,7 +387,6 @@ function mapResultToTrips(
     tripPatterns: trip.tripPatterns.map((tripPattern) => ({
       expectedStartTime: tripPattern.expectedStartTime,
       expectedEndTime: tripPattern.expectedEndTime,
-      duration: tripPattern.duration || 0,
       walkDistance: tripPattern.streetDistance || 0,
       legs: tripPattern.legs.map((leg) => {
         return {

--- a/src/page-modules/assistant/server/journey-planner/journey-gql/trip-with-details.gql
+++ b/src/page-modules/assistant/server/journey-planner/journey-gql/trip-with-details.gql
@@ -28,7 +28,6 @@ query TripsWithDetails(
     tripPatterns {
       expectedStartTime
       expectedEndTime
-      duration
       streetDistance
       legs {
         mode

--- a/src/page-modules/assistant/server/journey-planner/journey-gql/trip.gql
+++ b/src/page-modules/assistant/server/journey-planner/journey-gql/trip.gql
@@ -94,7 +94,6 @@ fragment trip on Trip {
 fragment tripPattern on TripPattern {
   expectedStartTime
   expectedEndTime
-  duration
   streetDistance
   legs {
     mode

--- a/src/page-modules/assistant/server/journey-planner/validators.ts
+++ b/src/page-modules/assistant/server/journey-planner/validators.ts
@@ -61,7 +61,6 @@ export const legSchema = z.object({
 export const tripPatternSchema = z.object({
   expectedStartTime: z.string(),
   expectedEndTime: z.string(),
-  duration: z.number(),
   walkDistance: z.number(),
   legs: z.array(legSchema),
   compressedQuery: z.string(),
@@ -83,7 +82,6 @@ export const nonTransitSchema = z.object({
 export const tripPatternWithDetailsSchema = z.object({
   expectedStartTime: z.string(),
   expectedEndTime: z.string(),
-  duration: z.number(),
   walkDistance: z.number(),
   legs: z.array(
     z.object({

--- a/src/page-modules/assistant/trip/trip-pattern/__tests__/trip-pattern.fixture.ts
+++ b/src/page-modules/assistant/trip/trip-pattern/__tests__/trip-pattern.fixture.ts
@@ -1,18 +1,17 @@
 import { TripPattern } from '../../../server/journey-planner/validators';
 
 export const tripPatternFixture: TripPattern = {
-  expectedStartTime: '2023-01-01T00:00:00+01:00',
-  expectedEndTime: '2023-01-01T01:00:00+01:00',
-  duration: 3600,
+  expectedStartTime: '2023-01-01T01:00:00+01:00',
+  expectedEndTime: '2023-01-01T02:00:00+01:00',
   walkDistance: 0,
   legs: [
     {
       mode: 'bus',
       distance: 1,
       duration: 1,
-      aimedStartTime: '2023-01-01T00:00:00+01:00',
-      expectedEndTime: '2023-01-01T01:00:00+01:00',
-      expectedStartTime: '2023-01-01T00:00:00+01:00',
+      aimedStartTime: '2023-01-01T01:00:00+01:00',
+      expectedEndTime: '2023-01-01T02:00:00+01:00',
+      expectedStartTime: '2023-01-01T01:00:00+01:00',
       realtime: false,
       transportSubmode: 'regionalBus',
       line: {

--- a/src/page-modules/assistant/trip/trip-pattern/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/index.tsx
@@ -104,7 +104,7 @@ export default function TripPattern({
                   </div>
 
                   <Typo.span textType="body__tertiary">
-                    {formatToClock(leg.aimedStartTime, language, 'floor')}
+                    {formatToClock(leg.expectedStartTime, language, 'floor')}
                   </Typo.span>
                 </div>
 

--- a/src/page-modules/assistant/trip/trip-pattern/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/index.tsx
@@ -5,7 +5,7 @@ import { getFilteredLegsByWalkOrWaitTime, tripSummary } from './utils';
 import { PageText, useTranslation } from '@atb/translations';
 import { type TripPattern as TripPatternType } from '../../server/journey-planner/validators';
 import style from './trip-pattern.module.css';
-import { formatLocaleTime, isInPast } from '@atb/utils/date';
+import { formatToClock, isInPast } from '@atb/utils/date';
 import { TripPatternHeader } from './trip-pattern-header';
 import { MonoIcon } from '@atb/components/icon';
 import { Typo } from '@atb/components/typography';
@@ -104,7 +104,7 @@ export default function TripPattern({
                   </div>
 
                   <Typo.span textType="body__tertiary">
-                    {formatLocaleTime(leg.aimedStartTime, language)}
+                    {formatToClock(leg.aimedStartTime, language, 'floor')}
                   </Typo.span>
                 </div>
 
@@ -136,7 +136,7 @@ export default function TripPattern({
             <MonoIcon icon="places/Destination" />
           </div>
           <Typo.span textType="body__tertiary">
-            {formatLocaleTime(tripPattern.expectedEndTime, language)}
+            {formatToClock(tripPattern.expectedEndTime, language, 'ceil')}
           </Typo.span>
         </div>
       </div>

--- a/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/__tests__/trip-pattern.fixture.ts
+++ b/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/__tests__/trip-pattern.fixture.ts
@@ -1,18 +1,17 @@
 import { TripPattern } from '../../../../server/journey-planner/validators';
 
 export const tripPatternFixture: TripPattern = {
-  expectedStartTime: '2023-01-01T00:00:00+01:00',
-  expectedEndTime: '2023-01-01T01:00:00+01:00',
-  duration: 3600,
+  expectedStartTime: '2023-01-01T01:00:00+01:00',
+  expectedEndTime: '2023-01-01T02:00:00+01:00',
   walkDistance: 0,
   legs: [
     {
       mode: 'bus',
       distance: 1,
       duration: 1,
-      aimedStartTime: '2023-01-01T00:00:00+01:00',
-      expectedEndTime: '2023-01-01T01:00:00+01:00',
-      expectedStartTime: '2023-01-01T00:00:00+01:00',
+      aimedStartTime: '2023-01-01T01:00:00+01:00',
+      expectedEndTime: '2023-01-01T02:00:00+01:00',
+      expectedStartTime: '2023-01-01T01:00:00+01:00',
       realtime: false,
       transportSubmode: 'regionalBus',
       line: {

--- a/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/index.tsx
@@ -2,7 +2,7 @@ import { TripPattern, Quay } from '../../../server/journey-planner/validators';
 import style from './trip-pattern-header.module.css';
 import { Typo } from '@atb/components/typography';
 import { useTranslation, PageText } from '@atb/translations';
-import { secondsToDuration } from '@atb/utils/date';
+import { formatTripDuration } from '@atb/utils/date';
 import { flatMap } from 'lodash';
 import { getNoticesForLeg } from './utils';
 import { RailReplacementBusMessage } from './rail-replacement-bus';
@@ -15,7 +15,11 @@ type TripPatternHeaderProps = {
 export function TripPatternHeader({ tripPattern }: TripPatternHeaderProps) {
   const { t, language } = useTranslation();
 
-  const duration = secondsToDuration(tripPattern.duration, language);
+  const { duration } = formatTripDuration(
+    tripPattern.expectedStartTime,
+    tripPattern.expectedEndTime,
+    language,
+  );
 
   const { startMode, startPlace } = getStartModeAndPlace(tripPattern);
 

--- a/src/page-modules/assistant/trip/trip-pattern/utils.ts
+++ b/src/page-modules/assistant/trip/trip-pattern/utils.ts
@@ -2,7 +2,6 @@ import {
   formatToClock,
   formatTripDuration,
   secondsBetween,
-  secondsToDuration,
 } from '@atb/utils/date';
 import { Leg, TripPattern } from '../../server/journey-planner/validators';
 import { getQuayName } from './trip-pattern-header';

--- a/src/page-modules/assistant/trip/trip-pattern/utils.ts
+++ b/src/page-modules/assistant/trip/trip-pattern/utils.ts
@@ -1,5 +1,6 @@
 import {
   formatToClock,
+  formatTripDuration,
   secondsBetween,
   secondsToDuration,
 } from '@atb/utils/date';
@@ -141,11 +142,16 @@ export const tripSummary = (
     filteredLegs.length > 0 &&
     isLegFlexibleTransport(filteredLegs[filteredLegs.length - 1]);
 
+  const { duration } = formatTripDuration(
+    tripPattern.expectedStartTime,
+    tripPattern.expectedEndTime,
+    language,
+  );
   const travelTimesText = t(
     PageText.Assistant.trip.tripSummary.journeySummary.travelTimes(
       formatToClock(tripPattern.expectedStartTime, language, 'floor'),
       formatToClock(tripPattern.expectedEndTime, language, 'ceil'),
-      secondsToDuration(tripPattern.duration, language),
+      duration,
       startTimeIsApproximation,
       endTimeIsApproximation,
     ),

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -331,3 +331,26 @@ function getShortHumanizer(
 
   return humanizer(ms, opts);
 }
+
+export function formatTripDuration(
+  originalDepartureTimeISO: string,
+  originalArrivalTimeISO: string,
+  language: Language,
+) {
+  const regex = /T(\d{2}:\d{2}):\d{2}\+/;
+  const departure = formatToClock(originalDepartureTimeISO, language, 'floor');
+  const arrival = formatToClock(originalArrivalTimeISO, language, 'ceil');
+
+  const departureTime = originalDepartureTimeISO.replace(
+    regex,
+    `T${departure}:00+`,
+  );
+  const arrivalTime = originalArrivalTimeISO.replace(regex, `T${arrival}:00+`);
+
+  const duration = secondsToDuration(
+    secondsBetween(departureTime, arrivalTime),
+    language,
+  );
+
+  return { duration, departure, arrival };
+}


### PR DESCRIPTION
Show correct trip duration based on rounded times. Previously the trip duration did not always correspond with the formatted times of departure and arrival. E.g. if a trip departs at 16:04 and arrives at 16:48, the duration might have said 42 minutes since the departure time rounds down (floors) and arrival times are rounded up (ceil)¹. 

So the solution was to base the duration of the trip on the formatted times of departure and arrival, ignoring the real duration of the trip. That way we get a duration corresponding with the times shown.

[1]: AtB have spent deciding how to round the departure and arrival times in the app, so that should be done the same in the travel planner; "We have chosen to display rounding that minimizes the likelihood of the user missing the bus - so departures are rounded down, while arrivals are rounded up."

Closes https://github.com/AtB-AS/kundevendt/issues/15928