### PR TITLE
feat: show duration of walking leg

### DIFF
--- a/src/components/map/map.tsx
+++ b/src/components/map/map.tsx
@@ -7,7 +7,6 @@ import { Button } from '@atb/components/button';
 import { MonoIcon } from '@atb/components/icon';
 import { ComponentText, useTranslation } from '@atb/translations';
 import { FocusScope } from '@react-aria/focus';
-import { useTheme } from '@atb/modules/theme';
 import { ZOOM_LEVEL, defaultPosition } from './utils';
 import { useMapInteractions } from './use-map-interactions';
 import { useFullscreenMap } from './use-fullscreen-map';
@@ -31,7 +30,6 @@ export function Map({
   mapLegs,
   initialZoom = ZOOM_LEVEL,
 }: MapProps) {
-  const { transport } = useTheme();
   const mapWrapper = useRef<HTMLDivElement>(null);
   const mapContainer = useRef<HTMLDivElement>(null);
   const map = useRef<mapboxgl.Map>();
@@ -56,7 +54,7 @@ export function Map({
     map,
   );
   useMapPin(map, position, layer);
-  useMapLegs(map, transport, mapLegs);
+  useMapLegs(map, mapLegs);
 
   useEffect(() => {
     if (map.current) {

--- a/src/components/map/use-map-legs.ts
+++ b/src/components/map/use-map-legs.ts
@@ -12,7 +12,7 @@ export const useMapLegs = (
   mapLegs?: MapLegType[],
 ) => {
   const { t, language } = useTranslation();
-  const theme = useTheme();
+  const { transport, static: staticColors } = useTheme();
 
   const addToMap = useCallback(
     (map: Map, mapLeg: MapLegType, id: number) => {
@@ -21,7 +21,7 @@ export const useMapLegs = (
           mode: mapLeg.faded ? 'unknown' : mapLeg.transportMode,
           subMode: mapLeg.transportSubmode,
         },
-        theme,
+        transport,
       );
       const lineColor = mapLeg.faded
         ? hexToRgba(transportColor.background, 0.5)
@@ -40,7 +40,7 @@ export const useMapLegs = (
       map.addLayer(createRouteLayer(id, lineColor, isDotted));
       map.addLayer(createStartEndLayer(id, lineColor));
     },
-    [theme],
+    [transport],
   );
 
   const addStartEndText = useCallback(
@@ -51,13 +51,13 @@ export const useMapLegs = (
       const startTextLayer = createStartEndTextLayer(
         startTextSourceId,
         t(ComponentText.Map.map.startPoint),
-        theme.static.background.background_accent_0,
+        staticColors.background.background_accent_0,
       );
       const endTextPoint = createStartEndTextPoint(endMapLeg.points[0]);
       const endTextLayer = createStartEndTextLayer(
         endTextSourceId,
         t(ComponentText.Map.map.endPoint),
-        theme.static.background.background_accent_0,
+        staticColors.background.background_accent_0,
       );
 
       map.addSource(startTextSourceId, startTextPoint);
@@ -65,7 +65,7 @@ export const useMapLegs = (
       map.addLayer(startTextLayer);
       map.addLayer(endTextLayer);
     },
-    [theme, t],
+    [staticColors, t],
   );
 
   /**

--- a/src/modules/transport-mode/icon/icon.module.css
+++ b/src/modules/transport-mode/icon/icon.module.css
@@ -13,11 +13,20 @@
 .transportIconWithLabel {
   display: flex;
   align-items: center;
-  gap: var(--spacings-xSmall);
   padding: var(--spacings-small) var(--spacings-medium);
 }
 
 .transportIcon img,
 .transportIconWithLabel img {
   display: block;
+}
+
+.transportIconWithLabel__label {
+  margin-left: var(--spacings-xSmall);
+}
+
+.transportIconWithLabel__duration {
+  align-self: flex-end;
+  transform: translateY(25%);
+  margin-left: -0.125rem;
 }

--- a/src/modules/transport-mode/icon/index.tsx
+++ b/src/modules/transport-mode/icon/index.tsx
@@ -1,13 +1,14 @@
 import { TransportModeGroup, TransportSubmodeType } from '../types';
-
 import { ContrastColor, Theme } from '@atb-as/theme';
 import MonoIcon, { MonoIconProps } from '@atb/components/icon/mono-icon';
 import { useTheme } from '@atb/modules/theme';
-
 import { useTranslation } from '@atb/translations';
 import { transportModeToTranslatedString } from '../utils';
-import style from './icon.module.css';
 import { colorToOverrideMode } from '@atb/utils/color';
+import { Typo } from '@atb/components/typography';
+import { secondsToMinutes } from 'date-fns';
+
+import style from './icon.module.css';
 
 export type TransportIconsProps = {
   modes: TransportModeGroup[];
@@ -56,26 +57,56 @@ export function TransportMonoIcon({ mode }: TransportIconProps) {
 export type TransportIconWithLabelProps = {
   mode: TransportModeGroup;
   label?: string | null;
+  duration?: number | null;
 };
 
-export function TransportIconWithLabel({
+export function TransportIconWithLabelOrDuration({
   mode,
   label,
+  duration,
 }: TransportIconWithLabelProps) {
   const { t } = useTranslation();
-  const { backgroundColor, overrideMode } = useTransportationThemeColor(mode);
+  const { static: staticColors } = useTheme();
+  let colors = useTransportationThemeColor(mode);
+
+  // Walking legs should have a lighter background color in the trip pattern view.
+  if (mode.mode === 'foot') {
+    colors = {
+      backgroundColor: staticColors.background.background_2.background,
+      textColor: staticColors.background.background_2.text,
+      overrideMode: colorToOverrideMode(
+        staticColors.background.background_2.text,
+      ),
+    };
+  }
+
   return (
-    <span className={style.transportIconWithLabel} style={{ backgroundColor }}>
+    <span
+      className={style.transportIconWithLabel}
+      style={{ backgroundColor: colors.backgroundColor }}
+    >
       <MonoIcon
         icon={getTransportModeIcon(mode)}
         role="img"
         alt={t(transportModeToTranslatedString(mode))}
-        overrideMode={overrideMode}
+        overrideMode={colors.overrideMode}
       />
       {label && (
-        <span style={{ color: overrideMode === 'light' ? 'black' : 'white' }}>
+        <span
+          style={{ color: colors.textColor }}
+          className={style.transportIconWithLabel__label}
+        >
           {label}
         </span>
+      )}
+      {!label && duration && (
+        <Typo.span
+          textType="body__tertiary"
+          style={{ color: colors.textColor }}
+          className={style.transportIconWithLabel__duration}
+        >
+          {Math.max(secondsToMinutes(duration), 1)}
+        </Typo.span>
       )}
     </span>
   );

--- a/src/page-modules/assistant/trip/trip-pattern/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/index.tsx
@@ -9,7 +9,7 @@ import { formatLocaleTime, isInPast } from '@atb/utils/date';
 import { TripPatternHeader } from './trip-pattern-header';
 import { MonoIcon } from '@atb/components/icon';
 import { Typo } from '@atb/components/typography';
-import { TransportIconWithLabel } from '@atb/modules/transport-mode';
+import { TransportIconWithLabelOrDuration } from '@atb/modules/transport-mode';
 import { andIf } from '@atb/utils/css';
 
 const LAST_LEG_PADDING = 20;
@@ -89,12 +89,13 @@ export default function TripPattern({
                 <div className={style.legs__leg}>
                   <div className={style.legs__leg__icon}>
                     {leg.mode ? (
-                      <TransportIconWithLabel
+                      <TransportIconWithLabelOrDuration
                         mode={{
                           mode: leg.mode,
                           subMode: leg.transportSubmode ?? undefined,
                         }}
                         label={leg.line?.publicCode}
+                        duration={leg.mode === 'foot' ? leg.duration : null}
                       />
                     ) : (
                       <div className={style.legs__leg__walkIcon}>


### PR DESCRIPTION
Show the duration of a walking leg in the search results view. The icon for a leg that is by foot is now showing how many minutes of walking it is (showing a minimum of 1 if the duration is less than a minute).


Closes https://github.com/AtB-AS/kundevendt/issues/15924