### PR TITLE
fix: avoid crashing details if browser not supports webgl

### DIFF
--- a/src/components/map/map.module.css
+++ b/src/components/map/map.module.css
@@ -51,6 +51,7 @@
   width: 100%;
   border-radius: 0 0 var(--border-radius-regular) var(--border-radius-regular);
   overflow: hidden;
+  background-color: var(--static-background-background_0-background);
 }
 
 .mapContainer__borderRadius {

--- a/src/components/map/map.tsx
+++ b/src/components/map/map.tsx
@@ -39,6 +39,10 @@ export function Map({
 
   useEffect(() => {
     if (!mapContainer.current) return;
+
+    // If browsers doesn't support WebGL, don't initialize map
+    if (!mapboxgl.supported()) return;
+
     map.current = new mapboxgl.Map({
       container: mapContainer.current,
       accessToken: mapboxData.accessToken,

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -16,6 +16,8 @@ vi.stubEnv('NEXT_PUBLIC_MAPBOX_DEFAULT_LNG', '6.1495');
 vi.mock('mapbox-gl/dist/mapbox-gl.js', () => {
   return {
     default: {
+      // Mark mapbox as not supported in test env.
+      supported: () => false,
       Map: class Map {
         setCenter() {}
         remove() {}


### PR DESCRIPTION
Disables map if the browser doesn't support WebGL. These are old browsers. Acceptable to not show map if this happens