### PR TITLE
fix: show "Ferry from" if it's ferry and not boat

### DIFF
--- a/src/modules/transport-mode/icon/index.tsx
+++ b/src/modules/transport-mode/icon/index.tsx
@@ -3,7 +3,7 @@ import { ContrastColor, Theme } from '@atb-as/theme';
 import MonoIcon, { MonoIconProps } from '@atb/components/icon/mono-icon';
 import { useTheme } from '@atb/modules/theme';
 import { useTranslation } from '@atb/translations';
-import { transportModeToTranslatedString } from '../utils';
+import { isSubmodeBoat, transportModeToTranslatedString } from '../utils';
 import { colorToOverrideMode } from '@atb/utils/color';
 import { Typo } from '@atb/components/typography';
 import { secondsToMinutes } from 'date-fns';
@@ -122,14 +122,6 @@ export function useTransportationThemeColor(mode: TransportModeGroup) {
   };
 }
 
-const TRANSPORT_SUB_MODES_BOAT: TransportSubmodeType[] = [
-  'highSpeedPassengerService',
-  'highSpeedVehicleService',
-  'nationalPassengerFerry',
-  'localPassengerFerry',
-  'sightseeingService',
-];
-
 export function transportModeToColor(
   mode: TransportModeGroup,
   transport: Theme['transport'],
@@ -189,7 +181,7 @@ export function getTransportModeIcon(
     case 'air':
       return 'transportation-entur/Plane';
     case 'water':
-      return mode.subMode && TRANSPORT_SUB_MODES_BOAT.includes(mode.subMode)
+      return isSubmodeBoat(mode.subMode)
         ? 'transportation/Boat'
         : 'transportation/Ferry';
     case 'metro':

--- a/src/modules/transport-mode/index.ts
+++ b/src/modules/transport-mode/index.ts
@@ -12,6 +12,7 @@ export {
   isTransportModeType,
   isTransportSubmodeType,
   filterGraphQlTransportModes,
+  isSubmodeBoat,
 } from './utils';
 
 export * from './icon';

--- a/src/modules/transport-mode/utils.ts
+++ b/src/modules/transport-mode/utils.ts
@@ -41,3 +41,16 @@ export function filterGraphQlTransportModes(
   if (transportModes.length === 0) return undefined;
   return transportModes;
 }
+
+const TRANSPORT_SUB_MODES_BOAT: TransportSubmodeType[] = [
+  'highSpeedPassengerService',
+  'highSpeedVehicleService',
+  'nationalPassengerFerry',
+  'localPassengerFerry',
+  'sightseeingService',
+];
+
+export function isSubmodeBoat(submode?: TransportSubmodeType) {
+  if (!submode) return false;
+  return TRANSPORT_SUB_MODES_BOAT.includes(submode);
+}

--- a/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/__tests__/trip-pattern-header.test.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/__tests__/trip-pattern-header.test.tsx
@@ -2,14 +2,18 @@ import { cleanup, render, screen } from '@testing-library/react';
 import mockRouter from 'next-router-mock';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createDynamicRouteParser } from 'next-router-mock/dynamic-routes';
-import { getQuayName, getStartModeAndPlace, TripPatternHeader } from '..';
+import { getQuayName, getStartModeAndPlaceText, TripPatternHeader } from '..';
 import { tripPatternFixture } from './trip-pattern.fixture';
 import {
   AppCookiesProvider,
   AppCookiesProviderProps,
 } from '@atb/modules/cookies/cookies-context';
 import React from 'react';
-import { AppLanguageProvider } from '@atb/translations';
+import {
+  AppLanguageProvider,
+  Language,
+  useTranslation,
+} from '@atb/translations';
 
 afterEach(function () {
   cleanup();
@@ -97,9 +101,25 @@ describe('trip pattern header', function () {
   });
 
   it('should get start mode and start place from trip', () => {
-    const { startMode, startPlace } = getStartModeAndPlace(tripPatternFixture);
+    const Test = function () {
+      const { t } = useTranslation();
 
-    expect(startMode).toBe('bus');
-    expect(startPlace).toBe('From 1');
+      const startModeAndPlaceText = getStartModeAndPlaceText(
+        tripPatternFixture,
+        t,
+      );
+      return <div>{startModeAndPlaceText}</div>;
+    };
+
+    customRender(<Test />, {
+      providerProps: {
+        initialCookies: {
+          darkmode: false,
+          language: 'no',
+        },
+      },
+    });
+
+    expect(screen.getByText('Buss fra From 1')).toBeInTheDocument();
   });
 });

--- a/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/index.tsx
@@ -1,12 +1,13 @@
 import { TripPattern, Quay } from '../../../server/journey-planner/validators';
 import style from './trip-pattern-header.module.css';
 import { Typo } from '@atb/components/typography';
-import { useTranslation, PageText } from '@atb/translations';
+import { useTranslation, PageText, TranslateFunction } from '@atb/translations';
 import { formatTripDuration } from '@atb/utils/date';
 import { flatMap } from 'lodash';
 import { getNoticesForLeg } from './utils';
 import { RailReplacementBusMessage } from './rail-replacement-bus';
 import { SituationOrNoticeIcon } from '@atb/modules/situations';
+import { isSubmodeBoat } from '@atb/modules/transport-mode';
 
 type TripPatternHeaderProps = {
   tripPattern: TripPattern;
@@ -21,19 +22,12 @@ export function TripPatternHeader({ tripPattern }: TripPatternHeaderProps) {
     language,
   );
 
-  const { startMode, startSubmode, startPlace } =
-    getStartModeAndPlace(tripPattern);
+  const startModeAndPlaceText = getStartModeAndPlaceText(tripPattern, t);
 
   return (
     <header className={style.header}>
       <Typo.span textType="body__secondary--bold">
-        {t(
-          PageText.Assistant.trip.tripPattern.travelFrom(
-            startMode,
-            startSubmode,
-            startPlace,
-          ),
-        )}
+        {startModeAndPlaceText}
       </Typo.span>
       <Typo.span textType="body__secondary" className={style.header__duration}>
         {duration}
@@ -44,34 +38,63 @@ export function TripPatternHeader({ tripPattern }: TripPatternHeaderProps) {
       <SituationOrNoticeIcon
         situations={flatMap(tripPattern.legs, (leg) => leg.situations)}
         notices={flatMap(tripPattern.legs, getNoticesForLeg)}
-        accessibilityLabel={t(
-          PageText.Assistant.trip.tripPattern.travelFrom(
-            startMode,
-            startSubmode,
-            startPlace,
-          ),
-        )}
+        accessibilityLabel={startModeAndPlaceText}
       />
     </header>
   );
 }
 
-export function getStartModeAndPlace(tripPattern: TripPattern) {
+export function getStartModeAndPlaceText(
+  tripPattern: TripPattern,
+  t: TranslateFunction,
+): string {
   let startLeg = tripPattern.legs[0];
-  let startName = startLeg.fromPlace.name;
+  let tmpStartName = startLeg.fromPlace.name;
 
   if (tripPattern.legs[0].mode === 'foot' && tripPattern.legs[1]) {
     startLeg = tripPattern.legs[1];
-    startName = getQuayName(startLeg.fromPlace.quay);
+    tmpStartName = getQuayName(startLeg.fromPlace.quay);
   } else if (tripPattern.legs[0].mode !== 'foot') {
-    startName = getQuayName(startLeg.fromPlace.quay);
+    tmpStartName = getQuayName(startLeg.fromPlace.quay);
   }
 
-  return {
-    startMode: startLeg.mode ?? 'unknown',
-    startSubmode: startLeg.transportSubmode ?? undefined,
-    startPlace: startName ?? '',
-  };
+  const startName: string =
+    tmpStartName ??
+    t(PageText.Assistant.trip.tripPattern.travelFrom.unknownPlace);
+
+  switch (startLeg.mode) {
+    case 'bus':
+    case 'coach':
+      return t(PageText.Assistant.trip.tripPattern.travelFrom.bus(startName));
+    case 'tram':
+      return t(PageText.Assistant.trip.tripPattern.travelFrom.tram(startName));
+    case 'metro':
+      return t(PageText.Assistant.trip.tripPattern.travelFrom.metro(startName));
+    case 'rail':
+      return t(PageText.Assistant.trip.tripPattern.travelFrom.rail(startName));
+    case 'water':
+      if (isSubmodeBoat(startLeg.transportSubmode ?? 'unknown')) {
+        return t(
+          PageText.Assistant.trip.tripPattern.travelFrom.boat(startName),
+        );
+      } else {
+        return t(
+          PageText.Assistant.trip.tripPattern.travelFrom.ferry(startName),
+        );
+      }
+    case 'air':
+      return t(PageText.Assistant.trip.tripPattern.travelFrom.air(startName));
+    case 'bicycle':
+      return t(
+        PageText.Assistant.trip.tripPattern.travelFrom.bicycle(startName),
+      );
+    case 'foot':
+      return t(PageText.Assistant.trip.tripPattern.travelFrom.foot(startName));
+    default:
+      return t(
+        PageText.Assistant.trip.tripPattern.travelFrom.unknown(startName),
+      );
+  }
 }
 
 export function getQuayName(quay: Quay | null): string | null {

--- a/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/index.tsx
@@ -21,13 +21,18 @@ export function TripPatternHeader({ tripPattern }: TripPatternHeaderProps) {
     language,
   );
 
-  const { startMode, startPlace } = getStartModeAndPlace(tripPattern);
+  const { startMode, startSubmode, startPlace } =
+    getStartModeAndPlace(tripPattern);
 
   return (
     <header className={style.header}>
       <Typo.span textType="body__secondary--bold">
         {t(
-          PageText.Assistant.trip.tripPattern.travelFrom(startMode, startPlace),
+          PageText.Assistant.trip.tripPattern.travelFrom(
+            startMode,
+            startSubmode,
+            startPlace,
+          ),
         )}
       </Typo.span>
       <Typo.span textType="body__secondary" className={style.header__duration}>
@@ -40,7 +45,11 @@ export function TripPatternHeader({ tripPattern }: TripPatternHeaderProps) {
         situations={flatMap(tripPattern.legs, (leg) => leg.situations)}
         notices={flatMap(tripPattern.legs, getNoticesForLeg)}
         accessibilityLabel={t(
-          PageText.Assistant.trip.tripPattern.travelFrom(startMode, startPlace),
+          PageText.Assistant.trip.tripPattern.travelFrom(
+            startMode,
+            startSubmode,
+            startPlace,
+          ),
         )}
       />
     </header>
@@ -60,6 +69,7 @@ export function getStartModeAndPlace(tripPattern: TripPattern) {
 
   return {
     startMode: startLeg.mode ?? 'unknown',
+    startSubmode: startLeg.transportSubmode ?? undefined,
     startPlace: startName ?? '',
   };
 }

--- a/src/translations/pages/assistant.ts
+++ b/src/translations/pages/assistant.ts
@@ -1,5 +1,9 @@
 import { translation as _ } from '@atb/translations/commons';
-import { TransportModeType } from '@atb/modules/transport-mode';
+import {
+  isSubmodeBoat,
+  TransportModeType,
+  TransportSubmodeType,
+} from '@atb/modules/transport-mode';
 
 export const Assistant = {
   title: _('Planlegg reisen', 'Plan travel', 'Planlegg reisa'),
@@ -40,7 +44,11 @@ export const Assistant = {
   },
   trip: {
     tripPattern: {
-      travelFrom: (mode: TransportModeType, place: string) => {
+      travelFrom: (
+        mode: TransportModeType,
+        submode: TransportSubmodeType | undefined,
+        place: string,
+      ) => {
         switch (mode) {
           case 'bus':
           case 'coach':
@@ -68,10 +76,17 @@ export const Assistant = {
               `Tog frå ${place}`,
             );
           case 'water':
+            if (isSubmodeBoat(submode)) {
+              return _(
+                `Båt fra ${place}`,
+                `Boat from ${place}`,
+                `Båt frå ${place}`,
+              );
+            }
             return _(
-              `Båt fra ${place}`,
-              `Boat from ${place}`,
-              `Båt frå ${place}`,
+              `Ferge fra ${place}`,
+              `Ferry from ${place}`,
+              `Ferje frå ${place}`,
             );
           case 'air':
             return _(

--- a/src/translations/pages/assistant.ts
+++ b/src/translations/pages/assistant.ts
@@ -1,9 +1,4 @@
 import { translation as _ } from '@atb/translations/commons';
-import {
-  isSubmodeBoat,
-  TransportModeType,
-  TransportSubmodeType,
-} from '@atb/modules/transport-mode';
 
 export const Assistant = {
   title: _('Planlegg reisen', 'Plan travel', 'Planlegg reisa'),
@@ -44,71 +39,34 @@ export const Assistant = {
   },
   trip: {
     tripPattern: {
-      travelFrom: (
-        mode: TransportModeType,
-        submode: TransportSubmodeType | undefined,
-        place: string,
-      ) => {
-        switch (mode) {
-          case 'bus':
-          case 'coach':
-            return _(
-              `Buss fra ${place}`,
-              `Bus from ${place}`,
-              `Buss frå ${place}`,
-            );
-          case 'tram':
-            return _(
-              `Trikk fra ${place}`,
-              `Tram from ${place}`,
-              `Trikk frå ${place}`,
-            );
-          case 'metro':
-            return _(
-              `T-bane fra ${place}`,
-              `Metro from ${place}`,
-              `T-bane frå ${place}`,
-            );
-          case 'rail':
-            return _(
-              `Tog fra ${place}`,
-              `Train from ${place}`,
-              `Tog frå ${place}`,
-            );
-          case 'water':
-            if (isSubmodeBoat(submode)) {
-              return _(
-                `Båt fra ${place}`,
-                `Boat from ${place}`,
-                `Båt frå ${place}`,
-              );
-            }
-            return _(
-              `Ferge fra ${place}`,
-              `Ferry from ${place}`,
-              `Ferje frå ${place}`,
-            );
-          case 'air':
-            return _(
-              `Fly fra ${place}`,
-              `Air from ${place}`,
-              `Fly frå ${place}`,
-            );
-          case 'bicycle':
-            return _(
-              `Sykkel fra ${place}`,
-              `Bike from ${place}`,
-              `Sykkel frå ${place}`,
-            );
-          case 'foot':
-            return _(
-              `Gå fra ${place}`,
-              `Walk from ${place}`,
-              `Gå frå ${place}`,
-            );
-          default:
-            return _(`Fra ${place}`, `From ${place}`, `Frå ${place}`);
-        }
+      travelFrom: {
+        bus: (place: string) =>
+          _(`Buss fra ${place}`, `Bus from ${place}`, `Buss frå ${place}`),
+        coach: (place: string) =>
+          _(`Buss fra ${place}`, `Coach from ${place}`, `Buss frå ${place}`),
+        tram: (place: string) =>
+          _(`Trikk fra ${place}`, `Tram from ${place}`, `Trikk frå ${place}`),
+        metro: (place: string) =>
+          _(
+            `T-bane fra ${place}`,
+            `Metro from ${place}`,
+            `T-bane frå ${place}`,
+          ),
+        rail: (place: string) =>
+          _(`Tog fra ${place}`, `Train from ${place}`, `Tog frå ${place}`),
+        boat: (place: string) =>
+          _(`Båt fra ${place}`, `Boat from ${place}`, `Båt frå ${place}`),
+        ferry: (place: string) =>
+          _(`Ferge fra ${place}`, `Ferry from ${place}`, `Ferje frå ${place}`),
+        air: (place: string) =>
+          _(`Fly fra ${place}`, `Air from ${place}`, `Fly frå ${place}`),
+        bicycle: (place: string) =>
+          _(`Sykkel fra ${place}`, `Bike from ${place}`, `Sykkel frå ${place}`),
+        foot: (place: string) =>
+          _(`Gå fra ${place}`, `Walk from ${place}`, `Gå frå ${place}`),
+        unknown: (place: string) =>
+          _(`Fra ${place}`, `From ${place}`, `Frå ${place}`),
+        unknownPlace: _('ukjent', 'unknown', 'ukjend'),
       },
       details: _('Detaljer', 'Details', 'Detaljar'),
       hasSituationsTip: _(


### PR DESCRIPTION
This PR fixes a mislabeling issue, ensuring the correct information is shown for transportation mode.

#### Changes Include:
-  Updated logic to correctly display "Ferry from" when the transportation mode is a ferry, not a boat.

**Impact**: This change improves the display information integrity, enhancing user understanding and experience.


Closes https://github.com/AtB-AS/kundevendt/issues/15996