### PR TITLE
i18n: fix translations for tab link

### DIFF
--- a/src/translations/common/layout.ts
+++ b/src/translations/common/layout.ts
@@ -6,7 +6,7 @@ const LayoutInternal = {
     defaultDescription: _(
       'Finn rutetider, holdeplasser og tilbud for buss, trikk, båt og tog i Trøndelag med reiseplanleggeren.',
       'Find timetables, stops and offers for bus, tram, boat and train in Trøndelag with the travel planner.',
-      'Finn rutetider, haldeplassar og tilbod for buss, trikk, båt og tog i Trøndelag med reiseplanleggjaren.',
+      'Finn rutetider, haldeplassar og tilbod for buss, trikk, båt og tog i Trøndelag med reiseplanleggaren.',
     ),
   },
 };
@@ -17,7 +17,7 @@ export const Layout = orgSpecificTranslations(LayoutInternal, {
       defaultDescription: _(
         'Finn rutetider, holdeplasser og tilbud for buss, båt og tog i Nordland med reiseplanleggeren.',
         'Find timetables, stops and offers for bus, boat and train in Nordland with the travel planner.',
-        'Finn rutetider, haldeplassar og tilbod for buss, båt og tog i Nordland med reiseplanleggjaren.',
+        'Finn rutetider, haldeplassar og tilbod for buss, båt og tog i Nordland med reiseplanleggaren.',
       ),
     },
   },
@@ -26,7 +26,7 @@ export const Layout = orgSpecificTranslations(LayoutInternal, {
       defaultDescription: _(
         'Finn rutetider, holdeplasser, kaier og tilbud for buss, hurtigbåt og ferge i Møre og Romsdal med reiseplanleggeren.',
         'Find timetables, stops and offers for bus, boat and ferry in Møre og Romsdal with the travel planner.',
-        'Finn rutetider, haldeplassar, kaier og tilbod for buss, hurtigbåt og ferje i Møre og Romsdal med reiseplanleggjaren.',
+        'Finn rutetider, haldeplassar, kaier og tilbod for buss, hurtigbåt og ferje i Møre og Romsdal med reiseplanleggaren.',
       ),
     },
   },

--- a/src/translations/components/tab-link.ts
+++ b/src/translations/components/tab-link.ts
@@ -1,6 +1,6 @@
 import { translation as _ } from '@atb/translations/commons';
 
 export const TabLink = {
-  assistant: _('Reiseplanlegger', 'Travel planer', 'Reiseplanlegger'),
+  assistant: _('Reiseplanlegger', 'Travel planner', 'Reiseplanleggar'),
   departures: _('Avganger', 'Departures', 'Avganger'),
 };


### PR DESCRIPTION
Fixes a couple of translations.

Nynorsk:
Reiseplanleggjaren → Reiseplanleggaren
Reiseplanleggeren → Reiseplanleggaren

Engelsk:
Travel planer → Travel planner