### PR TITLE
fix: use point in "From" as focus point

### DIFF
--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -113,6 +113,7 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
                   isLoading={isSwapping}
                 />
               }
+              autocompleteFocusPoint={tripQuery.from ?? undefined}
             />
           </div>
           <div className={style.date}>


### PR DESCRIPTION
Use the point in "From" as focus point when searching for address, pier or stop place in "To". 

The property was removed at some point and the only thing needed was to add it again.