### PR TITLE
refactor(filtering): include subMode, remove from departures

### DIFF
--- a/src/components/line-chip/index.tsx
+++ b/src/components/line-chip/index.tsx
@@ -19,8 +19,8 @@ export default function LineChip({
   publicCode,
 }: LineChipProps) {
   const transportationColor = useTransportationThemeColor({
-    mode: transportMode,
-    subMode: transportSubmode,
+    transportMode: transportMode,
+    transportSubModes: transportSubmode && [transportSubmode],
   });
 
   return (
@@ -33,8 +33,8 @@ export default function LineChip({
     >
       <TransportIcon
         mode={{
-          mode: transportMode,
-          subMode: transportSubmode,
+          transportMode: transportMode,
+          transportSubModes: transportSubmode && [transportSubmode],
         }}
       />
       {publicCode && (

--- a/src/components/map/map-header.tsx
+++ b/src/components/map/map-header.tsx
@@ -32,14 +32,14 @@ export function MapHeader({
               <MonoIcon size="large" icon="map/Pin" overrideMode="dark" />
             </div>
           ) : (
-            transportModes.map((mode) => (
-              <div key={`${mode}-icon`}>
+            transportModes.map((transportMode) => (
+              <div key={`${transportMode}-icon`}>
                 <MonoIcon
                   size="large"
                   overrideMode="dark"
-                  icon={getTransportModeIcon({ mode })}
+                  icon={getTransportModeIcon({ transportMode })}
                   role="img"
-                  alt={t(transportModeToTranslatedString({ mode }))}
+                  alt={t(transportModeToTranslatedString({ transportMode }))}
                 />
               </div>
             ))

--- a/src/components/map/use-map-legs.ts
+++ b/src/components/map/use-map-legs.ts
@@ -18,8 +18,10 @@ export const useMapLegs = (
     (map: Map, mapLeg: MapLegType, id: number) => {
       const transportColor = transportModeToColor(
         {
-          mode: mapLeg.faded ? 'unknown' : mapLeg.transportMode,
-          subMode: mapLeg.transportSubmode,
+          transportMode: mapLeg.faded ? 'unknown' : mapLeg.transportMode,
+          transportSubModes: mapLeg.transportSubmode && [
+            mapLeg.transportSubmode,
+          ],
         },
         transport,
       );

--- a/src/modules/transport-mode/filter/filter.tsx
+++ b/src/modules/transport-mode/filter/filter.tsx
@@ -109,8 +109,10 @@ function FilterCheckbox({ option, checked, onChange }: FilterCheckboxProps) {
       <label htmlFor={option.id} aria-hidden>
         <MonoIcon
           icon={getTransportModeIcon({
-            mode: option.icon?.transportMode,
-            subMode: option.icon?.transportSubMode,
+            transportMode: option.icon?.transportMode,
+            transportSubModes: option.icon?.transportSubMode
+              ? [option.icon.transportSubMode]
+              : undefined,
           })}
         />
         <span id={`label-${option.id}`}>{text}</span>

--- a/src/modules/transport-mode/filter/utils.ts
+++ b/src/modules/transport-mode/filter/utils.ts
@@ -4,7 +4,7 @@ import {
   TransportModeFilterOptionType,
   TransportModeFilterState,
 } from './types';
-import { TransportModeType } from '../types';
+import type { TransportModeGroup } from '../types';
 
 const transportModeFilterOptions: TransportModeFilterOption[] = [
   'bus',
@@ -58,20 +58,18 @@ export function parseFilterQuery(
 
 export function getAllTransportModesFromFilterOptions(
   filterOptions: TransportModeFilterOption[] | null,
-): TransportModeType[] {
+): TransportModeGroup[] {
   if (!filterOptions)
-    return Object.values(filterOptionsWithTransportModes).flatMap((option) =>
-      option.modes.map((mode) => mode.transportMode),
+    return Object.values(filterOptionsWithTransportModes).flatMap(
+      (option) => option.modes,
     );
 
-  const transportModes: TransportModeType[] = [];
+  const transportModes: TransportModeGroup[] = [];
 
   filterOptions.forEach((filterOption) => {
     const option = filterOptionsWithTransportModes[filterOption];
 
-    const optionTransportModes = option.modes.map((mode) => mode.transportMode);
-
-    transportModes.push(...optionTransportModes);
+    transportModes.push(...option.modes);
   });
 
   return uniq(transportModes);

--- a/src/modules/transport-mode/icon/index.tsx
+++ b/src/modules/transport-mode/icon/index.tsx
@@ -3,7 +3,7 @@ import { ContrastColor, Theme } from '@atb-as/theme';
 import MonoIcon, { MonoIconProps } from '@atb/components/icon/mono-icon';
 import { useTheme } from '@atb/modules/theme';
 import { useTranslation } from '@atb/translations';
-import { isSubmodeBoat, transportModeToTranslatedString } from '../utils';
+import { isSubModeBoat, transportModeToTranslatedString } from '../utils';
 import { colorToOverrideMode } from '@atb/utils/color';
 import { Typo } from '@atb/components/typography';
 import { secondsToMinutes } from 'date-fns';
@@ -17,7 +17,10 @@ export function TransportIcons({ modes }: TransportIconsProps) {
   return (
     <div className={style.transportIcons}>
       {modes.map((mode) => (
-        <TransportIcon key={mode.mode + mode.subMode} mode={mode} />
+        <TransportIcon
+          key={mode.transportMode + mode.transportSubModes}
+          mode={mode}
+        />
       ))}
     </div>
   );
@@ -70,7 +73,7 @@ export function TransportIconWithLabel({
   let colors = useTransportationThemeColor(mode);
 
   // Walking legs should have a lighter background color in the trip pattern view.
-  if (mode.mode === 'foot') {
+  if (mode.transportMode === 'foot') {
     colors = {
       backgroundColor: staticColors.background.background_2.background,
       textColor: staticColors.background.background_2.text,
@@ -126,19 +129,19 @@ export function transportModeToColor(
   mode: TransportModeGroup,
   transport: Theme['transport'],
 ): ContrastColor {
-  switch (mode.mode) {
+  switch (mode.transportMode) {
     case 'bus':
     case 'coach':
-      if (mode.subMode === 'localBus') {
+      if (mode.transportSubModes?.includes('localBus')) {
         return transport.transport_city.primary;
       }
-      if (mode.subMode === 'airportLinkBus') {
+      if (mode.transportSubModes?.includes('airportLinkBus')) {
         return transport.transport_airport_express.primary;
       }
       return transport.transport_region.primary;
 
     case 'rail':
-      if (mode.subMode === 'airportLinkRail') {
+      if (mode.transportSubModes?.includes('airportLinkRail')) {
         return transport.transport_airport_express.primary;
       }
       return transport.transport_train.primary;
@@ -166,7 +169,7 @@ export function transportModeToColor(
 export function getTransportModeIcon(
   mode: TransportModeGroup,
 ): MonoIconProps['icon'] {
-  switch (mode.mode) {
+  switch (mode.transportMode) {
     case 'bus':
     case 'coach':
       return 'transportation/Bus';
@@ -181,7 +184,7 @@ export function getTransportModeIcon(
     case 'air':
       return 'transportation-entur/Plane';
     case 'water':
-      return isSubmodeBoat(mode.subMode)
+      return isSubModeBoat(mode.transportSubModes)
         ? 'transportation/Boat'
         : 'transportation/Ferry';
     case 'metro':

--- a/src/modules/transport-mode/index.ts
+++ b/src/modules/transport-mode/index.ts
@@ -12,7 +12,7 @@ export {
   isTransportModeType,
   isTransportSubmodeType,
   filterGraphQlTransportModes,
-  isSubmodeBoat,
+  isSubModeBoat,
 } from './utils';
 
 export * from './icon';

--- a/src/modules/transport-mode/types.ts
+++ b/src/modules/transport-mode/types.ts
@@ -140,6 +140,6 @@ export const transportSubmodeSchema = z.union([
 export type TransportSubmodeType = z.infer<typeof transportSubmodeSchema>;
 
 export type TransportModeGroup = {
-  mode: TransportModeType;
-  subMode?: TransportSubmodeType;
+  transportMode: TransportModeType;
+  transportSubModes?: TransportSubmodeType[];
 };

--- a/src/modules/transport-mode/utils.ts
+++ b/src/modules/transport-mode/utils.ts
@@ -9,16 +9,16 @@ import {
 import { TransportMode as GraphQlTransportMode } from '@atb/modules/graphql-types';
 
 export function transportModeToTranslatedString(mode: TransportModeGroup) {
-  if (!ComponentText.TransportMode.modes[mode.mode]) {
+  if (!ComponentText.TransportMode.modes[mode.transportMode]) {
     return ComponentText.TransportMode.modes.unknown;
   }
-  return ComponentText.TransportMode.modes[mode.mode];
+  return ComponentText.TransportMode.modes[mode.transportMode];
 }
 export function severalTransportModesToTranslatedStrings(
   modes: TransportModeGroup[],
 ) {
   return modes
-    .map((mode) => ComponentText.TransportMode.modes[mode.mode])
+    .map((mode) => ComponentText.TransportMode.modes[mode.transportMode])
     .filter(Boolean);
 }
 
@@ -50,7 +50,7 @@ const TRANSPORT_SUB_MODES_BOAT: TransportSubmodeType[] = [
   'sightseeingService',
 ];
 
-export function isSubmodeBoat(submode?: TransportSubmodeType) {
-  if (!submode) return false;
-  return TRANSPORT_SUB_MODES_BOAT.includes(submode);
+export function isSubModeBoat(subModes?: TransportSubmodeType[]) {
+  if (!subModes) return false;
+  return subModes.some((subMode) => TRANSPORT_SUB_MODES_BOAT.includes(subMode));
 }

--- a/src/page-modules/assistant/details/trip-section/index.tsx
+++ b/src/page-modules/assistant/details/trip-section/index.tsx
@@ -40,8 +40,8 @@ export default function TripSection({
   const { t } = useTranslation();
   const isWalkSection = leg.mode === 'foot';
   const legColor = useTransportationThemeColor({
-    mode: leg.mode,
-    subMode: leg.transportSubmode,
+    transportMode: leg.mode,
+    transportSubModes: leg.transportSubmode && [leg.transportSubmode],
   });
 
   const showFrom = !isWalkSection || (isFirst && isWalkSection);
@@ -86,7 +86,12 @@ export default function TripSection({
           <TripRow
             rowLabel={
               <TransportIcon
-                mode={{ mode: leg.mode, subMode: leg.transportSubmode }}
+                mode={{
+                  transportMode: leg.mode,
+                  transportSubModes: leg.transportSubmode && [
+                    leg.transportSubmode,
+                  ],
+                }}
                 size="small"
               />
             }

--- a/src/page-modules/assistant/details/trip-section/interchange-section.tsx
+++ b/src/page-modules/assistant/details/trip-section/interchange-section.tsx
@@ -24,8 +24,8 @@ export function InterchangeSection({
 }: InterchangeSectionProps) {
   const { t } = useTranslation();
   const unknownTransportationColor = useTransportationThemeColor({
-    mode: 'unknown',
-    subMode: undefined,
+    transportMode: 'unknown',
+    transportSubModes: undefined,
   });
   return (
     <div className={style.rowContainer}>

--- a/src/page-modules/assistant/details/trip-section/wait-section.tsx
+++ b/src/page-modules/assistant/details/trip-section/wait-section.tsx
@@ -21,8 +21,8 @@ export type WaitSectionProps = {
 export default function WaitSection({ legWaitDetails }: WaitSectionProps) {
   const { t, language } = useTranslation();
   const unknownTransportationColor = useTransportationThemeColor({
-    mode: 'unknown',
-    subMode: undefined,
+    transportMode: 'unknown',
+    transportSubModes: undefined,
   });
 
   const showWaitSection =

--- a/src/page-modules/assistant/details/trip-section/walk-section.tsx
+++ b/src/page-modules/assistant/details/trip-section/walk-section.tsx
@@ -16,7 +16,9 @@ export default function WalkSection({ walkDuration }: WalkSectionProps) {
   const isWalkTimeOfSignificance =
     walkDuration > MIN_SIGNIFICANT_WALK_IN_SECONDS;
   return (
-    <TripRow rowLabel={<TransportIcon mode={{ mode: 'foot' }} size="small" />}>
+    <TripRow
+      rowLabel={<TransportIcon mode={{ transportMode: 'foot' }} size="small" />}
+    >
       <Typo.p textType="body__secondary" className={style.walkTime}>
         {isWalkTimeOfSignificance
           ? t(

--- a/src/page-modules/assistant/non-transit-pill/index.tsx
+++ b/src/page-modules/assistant/non-transit-pill/index.tsx
@@ -32,7 +32,7 @@ export function NonTransitTrip({ nonTransit }: NonTransitTripProps) {
       href={`/assistant/${nonTransit.compressedQuery}`}
       title={`${modeText} ${durationShort}`}
       icon={{
-        left: <TransportMonoIcon mode={{ mode }} />,
+        left: <TransportMonoIcon mode={{ transportMode: mode }} />,
         right: <MonoIcon icon="navigation/ArrowRight" />,
       }}
     />

--- a/src/page-modules/assistant/server/journey-planner/index.ts
+++ b/src/page-modules/assistant/server/journey-planner/index.ts
@@ -1,7 +1,7 @@
 import { GraphQlRequester } from '@atb/modules/api-server';
 import {
   StreetMode,
-  TransportMode as GraphQlTransportMode,
+  TransportModes as GraphQlTransportModes,
   Notice as GraphQlNotice,
 } from '@atb/modules/graphql-types';
 import {
@@ -146,10 +146,7 @@ export function createJourneyApi(
         // Show specific non-transit suggestions through separate API call
         directMode: undefined,
         egressMode: StreetMode.Foot,
-        transportModes:
-          input.transportModes?.map((mode) => ({
-            transportMode: mode as GraphQlTransportMode,
-          })) ?? undefined,
+        transportModes: input.transportModes as GraphQlTransportModes[],
       };
 
       const from = inputToLocation(input, 'from');
@@ -359,8 +356,8 @@ type RecursivePartial<T> = {
   [P in keyof T]?: T[P] extends (infer U)[]
     ? RecursivePartial<U>[]
     : T[P] extends object | undefined
-    ? RecursivePartial<T[P]>
-    : T[P];
+      ? RecursivePartial<T[P]>
+      : T[P];
 };
 
 function inputToLocation(

--- a/src/page-modules/assistant/trip/trip-pattern/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/index.tsx
@@ -91,8 +91,10 @@ export default function TripPattern({
                     {leg.mode ? (
                       <TransportIconWithLabel
                         mode={{
-                          mode: leg.mode,
-                          subMode: leg.transportSubmode ?? undefined,
+                          transportMode: leg.mode,
+                          transportSubModes: leg.transportSubmode
+                            ? [leg.transportSubmode]
+                            : undefined,
                         }}
                         label={leg.line?.publicCode ?? undefined}
                         duration={

--- a/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/index.tsx
@@ -7,7 +7,7 @@ import { flatMap } from 'lodash';
 import { getNoticesForLeg } from './utils';
 import { RailReplacementBusMessage } from './rail-replacement-bus';
 import { SituationOrNoticeIcon } from '@atb/modules/situations';
-import { isSubmodeBoat } from '@atb/modules/transport-mode';
+import { isSubModeBoat } from '@atb/modules/transport-mode';
 
 type TripPatternHeaderProps = {
   tripPattern: TripPattern;
@@ -73,7 +73,10 @@ export function getStartModeAndPlaceText(
     case 'rail':
       return t(PageText.Assistant.trip.tripPattern.travelFrom.rail(startName));
     case 'water':
-      if (isSubmodeBoat(startLeg.transportSubmode ?? 'unknown')) {
+      if (
+        startLeg.transportSubmode &&
+        isSubModeBoat([startLeg.transportSubmode])
+      ) {
         return t(
           PageText.Assistant.trip.tripPattern.travelFrom.boat(startName),
         );

--- a/src/page-modules/assistant/trip/trip-pattern/utils.ts
+++ b/src/page-modules/assistant/trip/trip-pattern/utils.ts
@@ -48,7 +48,7 @@ export const tripSummary = (
         PageText.Assistant.trip.tripSummary.header.title(
           t(
             transportModeToTranslatedString({
-              mode: tripPattern.legs[0].mode ?? 'unknown',
+              transportMode: tripPattern.legs[0].mode ?? 'unknown',
             }),
           ),
           quayName,
@@ -72,7 +72,7 @@ export const tripSummary = (
   const modeAndNumberText = firstLeg
     ? t(
         transportModeToTranslatedString({
-          mode: firstLeg.mode ?? 'unknown',
+          transportMode: firstLeg.mode ?? 'unknown',
         }),
       ) +
       (firstLeg.line?.publicCode
@@ -110,20 +110,20 @@ export const tripSummary = (
           .footLegsOnly,
       )
     : nonFootLegs.length === 1
-    ? t(
-        PageText.Assistant.trip.tripSummary.journeySummary.legsDescription
-          .noSwitching,
-      )
-    : nonFootLegs.length === 2
-    ? t(
-        PageText.Assistant.trip.tripSummary.journeySummary.legsDescription
-          .oneSwitch,
-      )
-    : t(
-        PageText.Assistant.trip.tripSummary.journeySummary.legsDescription.someSwitches(
-          nonFootLegs.length - 1,
-        ),
-      );
+      ? t(
+          PageText.Assistant.trip.tripSummary.journeySummary.legsDescription
+            .noSwitching,
+        )
+      : nonFootLegs.length === 2
+        ? t(
+            PageText.Assistant.trip.tripSummary.journeySummary.legsDescription
+              .oneSwitch,
+          )
+        : t(
+            PageText.Assistant.trip.tripSummary.journeySummary.legsDescription.someSwitches(
+              nonFootLegs.length - 1,
+            ),
+          );
 
   const walkDistance = tripPattern.legs
     .filter((l) => l.mode === 'foot')

--- a/src/page-modules/assistant/types.ts
+++ b/src/page-modules/assistant/types.ts
@@ -5,16 +5,16 @@ import type {
   TripData,
 } from './server/journey-planner/validators';
 import { searchModeSchema, type SearchTime } from '@atb/modules/search-time';
-import {
+import type {
   TransportModeFilterOption,
-  type TransportModeType,
+  TransportModeGroup,
 } from '@atb/modules/transport-mode';
 
 export type TripInput = {
   from: GeocoderFeature;
   to: GeocoderFeature;
   searchTime: SearchTime;
-  transportModes?: TransportModeType[];
+  transportModes?: TransportModeGroup[];
   cursor?: string;
 };
 

--- a/src/page-modules/departures/__tests__/departure.test.tsx
+++ b/src/page-modules/departures/__tests__/departure.test.tsx
@@ -135,7 +135,6 @@ describe('departure page', function () {
           searchTime: { mode: 'now' },
           from: null,
           isAddress: false,
-          transportModeFilter: null,
         }}
         nearestStopPlaces={[]}
       />,

--- a/src/page-modules/departures/departures.module.css
+++ b/src/page-modules/departures/departures.module.css
@@ -9,7 +9,6 @@
   display: grid;
   grid-template-areas:
     'main'
-    'alternatives';
 }
 
 .main {
@@ -20,6 +19,7 @@
   width: 100%;
   max-width: var(--maxPageWidth);
   padding: var(--spacings-xLarge);
+  padding-bottom: 5.75rem;
   margin: 0 auto;
 }
 
@@ -48,21 +48,6 @@
   grid-column: 1 / -1;
 }
 
-.alternativesWrapper {
-  grid-area: alternatives;
-  overflow: hidden;
-  width: 100%;
-  background-color: var(--static-background-background_accent_1-background);
-}
-
-.alternatives {
-  padding: var(--spacings-xLarge);
-  width: 100%;
-  max-width: var(--maxPageWidth);
-  margin: 0 auto;
-  padding-bottom: 5.75rem;
-}
-
 .buttons {
   align-self: end;
   display: flex;
@@ -71,8 +56,7 @@
   width: 100%;
   max-width: var(--maxPageWidth);
   margin: 0 auto;
-  padding: 0 var(--spacings-xLarge) var(--spacings-xLarge)
-    var(--spacings-xLarge);
+  padding: 0 var(--spacings-xLarge) var(--spacings-xLarge) var(--spacings-xLarge);
   z-index: 10;
   position: absolute;
   left: 0;
@@ -84,7 +68,6 @@
     grid-template-areas:
       'main'
       'buttons'
-      'alternatives';
   }
 
   .main {
@@ -95,13 +78,7 @@
 
   .buttons {
     grid-area: buttons;
-    display: grid;
-    grid-template-columns: 1fr 1fr;
     position: relative;
-  }
-
-  .alternatives {
-    padding-bottom: var(--spacings-xLarge);
   }
 }
 

--- a/src/page-modules/departures/details/estimated-call-rows.tsx
+++ b/src/page-modules/departures/details/estimated-call-rows.tsx
@@ -147,8 +147,8 @@ function EstimatedCallRow({
   const { group, isStartOfGroup, isEndOfGroup } = call.metadata;
   const isBetween = !isStartOfGroup && !isEndOfGroup;
   const iconColor = useTransportationThemeColor({
-    mode: group === 'trip' ? mode : 'unknown',
-    subMode,
+    transportMode: group === 'trip' ? mode : 'unknown',
+    transportSubModes: subMode && [subMode],
   });
 
   return (

--- a/src/page-modules/departures/fetch-departure-query.ts
+++ b/src/page-modules/departures/fetch-departure-query.ts
@@ -1,5 +1,4 @@
 import { parseSearchTimeQuery } from '@atb/modules/search-time';
-import { parseFilterQuery } from '@atb/modules/transport-mode';
 import type { DepartureClient } from './server';
 import type { FromDepartureQuery } from './types';
 
@@ -9,7 +8,6 @@ export async function fetchFromDepartureQuery(
   client: DepartureClient,
 ): Promise<FromDepartureQuery> {
   const id = paramId?.[0];
-  const transportModeFilter = parseFilterQuery(query.filter);
   const searchTime = parseSearchTimeQuery(
     query.searchMode,
     query.searchTime ? Number(query.searchTime) : undefined,
@@ -25,7 +23,6 @@ export async function fetchFromDepartureQuery(
 
     return {
       isAddress: false,
-      transportModeFilter,
       searchTime,
       from: from ?? null,
     };
@@ -40,7 +37,6 @@ export async function fetchFromDepartureQuery(
     return {
       isAddress: true,
       from: from ?? null,
-      transportModeFilter,
       searchTime,
     };
   }
@@ -48,7 +44,6 @@ export async function fetchFromDepartureQuery(
   return {
     from: null,
     isAddress: false,
-    transportModeFilter,
     searchTime,
   };
 }

--- a/src/page-modules/departures/layout.tsx
+++ b/src/page-modules/departures/layout.tsx
@@ -1,19 +1,12 @@
 import { Button } from '@atb/components/button';
-import { MonoIcon } from '@atb/components/icon';
 import LoadingEmptySearch from '@atb/components/loading-empty-results';
 import { MessageBox } from '@atb/components/message-box';
 import Search from '@atb/components/search';
 import GeolocationButton from '@atb/components/search/geolocation-button';
 import { Typo } from '@atb/components/typography';
 import { SearchTime, SearchTimeSelector } from '@atb/modules/search-time';
-import {
-  TransportModeFilter,
-  getInitialTransportModeFilter,
-} from '@atb/modules/transport-mode';
 import type { GeocoderFeature } from '@atb/page-modules/departures';
 import { PageText, useTranslation } from '@atb/translations';
-import { FocusScope } from '@react-aria/focus';
-import { AnimatePresence, motion } from 'framer-motion';
 import { useRouter } from 'next/router';
 import { FormEventHandler, PropsWithChildren, useState } from 'react';
 import style from './departures.module.css';
@@ -28,22 +21,15 @@ export type DeparturesLayoutProps = PropsWithChildren<{
 function DeparturesLayout({ children, fromQuery }: DeparturesLayoutProps) {
   const { t } = useTranslation();
   const router = useRouter();
-  const [showAlternatives, setShowAlternatives] = useState(false);
   const [searchTime, setSearchTime] = useState<SearchTime>(
     fromQuery.searchTime,
-  );
-  const [transportModeFilter, setTransportModeFilter] = useState(
-    getInitialTransportModeFilter(fromQuery.transportModeFilter),
   );
   const [isSearching, setIsSearching] = useState(false);
   const [geolocationError, setGeolocationError] = useState<string | null>(null);
 
   const doSearch = async (override: Partial<FromDepartureQuery>) => {
     setIsSearching(true);
-    const newRoute = createFromQuery(
-      { ...fromQuery, ...override, searchTime },
-      transportModeFilter,
-    );
+    const newRoute = createFromQuery({ ...fromQuery, ...override, searchTime });
     await router.push(newRoute);
     setIsSearching(false);
   };
@@ -59,12 +45,7 @@ function DeparturesLayout({ children, fromQuery }: DeparturesLayoutProps) {
   return (
     <div className={style.departuresPage}>
       <form className={style.container} onSubmit={onSubmitHandler}>
-        <motion.div
-          animate={{ paddingBottom: showAlternatives ? '1.5rem' : '5.75rem' }}
-          initial={{ paddingBottom: '5.75rem' }}
-          transition={{ duration: 0.25, ease: [0.04, 0.62, 0.23, 0.98] }}
-          className={style.main}
-        >
+        <div className={style.main}>
           <TabLink activePath="/departures" />
 
           <div className={style.input}>
@@ -102,56 +83,9 @@ function DeparturesLayout({ children, fromQuery }: DeparturesLayoutProps) {
               <MessageBox type="warning" message={geolocationError} />
             </div>
           )}
-        </motion.div>
-
-        <AnimatePresence initial={false}>
-          {showAlternatives && (
-            <FocusScope contain={false} autoFocus={showAlternatives}>
-              <motion.div
-                className={style.alternativesWrapper}
-                key="content"
-                initial="collapsed"
-                animate="open"
-                exit="collapsed"
-                variants={{
-                  open: { opacity: 1, height: 'auto' },
-                  collapsed: { opacity: 0, height: 0 },
-                }}
-                transition={{ duration: 0.25, ease: [0.04, 0.62, 0.23, 0.98] }}
-              >
-                <div className={style.alternatives}>
-                  <div>
-                    <Typo.p
-                      textType="body__primary--bold"
-                      className={style.heading}
-                    >
-                      {t(PageText.Departures.search.filter.label)}
-                    </Typo.p>
-
-                    <TransportModeFilter
-                      filterState={transportModeFilter}
-                      onFilterChange={setTransportModeFilter}
-                    />
-                  </div>
-                </div>
-              </motion.div>
-            </FocusScope>
-          )}
-        </AnimatePresence>
+        </div>
 
         <div className={style.buttons}>
-          <Button
-            title={
-              showAlternatives
-                ? t(PageText.Departures.search.buttons.alternatives.less)
-                : t(PageText.Departures.search.buttons.alternatives.more)
-            }
-            className={style.button}
-            mode="interactive_2"
-            onClick={() => setShowAlternatives(!showAlternatives)}
-            icon={{ right: <MonoIcon icon="actions/Adjust" /> }}
-          />
-
           <Button
             title={t(PageText.Departures.search.buttons.find.title)}
             className={style.button}

--- a/src/page-modules/departures/server/journey-planner/index.ts
+++ b/src/page-modules/departures/server/journey-planner/index.ts
@@ -34,10 +34,8 @@ import {
   ServiceJourneyData,
   serviceJourneySchema,
 } from './validators';
-import { TransportMode as GraphQlTransportMode } from '@atb/modules/graphql-types';
 import { PtSituationElement as GraphQlSituation } from '@atb/modules/graphql-types';
 import {
-  type TransportModeType,
   isTransportModeType,
   filterGraphQlTransportModes,
 } from '@atb/modules/transport-mode';
@@ -54,7 +52,6 @@ import { sortQuays } from './utils';
 export type DepartureInput = {
   id: string;
   date: number | null;
-  transportModes: TransportModeType[] | null;
 };
 export type { DepartureData, Quay, Departure };
 
@@ -65,13 +62,11 @@ export type StopPlaceInput = {
 export type NearestStopPlacesInput = {
   lat: number;
   lon: number;
-  transportModes: TransportModeType[] | null;
 };
 
 export type EstimatedCallsInput = {
   quayId: string;
   startTime: string;
-  transportModes: TransportModeType[] | null;
 };
 
 export type ServiceJourneyInput = {
@@ -108,8 +103,6 @@ export function createJourneyApi(
             ? new Date(input.date).toISOString()
             : new Date().toISOString(),
           numberOfDepartures: 10,
-          transportModes:
-            (input.transportModes as GraphQlTransportMode[]) ?? null,
         },
       });
 
@@ -215,8 +208,6 @@ export function createJourneyApi(
         variables: {
           // Max distance in meters
           distance: 900,
-          transportModes:
-            (input.transportModes as GraphQlTransportMode[]) ?? null,
 
           latitude: input.lat,
           longitude: input.lon,
@@ -279,8 +270,6 @@ export function createJourneyApi(
           id: input.quayId,
           numberOfDepartures: 6,
           startTime: new Date(input.startTime),
-          transportModes:
-            (input.transportModes as GraphQlTransportMode[]) ?? null,
         },
       });
 
@@ -421,8 +410,8 @@ type RecursivePartial<T> = {
   [P in keyof T]?: T[P] extends (infer U)[]
     ? RecursivePartial<U>[]
     : T[P] extends object | undefined
-    ? RecursivePartial<T[P]>
-    : T[P];
+      ? RecursivePartial<T[P]>
+      : T[P];
 };
 
 const mapAndFilterDuplicateGraphQlSituations = (

--- a/src/page-modules/departures/server/journey-planner/journey-gql/departures.gql
+++ b/src/page-modules/departures/server/journey-planner/journey-gql/departures.gql
@@ -2,7 +2,6 @@ query stopPlaceQuayDepartures(
   $id: String!
   $numberOfDepartures: Int
   $startTime: DateTime
-  $transportModes: [TransportMode]
 ) {
   stopPlace(id: $id) {
     id
@@ -21,7 +20,6 @@ query stopPlaceQuayDepartures(
         numberOfDepartures: $numberOfDepartures
         startTime: $startTime
         includeCancelledTrips: true
-        whiteListedModes: $transportModes
       ) {
         date
         expectedDepartureTime

--- a/src/page-modules/departures/server/journey-planner/journey-gql/estimated-calls.gql
+++ b/src/page-modules/departures/server/journey-planner/journey-gql/estimated-calls.gql
@@ -2,7 +2,6 @@ query quayEstimatedCalls(
   $id: String!
   $numberOfDepartures: Int
   $startTime: DateTime
-  $transportModes: [TransportMode]
 ) {
   quay(id: $id) {
     description
@@ -13,7 +12,6 @@ query quayEstimatedCalls(
       numberOfDepartures: $numberOfDepartures
       startTime: $startTime
       includeCancelledTrips: true
-      whiteListedModes: $transportModes
     ) {
       aimedDepartureTime
       date

--- a/src/page-modules/departures/server/journey-planner/journey-gql/nearest-stop-places.gql
+++ b/src/page-modules/departures/server/journey-planner/journey-gql/nearest-stop-places.gql
@@ -4,7 +4,6 @@ query nearestStopPlaces(
   $longitude: Float!
   $latitude: Float!
   $after: String
-  $transportModes: [TransportMode]
 ) {
   nearest(
     latitude: $latitude
@@ -15,7 +14,6 @@ query nearestStopPlaces(
     filterByInUse: true
     filterByPlaceTypes: stopPlace
     multiModalMode: parent
-    filterByModes: $transportModes
   ) {
     pageInfo {
       endCursor

--- a/src/page-modules/departures/types.ts
+++ b/src/page-modules/departures/types.ts
@@ -1,6 +1,5 @@
 import type { FeatureCategory } from '@atb/components/venue-icon';
 import type { ServiceJourneyData } from './server/journey-planner/validators';
-import type { TransportModeFilterOption } from '@atb/modules/transport-mode';
 import type { SearchTime } from '@atb/modules/search-time';
 
 export type GeocoderFeature = {
@@ -16,7 +15,6 @@ export type GeocoderFeature = {
 };
 
 export type FromDepartureQuery = {
-  transportModeFilter: TransportModeFilterOption[] | null;
   searchTime: SearchTime;
   from: GeocoderFeature | null;
   isAddress: boolean;

--- a/src/page-modules/departures/utils.ts
+++ b/src/page-modules/departures/utils.ts
@@ -1,29 +1,11 @@
-import {
-  TransportModeFilterState,
-  filterToQueryString,
-} from '@atb/modules/transport-mode';
 import { FromDepartureQuery } from './types';
 import { searchTimeToQueryString } from '@atb/modules/search-time';
-import { Url } from 'url';
 import { ParsedUrlQueryInput } from 'querystring';
 
-export function createFromQuery(
-  tripQuery: FromDepartureQuery,
-  transportModeFilter: TransportModeFilterState,
-): {
+export function createFromQuery(tripQuery: FromDepartureQuery): {
   pathname: string;
   query: ParsedUrlQueryInput;
 } {
-  let transportModeFilterQuery = {};
-  if (transportModeFilter) {
-    const filterQueryString = filterToQueryString(transportModeFilter);
-    if (filterQueryString) {
-      transportModeFilterQuery = {
-        filter: filterQueryString,
-      };
-    }
-  }
-
   const searchTimeQuery = searchTimeToQueryString(tripQuery.searchTime);
 
   if (tripQuery.from?.layer == 'venue') {
@@ -31,7 +13,6 @@ export function createFromQuery(
       pathname: '/departures/[[...id]]',
       query: {
         id: tripQuery.from.id,
-        ...transportModeFilterQuery,
         ...searchTimeQuery,
       },
     };
@@ -42,7 +23,6 @@ export function createFromQuery(
     return {
       pathname: '/departures',
       query: {
-        ...transportModeFilterQuery,
         ...searchTimeQuery,
         lon,
         lat,
@@ -52,9 +32,6 @@ export function createFromQuery(
 
   return {
     pathname: '/departures',
-    query: {
-      ...transportModeFilterQuery,
-      ...searchTimeQuery,
-    },
+    query: searchTimeQuery,
   };
 }

--- a/src/pages/api/departures/journey-planner.ts
+++ b/src/pages/api/departures/journey-planner.ts
@@ -4,10 +4,6 @@ import { handlerWithDepartureClient } from '@atb/page-modules/departures/server'
 import { ServerText } from '@atb/translations';
 import { constants } from 'http2';
 import { z } from 'zod';
-import {
-  getAllTransportModesFromFilterOptions,
-  parseFilterQuery,
-} from '@atb/modules/transport-mode';
 
 export default handlerWithDepartureClient<EstimatedCallsApiReturnType>({
   async GET(req, res, { client, ok }) {
@@ -32,9 +28,6 @@ export default handlerWithDepartureClient<EstimatedCallsApiReturnType>({
         await client.estimatedCalls({
           quayId: query.data.quayId,
           startTime: query.data.startTime,
-          transportModes: getAllTransportModesFromFilterOptions(
-            parseFilterQuery(query.data.transportModes),
-          ),
         }),
       );
     });

--- a/src/pages/departures/[[...id]].tsx
+++ b/src/pages/departures/[[...id]].tsx
@@ -1,6 +1,5 @@
 import DefaultLayout from '@atb/layouts/default';
 import { withGlobalData, type WithGlobalData } from '@atb/layouts/global-data';
-import { getAllTransportModesFromFilterOptions } from '@atb/modules/transport-mode';
 import {
   DeparturesLayout,
   NearestStopPlaces,
@@ -70,9 +69,6 @@ export const getServerSideProps = withGlobalData(
           fromQuery.searchTime.mode !== 'now'
             ? fromQuery.searchTime.dateTime
             : null,
-        transportModes: getAllTransportModesFromFilterOptions(
-          fromQuery.transportModeFilter,
-        ),
       });
 
       return {
@@ -86,9 +82,6 @@ export const getServerSideProps = withGlobalData(
       const input = {
         lon: fromQuery.from.geometry.coordinates[0],
         lat: fromQuery.from.geometry.coordinates[1],
-        transportModes: getAllTransportModesFromFilterOptions(
-          fromQuery.transportModeFilter,
-        ),
       };
 
       const nearestStopPlaces = await client.nearestStopPlaces(input);

--- a/src/translations/pages/departures.ts
+++ b/src/translations/pages/departures.ts
@@ -24,20 +24,9 @@ export const Departures = {
         'Når vil du reise?',
       ),
     },
-    filter: {
-      label: _(
-        'Hva vil du reise med?',
-        'How do you want to travel?',
-        'Kva vil du reise med?',
-      ),
-    },
     buttons: {
       find: {
         title: _('Finn avganger', 'Find departures', 'Finn avganger'),
-      },
-      alternatives: {
-        more: _('Flere valg', 'More choices', 'Fleire val'),
-        less: _('Færre valg', 'Less choices', 'Færre val'),
       },
     },
   },


### PR DESCRIPTION
This PR refactors how the transport mode filtering is done for a travel search, and it removes the transport mode filtering from departures since it does not work as we need it to.

The type used for the transport modes passed to the GraphQL query was refactored to include submodes. The issue (one of them) that was encountered was that if e.g. only `rail` was selected, it still showed buses. The reason for this was that for the filter option `rail`, one of the modes is `bus` with `subMode: ['railReplacementBus']`. It makes sense to show buses that are replacements for trains. So to fix this, the `transportSubModes` was included when passing to the GQL query.

> [!NOTE]
> In addition to including the sub mode, I removed transport mode filtering from departures in its entirety. I could and should have separated this removal to its own PR, but realised that when I was too deep in it, and after renaming types and refactoring, I didn't want to separate the changes. 🫣


Closes https://github.com/AtB-AS/kundevendt/issues/15753