### PR TITLE
refactor: use quay instead of pier

### DIFF
--- a/src/translations/pages/assistant.ts
+++ b/src/translations/pages/assistant.ts
@@ -14,7 +14,7 @@ export const Assistant = {
       to: _('Til', 'To', 'Til'),
       placeholder: _(
         'adresse, kai eller holdeplass',
-        'address, pier or bus stop',
+        'address, quay or bus stop',
         'adresse, kai eller haldeplass',
       ),
     },

--- a/src/translations/pages/departures.ts
+++ b/src/translations/pages/departures.ts
@@ -13,7 +13,7 @@ export const Departures = {
       from: _('Fra', 'From', 'Frå'),
       placeholder: _(
         'adresse, kai eller holdeplass',
-        'address, pier or bus stop',
+        'address, quay or bus stop',
         'adresse, kai eller haldeplass',
       ),
     },


### PR DESCRIPTION
Christoffer reported that we use `quay` and not `pier` so I have changed this