### PR TITLE
fix: keyboard navigation order with map

### DIFF
--- a/src/components/map/map.tsx
+++ b/src/components/map/map.tsx
@@ -71,7 +71,7 @@ export function Map({
   }, [position, initialZoom]);
 
   return (
-    <div className={style.map}>
+    <div className={style.map} aria-hidden="true">
       <Button
         className={style.fullscreenButton}
         title={t(ComponentText.Map.map.openFullscreenButton)}

--- a/src/page-modules/departures/nearest-stop-places/index.tsx
+++ b/src/page-modules/departures/nearest-stop-places/index.tsx
@@ -41,6 +41,14 @@ export function NearestStopPlaces({
   }
   return (
     <section className={style.nearestContainer}>
+      <ul className={style.stopPlacesList}>
+        {nearestStopPlaces.map((item) => (
+          <li key={item.stopPlace.id}>
+            <StopPlaceItem item={item} />
+          </li>
+        ))}
+      </ul>
+
       <div className={style.mapContainer}>
         {fromQuery.from && (
           <MapWithHeader
@@ -56,14 +64,6 @@ export function NearestStopPlaces({
           />
         )}
       </div>
-
-      <ul className={style.stopPlacesList}>
-        {nearestStopPlaces.map((item) => (
-          <li key={item.stopPlace.id}>
-            <StopPlaceItem item={item} />
-          </li>
-        ))}
-      </ul>
     </section>
   );
 }

--- a/src/page-modules/departures/stop-place/index.tsx
+++ b/src/page-modules/departures/stop-place/index.tsx
@@ -37,15 +37,6 @@ export function StopPlace({ departures }: StopPlaceProps) {
   const [isHoveringRefreshButton, setIsHoveringRefreshButton] = useState(false);
   return (
     <section className={style.stopPlaceContainer}>
-      <div className={style.mapContainer}>
-        <MapWithHeader
-          name={departures.stopPlace.name}
-          position={departures.stopPlace.position}
-          layer="venue"
-          onSelectStopPlace={(id) => router.push(`/departures/${id}`)}
-          transportModes={departures.stopPlace.transportMode}
-        />
-      </div>
       <div className={style.quaysContainer}>
         <Link
           href={router.asPath}
@@ -65,6 +56,15 @@ export function StopPlace({ departures }: StopPlaceProps) {
         {departures.quays.map((quay) => (
           <EstimatedCallList key={quay.id} quay={quay} />
         ))}
+      </div>
+      <div className={style.mapContainer}>
+        <MapWithHeader
+          name={departures.stopPlace.name}
+          position={departures.stopPlace.position}
+          layer="venue"
+          onSelectStopPlace={(id) => router.push(`/departures/${id}`)}
+          transportModes={departures.stopPlace.transportMode}
+        />
       </div>
     </section>
   );


### PR DESCRIPTION
Now the order when navigating with keyboard is off. Using grid here however we can just reorder the HTML to make it better. Also added aria-hidden to map as it doesn't make sense for screen readers.