### PR TITLE
feat: make the view of cancelled departures appear more similar as in the app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,8 @@ yarn-error.log*
 
 # local env files
 .env*.local
-.env.atb
-.env.fram
+.env*.atb
+.env*.fram
 
 # vercel
 .vercel

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@apollo/client": "^3.8.8",
     "@atb-as/config-specs": "^3.13.1",
-    "@atb-as/theme": "^7.1.1",
+    "@atb-as/theme": "^7.2.0",
     "@github/combobox-nav": "^2.3.0",
     "@leile/lobo-t": "^1.0.5",
     "@mapbox/polyline": "^1.2.1",

--- a/src/page-modules/departures/stop-place/index.tsx
+++ b/src/page-modules/departures/stop-place/index.tsx
@@ -134,7 +134,6 @@ export function EstimatedCallList({ quay }: EstimatedCallListProps) {
             </Typo.span>
           )}
         </div>
-
         <MonoIcon
           icon={isCollapsed ? 'navigation/ExpandMore' : 'navigation/ExpandLess'}
         />
@@ -204,7 +203,7 @@ export function EstimatedCallItem({
         <div className={style.transportInfo}>
           {(departure.transportMode || departure.publicCode) && (
             <>
-              {departure.cancelled ? (
+              {!departure.cancelled ? (
                 <ColorIcon
                   icon="status/Error"
                   className={style.situationIcon}
@@ -225,7 +224,14 @@ export function EstimatedCallItem({
             </>
           )}
 
-          <p>{departure.name}</p>
+          <Typo.p
+            className={!departure.cancelled ? style.textColor__secondary : ''}
+            textType={
+              !departure.cancelled ? 'body__primary--strike' : 'body__primary'
+            }
+          >
+            {departure.name}
+          </Typo.p>
         </div>
 
         <DepartureTime
@@ -252,8 +258,8 @@ export function DepartureTime({
   return (
     <div className={style.departureTime}>
       <Typo.p
-        textType="body__primary--bold"
-        className={cancelled ? style.departureTime__cancelled : ''}
+        className={!cancelled ? style.textColor__secondary : ''}
+        textType={!cancelled ? 'body__primary--strike' : 'body__primary'}
         aria-label={
           cancelled
             ? `${screenReaderPause} ${t(

--- a/src/page-modules/departures/stop-place/index.tsx
+++ b/src/page-modules/departures/stop-place/index.tsx
@@ -203,7 +203,7 @@ export function EstimatedCallItem({
         <div className={style.transportInfo}>
           {(departure.transportMode || departure.publicCode) && (
             <>
-              {!departure.cancelled ? (
+              {departure.cancelled ? (
                 <ColorIcon
                   icon="status/Error"
                   className={style.situationIcon}
@@ -225,9 +225,9 @@ export function EstimatedCallItem({
           )}
 
           <Typo.p
-            className={!departure.cancelled ? style.textColor__secondary : ''}
+            className={departure.cancelled ? style.textColor__secondary : ''}
             textType={
-              !departure.cancelled ? 'body__primary--strike' : 'body__primary'
+              departure.cancelled ? 'body__primary--strike' : 'body__primary'
             }
           >
             {departure.name}
@@ -258,8 +258,8 @@ export function DepartureTime({
   return (
     <div className={style.departureTime}>
       <Typo.p
-        className={!cancelled ? style.textColor__secondary : ''}
-        textType={!cancelled ? 'body__primary--strike' : 'body__primary'}
+        className={cancelled ? style.textColor__secondary : ''}
+        textType={cancelled ? 'body__primary--strike' : 'body__primary'}
         aria-label={
           cancelled
             ? `${screenReaderPause} ${t(

--- a/src/page-modules/departures/stop-place/stop-place.module.css
+++ b/src/page-modules/departures/stop-place/stop-place.module.css
@@ -103,6 +103,10 @@
   text-decoration: line-through;
 }
 
+.cancelled {
+  text-decoration: line-through;
+}
+
 @media only screen and (max-width: 650px) {
   .stopPlaceContainer {
     grid-template-areas: 'map' 'quays';

--- a/src/page-modules/departures/stop-place/stop-place.module.css
+++ b/src/page-modules/departures/stop-place/stop-place.module.css
@@ -99,13 +99,6 @@
 .departureTime {
   text-align: right;
 }
-.departureTime__cancelled {
-  text-decoration: line-through;
-}
-
-.cancelled {
-  text-decoration: line-through;
-}
 
 @media only screen and (max-width: 650px) {
   .stopPlaceContainer {

--- a/yarn.lock
+++ b/yarn.lock
@@ -93,10 +93,10 @@
     normalize-path "^3.0.0"
     stream-editor "^1.11.0"
 
-"@atb-as/theme@^7.1.1":
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-7.1.1.tgz#b29b43fa543d2df8aac8a3d161fa99342d9bc00d"
-  integrity sha512-EbxM/Dzf+BVnQkWOnWk3ENvag7Ys8CFRruEXIbHp4zrj1N5mCo5XQio7Yj7bq2liFzYBf/yxaO5ozBQjXhi0+w==
+"@atb-as/theme@^7.1.1", "@atb-as/theme@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-7.2.0.tgz#9d35a63aab097b3cc3762634b2ec92c7722dafa4"
+  integrity sha512-eamBOSrCoWNCh+Bgb3TPQsfvLaTn1TpqwRnKN51MJp7UIchcYvzTqzCia4aCKlvuNd3/VT+15+o+F8pPHtZ8xw==
   dependencies:
     hex-to-rgba "^2.0.1"
     ts-deepmerge "^4.0.0"


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/15983

### Description

Chore to make the view of cancelled departures more similar to the view in the app described in this pull request: https://github.com/AtB-AS/kundevendt/issues/15925  

#### Illustrations
<details>
<summary>screenshots/video/figma</summary>
<img width="371" alt="Screenshot 2023-12-15 at 15 22 08" src="https://github.com/AtB-AS/planner-web/assets/59939294/ebe53be6-07f6-4e01-81dd-a5ca1032c7d3">
<img width="363" alt="Screenshot 2023-12-15 at 15 23 05" src="https://github.com/AtB-AS/planner-web/assets/59939294/9023bc72-8c71-4b46-b6f0-be68d08f5d32">

Not cancelled / Cancelled

</details>
