### PR TITLE
fix: add correct data to estimated calls for next departures

### DIFF
--- a/src/page-modules/departures/client/journey-planner/index.ts
+++ b/src/page-modules/departures/client/journey-planner/index.ts
@@ -4,11 +4,9 @@ export type EstimatedCallsApiReturnType = EstimatedCallsData;
 export async function nextDepartures(
   quayId: string,
   startTime: string,
-  transportModes: string | null,
 ): Promise<EstimatedCallsApiReturnType> {
   const result = await fetch(
-    `/api/departures/journey-planner?quayId=${quayId}&startTime=${startTime}` +
-      (transportModes ? `&transportModes=${transportModes}` : ''),
+    `/api/departures/journey-planner?quayId=${quayId}&startTime=${startTime}`,
   );
 
   return await result.json();

--- a/src/page-modules/departures/server/journey-planner/index.ts
+++ b/src/page-modules/departures/server/journey-planner/index.ts
@@ -284,16 +284,25 @@ export function createJourneyApi(
         departures: result.data.quay?.estimatedCalls?.map((e) => ({
           id: e.serviceJourney.id,
           name: e.destinationDisplay?.frontText,
+          publicCode: e.serviceJourney.line.publicCode,
           date: e.date,
-          expectedDepartureTime: e.expectedDepartureTime,
           aimedDepartureTime: e.aimedDepartureTime,
+          expectedDepartureTime: e.expectedDepartureTime,
+          cancelled: e.cancellation,
           transportMode: isTransportModeType(
             e.serviceJourney.line.transportMode,
           )
             ? e.serviceJourney.line.transportMode
             : 'unknown',
           transportSubmode: e.serviceJourney.line.transportSubmode,
-          publicCode: e.serviceJourney.line.publicCode,
+          notices:
+            e.notices?.map((notice) => ({
+              id: notice.id,
+              text: notice.text,
+            })) ?? [],
+          situations: e.situations.map((situation) =>
+            mapGraphQlSituationToSituation(situation as GraphQlSituation),
+          ),
         })),
       };
       const validated = estimatedCallsSchema.safeParse(data);
@@ -410,8 +419,8 @@ type RecursivePartial<T> = {
   [P in keyof T]?: T[P] extends (infer U)[]
     ? RecursivePartial<U>[]
     : T[P] extends object | undefined
-      ? RecursivePartial<T[P]>
-      : T[P];
+    ? RecursivePartial<T[P]>
+    : T[P];
 };
 
 const mapAndFilterDuplicateGraphQlSituations = (

--- a/src/page-modules/departures/server/journey-planner/journey-gql/estimated-calls.gql
+++ b/src/page-modules/departures/server/journey-planner/journey-gql/estimated-calls.gql
@@ -34,6 +34,12 @@ query quayEstimatedCalls(
           transportSubmode
         }
       }
+      notices {
+        ...notice
+      }
+      situations {
+        ...situation
+      }
     }
   }
 }

--- a/src/page-modules/departures/stop-place/index.tsx
+++ b/src/page-modules/departures/stop-place/index.tsx
@@ -76,7 +76,6 @@ type EstimatedCallListProps = {
 
 export function EstimatedCallList({ quay }: EstimatedCallListProps) {
   const { t } = useTranslation();
-  const router = useRouter();
   const [isCollapsed, setIsCollapsed] = useState<boolean>(false);
   const [departures, setDepartures] = useState<Departure[]>(quay.departures);
   const [isFetchingDepartures, setIsFetchingDepartures] =
@@ -87,11 +86,7 @@ export function EstimatedCallList({ quay }: EstimatedCallListProps) {
     const latestDeparture = departures[departures.length - 1];
 
     const date = new Date(latestDeparture.aimedDepartureTime);
-    const data = await nextDepartures(
-      quay.id,
-      date.toISOString(),
-      router.query.filter?.toString() ?? null,
-    );
+    const data = await nextDepartures(quay.id, date.toISOString());
 
     const set = new Set(departures.map((departure) => departure.id));
     const filteredDepartures = data.departures.filter(

--- a/src/pages/api/departures/journey-planner.ts
+++ b/src/pages/api/departures/journey-planner.ts
@@ -11,7 +11,6 @@ export default handlerWithDepartureClient<EstimatedCallsApiReturnType>({
       .object({
         quayId: z.string(),
         startTime: z.string(),
-        transportModes: z.string().optional(),
       })
       .safeParse(req.query);
 


### PR DESCRIPTION
This PR fixes an issue where the website crashes on loading the next departures. This was because of some removed properties and newly added ones that were not mapped from GraphQL. 

The functionality is still not optimal and won't return new departures in some cases. I'll look into handling this as well, but this fixes the crashing at least. 