### PR TITLE
fix: add bordered mode of interactive 0 button

### DIFF
--- a/src/components/button/button.module.css
+++ b/src/components/button/button.module.css
@@ -99,6 +99,33 @@
     var(--interactive-interactive_0-outline-background);
 }
 
+/* Interactive button 0 bordered */
+.button--interactive_0--bordered,
+.button--interactive_0--bordered:visited {
+  background-color: var(--interactive-interactive_0-default-background);
+  color: var(--interactive-interactive_0-default-text);
+  box-shadow: inset 0 0 0 var(--border-width-slim)
+    var(--interactive-interactive_0-default-text);
+}
+.button--interactive_0--bordered:hover {
+  background-color: var(--interactive-interactive_0-hover-background);
+  color: var(--interactive-interactive_0-hover-text);
+}
+.button--interactive_0--bordered:active {
+  background-color: var(--interactive-interactive_0-active-background);
+  color: var(--interactive-interactive_0-active-text);
+}
+.button--interactive_0--bordered:disabled,
+.button--interactive_0--bordered.button--disabled {
+  background-color: var(--interactive-interactive_0-disabled-background);
+  color: var(--interactive-interactive_0-disabled-text);
+}
+.button--interactive_0--bordered:focus {
+  outline: 0;
+  box-shadow: inset 0 0 0 var(--border-width-medium)
+    var(--interactive-interactive_0-outline-background);
+}
+
 /* Interactive button 1 */
 
 .button--interactive_1,

--- a/src/components/button/utils.tsx
+++ b/src/components/button/utils.tsx
@@ -5,6 +5,7 @@ import { LoadingIcon } from '../loading';
 
 export type ButtonModes =
   | 'interactive_0'
+  | 'interactive_0--bordered'
   | 'interactive_1'
   | 'interactive_2'
   | 'interactive_3'

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -187,7 +187,7 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
           <Button
             title={t(PageText.Assistant.search.buttons.find.title)}
             className={style.button}
-            mode="interactive_0"
+            mode="interactive_0--bordered"
             disabled={!tripQuery.from || !tripQuery.to}
             buttonProps={{ type: 'submit' }}
             state={isSearching ? 'loading' : undefined}

--- a/src/page-modules/departures/layout.tsx
+++ b/src/page-modules/departures/layout.tsx
@@ -91,7 +91,7 @@ function DeparturesLayout({ children, fromQuery }: DeparturesLayoutProps) {
           <Button
             title={t(PageText.Departures.search.buttons.find.title)}
             className={style.button}
-            mode="interactive_0"
+            mode="interactive_0--bordered"
             disabled={!fromQuery.from}
             buttonProps={{ type: 'submit' }}
             state={isSearching ? 'loading' : undefined}

--- a/src/widget/widget.module.css
+++ b/src/widget/widget.module.css
@@ -209,6 +209,8 @@
 .button:visited {
   background-color: var(--interactive-interactive_0-default-background);
   color: var(--interactive-interactive_0-default-text);
+  box-shadow: inset 0 0 0 var(--border-width-slim)
+    var(--interactive-interactive_0-default-text);
 }
 .button:hover {
   background-color: var(--interactive-interactive_0-hover-background);


### PR DESCRIPTION
Add bordered mode of interactive 0 button.

<img width="988" alt="image" src="https://github.com/AtB-AS/planner-web/assets/14045515/6acf6e5b-a58b-4f6b-91b0-50d9c38d32b9">

<img width="980" alt="image" src="https://github.com/AtB-AS/planner-web/assets/14045515/7ae987e8-933c-409d-8244-69e4735a133a">

<img width="976" alt="image" src="https://github.com/AtB-AS/planner-web/assets/14045515/961f5435-fd3e-4c78-8b39-87653bc557cc">
