### PR TITLE
style: add focus style to search input

### DIFF
--- a/src/components/search/search.module.css
+++ b/src/components/search/search.module.css
@@ -7,6 +7,13 @@
   max-width: 32rem;
   display: flex;
   position: relative;
+  border-radius: 0.75rem;
+  background-color: var(--static-background-background_0-background);
+}
+.container:focus-within {
+  outline: 0;
+  box-shadow: inset 0 0 0 var(--border-width-medium)
+    var(--interactive-interactive_2-outline-background);
 }
 
 .label {
@@ -16,9 +23,7 @@
   min-width: 3rem;
   display: flex;
   align-items: center;
-  background-color: var(--static-background-background_0-background);
   padding: var(--spacings-small);
-  padding-right: var(--spacings-regular);
   border-bottom-left-radius: 0.75rem;
   border-top-left-radius: 0.75rem;
 }
@@ -31,10 +36,11 @@
   height: var(--height);
   padding: var(--spacings-small);
   border: none;
+  background: none;
   width: 100%;
   border-radius: 0;
-  background-color: var(--static-background-background_0-background);
   color: var(--static-background-background_0-text);
+  outline: 0;
 }
 
 .menu {

--- a/src/page-modules/assistant/assistant.module.css
+++ b/src/page-modules/assistant/assistant.module.css
@@ -75,8 +75,8 @@
 
 .searchInputButton {
   height: var(--height);
-  background-color: var(--static-background-background_0-background);
   border: none;
+  background: none;
   padding: var(--spacings-small);
   border-bottom-right-radius: 0.75rem;
   border-top-right-radius: 0.75rem;

--- a/src/page-modules/departures/departures.module.css
+++ b/src/page-modules/departures/departures.module.css
@@ -7,8 +7,7 @@
   height: 100%;
   position: relative;
   display: grid;
-  grid-template-areas:
-    'main'
+  grid-template-areas: 'main';
 }
 
 .main {
@@ -34,8 +33,8 @@
 
 .geolocationButton {
   height: var(--height);
-  background-color: var(--static-background-background_0-background);
   border: none;
+  background: none;
   padding: var(--spacings-small);
   border-bottom-right-radius: 0.75rem;
   border-top-right-radius: 0.75rem;
@@ -56,7 +55,8 @@
   width: 100%;
   max-width: var(--maxPageWidth);
   margin: 0 auto;
-  padding: 0 var(--spacings-xLarge) var(--spacings-xLarge) var(--spacings-xLarge);
+  padding: 0 var(--spacings-xLarge) var(--spacings-xLarge)
+    var(--spacings-xLarge);
   z-index: 10;
   position: absolute;
   left: 0;
@@ -67,7 +67,7 @@
   .container {
     grid-template-areas:
       'main'
-      'buttons'
+      'buttons';
   }
 
   .main {


### PR DESCRIPTION
Add a focus style to the search input that is more in line with the focus styles of the surrounding components.

<img width="488" alt="image" src="https://github.com/AtB-AS/planner-web/assets/14045515/41d21141-03c3-49e0-b5c7-b81e70e9123b">
<img width="484" alt="image" src="https://github.com/AtB-AS/planner-web/assets/14045515/6d7e9306-0e18-4603-96a5-405dd58548b3">
