### PR TITLE
fix: only show loading when both to and from are selected

### DIFF
--- a/src/components/loading-empty-results/index.tsx
+++ b/src/components/loading-empty-results/index.tsx
@@ -35,7 +35,7 @@ export default function LoadingEmptyResults({
           details={t(ComponentText.EmptySearch.emptyDetails[type])}
         />
       )}
-      {isSearching && hasEmptyChild && (
+      {isSearching && (
         <motion.div
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -42,7 +42,6 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
   const [geolocationError, setGeolocationError] = useState<string | null>(null);
 
   const setValuesWithLoading = async (override: Partial<FromToTripQuery>) => {
-    setIsSearching(true);
     const query = createTripQuery(
       {
         ...tripQuery,
@@ -51,6 +50,11 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
       },
       transportModeFilter,
     );
+
+    // Only show loading if we have both from and to selected.
+    if ((tripQuery.from && query.toId) || (tripQuery.to && query.fromId)) {
+      setIsSearching(true);
+    }
 
     logSpecificEvent('search_assistant');
 


### PR DESCRIPTION
Currently, when both from and to are empty and a place is selected the searching illustration and loading mode of the button is briefly triggered. I think this can cause confusion for some users, seeing that something happened on the screen, but in fact nothing did other than updating the URL (since nothing is done if either from or to is empty when the page loads).

Related to https://github.com/AtB-AS/kundevendt/issues/15757
