### PR TITLE
fix: reload page manually to refresh estimated calls

### DIFF
--- a/src/page-modules/departures/stop-place/index.tsx
+++ b/src/page-modules/departures/stop-place/index.tsx
@@ -38,9 +38,9 @@ export function StopPlace({ departures }: StopPlaceProps) {
   return (
     <section className={style.stopPlaceContainer}>
       <div className={style.quaysContainer}>
-        <Link
-          href={router.asPath}
-          className={style.refreshButtonLink}
+        <button
+          onClick={() => router.reload()}
+          className={style.refreshButton}
           onMouseEnter={() => setIsHoveringRefreshButton(true)}
           onMouseLeave={() => setIsHoveringRefreshButton(false)}
         >
@@ -52,7 +52,7 @@ export function StopPlace({ departures }: StopPlaceProps) {
             interactiveColor="interactive_1"
             interactiveState={isHoveringRefreshButton ? 'hover' : undefined}
           />
-        </Link>
+        </button>
         {departures.quays.map((quay) => (
           <EstimatedCallList key={quay.id} quay={quay} />
         ))}

--- a/src/page-modules/departures/stop-place/stop-place.module.css
+++ b/src/page-modules/departures/stop-place/stop-place.module.css
@@ -23,7 +23,7 @@
 .quaysContainer li {
   list-style: none;
 }
-.refreshButtonLink {
+.refreshButton {
   align-self: flex-end;
   display: flex;
   gap: var(--spacings-small);
@@ -33,6 +33,7 @@
   text-decoration: none;
   composes: interactive-interactive_1;
   transition: none;
+  border: none;
 }
 
 .listHeader {


### PR DESCRIPTION
Instead of using a `Link` I changed it to a `button` that calls `router.reload()`. This reloads the page and results in reloading the estimated calls list.

I think this is by no means a permanent solution, but rather a temporary solution to the problem we are currently seeing. At a later point we could look into updating just the list and not the whole page, but then we would be fetching data on the client side rather than the server side.

,> [!NOTE]
> I think the `Link` might be working, but if a quay, or multiple, is collapsed it won't be visible that the estimated calls was updated.
