### PR TITLE
feat: link to home page

### DIFF
--- a/orgs/atb.json
+++ b/orgs/atb.json
@@ -25,6 +25,7 @@
     },
     "facebookLink": "https://www.facebook.com/atb.no/",
     "instagramLink": "https://www.instagram.com/atb_no/",
-    "twitterLink": "https://twitter.com/atb_no"
+    "twitterLink": "https://twitter.com/atb_no",
+    "homePageUrl": "https://atb.no/"
   }
 }

--- a/orgs/atb.json
+++ b/orgs/atb.json
@@ -26,6 +26,9 @@
     "facebookLink": "https://www.facebook.com/atb.no/",
     "instagramLink": "https://www.instagram.com/atb_no/",
     "twitterLink": "https://twitter.com/atb_no",
-    "homePageUrl": "https://atb.no/"
+    "homePageUrl": {
+      "name": "atb.no",
+      "href": "https://atb.no/"
+    }
   }
 }

--- a/orgs/fram.json
+++ b/orgs/fram.json
@@ -24,6 +24,9 @@
       "default": "https://frammr.no/kontakt-oss",
       "en-US": "https://en.frammr.no/contact-us"
     },
-    "homePageUrl": "https://www.frammr.no/"
+    "homePageUrl": {
+      "name": "frammr.no",
+      "href": "https://www.frammr.no/"
+    }
   }
 }

--- a/orgs/fram.json
+++ b/orgs/fram.json
@@ -23,6 +23,7 @@
     "supportUrl": {
       "default": "https://frammr.no/kontakt-oss",
       "en-US": "https://en.frammr.no/contact-us"
-    }
+    },
+    "homePageUrl": "https://www.frammr.no/"
   }
 }

--- a/orgs/nfk.json
+++ b/orgs/nfk.json
@@ -24,6 +24,7 @@
     },
 
     "instagramLink": "https://www.instagram.com/reisnordland",
-    "facebookLink": "https://www.facebook.com/ReisNordland"
+    "facebookLink": "https://www.facebook.com/ReisNordland",
+    "homePageUrl": "https://www.reisnordland.no/"
   }
 }

--- a/orgs/nfk.json
+++ b/orgs/nfk.json
@@ -25,6 +25,9 @@
 
     "instagramLink": "https://www.instagram.com/reisnordland",
     "facebookLink": "https://www.facebook.com/ReisNordland",
-    "homePageUrl": "https://www.reisnordland.no/"
+    "homePageUrl": {
+      "name": "reisnordland.no",
+      "href": "https://www.reisnordland.no/"
+    }
   }
 }

--- a/orgs/schema-validation.json
+++ b/orgs/schema-validation.json
@@ -54,6 +54,9 @@
             },
             "twitterLink": {
               "type": "string"
+            },
+            "homePageUrl": {
+              "type": "string"
             }
           },
           "required": [

--- a/orgs/schema-validation.json
+++ b/orgs/schema-validation.json
@@ -56,7 +56,14 @@
               "type": "string"
             },
             "homePageUrl": {
-              "type": "string"
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "href": {
+                  "type": "string"
+                }
+              }
             }
           },
           "required": [

--- a/src/layouts/shared/page-header.module.css
+++ b/src/layouts/shared/page-header.module.css
@@ -4,8 +4,6 @@
 
 .pageHeader__content {
   width: 100%;
-  max-width: var(--maxPageWidth);
-  margin: 0 auto;
   padding: 0 var(--contentPadding);
   display: flex;
 }

--- a/src/modules/org-data/index.tsx
+++ b/src/modules/org-data/index.tsx
@@ -34,7 +34,10 @@ export type OrgData = {
     instagramLink?: string;
     facebookLink?: string;
     twitterLink?: string;
-    homePageUrl?: string;
+    homePageUrl: {
+      name: string;
+      href: string;
+    };
   };
 };
 

--- a/src/modules/org-data/index.tsx
+++ b/src/modules/org-data/index.tsx
@@ -34,6 +34,7 @@ export type OrgData = {
     instagramLink?: string;
     facebookLink?: string;
     twitterLink?: string;
+    homePageUrl?: string;
   };
 };
 

--- a/src/page-modules/assistant/assistant.module.css
+++ b/src/page-modules/assistant/assistant.module.css
@@ -1,7 +1,12 @@
 .wrapper {
   background-color: var(--static-background-background_accent_0-background);
 }
-
+.homeLink__container {
+  width: 100%;
+  max-width: var(--maxPageWidth);
+  padding: 0 var(--spacings-xLarge);
+  margin: 0 auto;
+}
 .container {
   background-color: var(--static-background-background_accent_0-background);
   height: 100%;

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -85,8 +85,8 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
       <div className={style.homeLink__container}>
         <ButtonLink
           mode="transparent"
-          href={urls.homePageUrl ?? '/'}
-          title={t(PageText.Assistant.homeLink)}
+          href={urls.homePageUrl.href}
+          title={t(PageText.Assistant.homeLink(urls.homePageUrl.name))}
           icon={{ left: <MonoIcon icon="navigation/ArrowLeft" /> }}
         />{' '}
       </div>

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@atb/components/button';
+import { Button, ButtonLink } from '@atb/components/button';
 import { MonoIcon } from '@atb/components/icon';
 import EmptySearch from '@atb/components/loading-empty-results';
 import { MessageBox } from '@atb/components/message-box';
@@ -21,6 +21,7 @@ import { FromToTripQuery } from './types';
 import { createTripQuery } from './utils';
 import { TabLink } from '@atb/components/tab-link';
 import { logSpecificEvent } from '@atb/modules/firebase';
+import { getOrgData } from '@atb/modules/org-data';
 
 export type AssistantLayoutProps = PropsWithChildren<{
   tripQuery: FromToTripQuery;
@@ -77,8 +78,18 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
   const onToSelected = async (to: GeocoderFeature) =>
     setValuesWithLoading({ to });
 
+  const { urls } = getOrgData();
+
   return (
     <div>
+      <div className={style.homeLink__container}>
+        <ButtonLink
+          mode="transparent"
+          href={urls.homePageUrl ?? '/'}
+          title={t(PageText.Assistant.homeLink)}
+          icon={{ left: <MonoIcon icon="navigation/ArrowLeft" /> }}
+        />{' '}
+      </div>
       <form className={style.container} onSubmit={onSubmitHandler}>
         <motion.div
           animate={{ paddingBottom: showAlternatives ? '1.5rem' : '5.75rem' }}

--- a/src/page-modules/departures/departures.module.css
+++ b/src/page-modules/departures/departures.module.css
@@ -1,14 +1,18 @@
 .wrapper {
   background-color: var(--static-background-background_accent_0-background);
 }
-
+.homeLink__container {
+  width: 100%;
+  max-width: var(--maxPageWidth);
+  padding: 0 var(--spacings-xLarge);
+  margin: 0 auto;
+}
 .container {
   background-color: var(--static-background-background_accent_0-background);
   height: 100%;
   position: relative;
   display: grid;
-  grid-template-areas:
-    'main'
+  grid-template-areas: 'main';
 }
 
 .main {
@@ -56,7 +60,8 @@
   width: 100%;
   max-width: var(--maxPageWidth);
   margin: 0 auto;
-  padding: 0 var(--spacings-xLarge) var(--spacings-xLarge) var(--spacings-xLarge);
+  padding: 0 var(--spacings-xLarge) var(--spacings-xLarge)
+    var(--spacings-xLarge);
   z-index: 10;
   position: absolute;
   left: 0;
@@ -67,7 +72,7 @@
   .container {
     grid-template-areas:
       'main'
-      'buttons'
+      'buttons';
   }
 
   .main {

--- a/src/page-modules/departures/layout.tsx
+++ b/src/page-modules/departures/layout.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@atb/components/button';
+import { Button, ButtonLink } from '@atb/components/button';
 import LoadingEmptySearch from '@atb/components/loading-empty-results';
 import { MessageBox } from '@atb/components/message-box';
 import Search from '@atb/components/search';
@@ -14,6 +14,8 @@ import type { FromDepartureQuery } from './types';
 import { createFromQuery } from './utils';
 import { TabLink } from '@atb/components/tab-link';
 import { logSpecificEvent } from '@atb/modules/firebase/analytics';
+import { getOrgData } from '@atb/modules/org-data';
+import { MonoIcon } from '@atb/components/icon';
 
 export type DeparturesLayoutProps = PropsWithChildren<{
   fromQuery: FromDepartureQuery;
@@ -44,8 +46,18 @@ function DeparturesLayout({ children, fromQuery }: DeparturesLayoutProps) {
   const onSelectFeature = (feature: GeocoderFeature) =>
     doSearch({ from: feature });
 
+  const { urls } = getOrgData();
+
   return (
     <div className={style.departuresPage}>
+      <div className={style.homeLink__container}>
+        <ButtonLink
+          mode="transparent"
+          href={urls.homePageUrl ?? '/'}
+          title={t(PageText.Departures.homeLink)}
+          icon={{ left: <MonoIcon icon="navigation/ArrowLeft" /> }}
+        />
+      </div>
       <form className={style.container} onSubmit={onSubmitHandler}>
         <div className={style.main}>
           <TabLink activePath="/departures" />

--- a/src/page-modules/departures/layout.tsx
+++ b/src/page-modules/departures/layout.tsx
@@ -53,8 +53,8 @@ function DeparturesLayout({ children, fromQuery }: DeparturesLayoutProps) {
       <div className={style.homeLink__container}>
         <ButtonLink
           mode="transparent"
-          href={urls.homePageUrl ?? '/'}
-          title={t(PageText.Departures.homeLink)}
+          href={urls.homePageUrl.href}
+          title={t(PageText.Departures.homeLink(urls.homePageUrl.name))}
           icon={{ left: <MonoIcon icon="navigation/ArrowLeft" /> }}
         />
       </div>

--- a/src/translations/pages/assistant.ts
+++ b/src/translations/pages/assistant.ts
@@ -2,6 +2,11 @@ import { translation as _ } from '@atb/translations/commons';
 
 export const Assistant = {
   title: _('Planlegg reisen', 'Plan travel', 'Planlegg reisa'),
+  homeLink: _(
+    'Tilbake til forsiden',
+    'Back to the front page',
+    'Tilbake til framsida',
+  ),
   shortTitle: _('Reiseplanlegger', 'Assistant', 'Reiseplanleggar'),
   search: {
     input: {

--- a/src/translations/pages/assistant.ts
+++ b/src/translations/pages/assistant.ts
@@ -2,11 +2,8 @@ import { translation as _ } from '@atb/translations/commons';
 
 export const Assistant = {
   title: _('Planlegg reisen', 'Plan travel', 'Planlegg reisa'),
-  homeLink: _(
-    'Tilbake til forsiden',
-    'Back to the front page',
-    'Tilbake til framsida',
-  ),
+  homeLink: (name: string) =>
+    _(`Tilbake til ${name}`, `Back to ${name}`, `Tilbake til ${name}`),
   shortTitle: _('Reiseplanlegger', 'Assistant', 'Reiseplanleggar'),
   search: {
     input: {

--- a/src/translations/pages/departures.ts
+++ b/src/translations/pages/departures.ts
@@ -2,11 +2,8 @@ import { translation as _ } from '@atb/translations/commons';
 
 export const Departures = {
   title: _('Finn avganger', 'Find departures', 'Finn avganger'),
-  homeLink: _(
-    'Tilbake til forsiden',
-    'Back to the front page',
-    'Tilbake til framsida',
-  ),
+  homeLink: (name: string) =>
+    _(`Tilbake til ${name}`, `Back to ${name}`, `Tilbake til ${name}`),
   shortTitle: _('Avganger', 'Departures', 'Avganger'),
   search: {
     input: {

--- a/src/translations/pages/departures.ts
+++ b/src/translations/pages/departures.ts
@@ -2,6 +2,11 @@ import { translation as _ } from '@atb/translations/commons';
 
 export const Departures = {
   title: _('Finn avganger', 'Find departures', 'Finn avganger'),
+  homeLink: _(
+    'Tilbake til forsiden',
+    'Back to the front page',
+    'Tilbake til framsida',
+  ),
   shortTitle: _('Avganger', 'Departures', 'Avganger'),
   search: {
     input: {


### PR DESCRIPTION
As per the Product Owner's request, I have included a new link enabling users to navigate back to the home page of each organization. This adjustment aligns with the Figma sketches. Additionally, I have modified the page header to span the full width, mirroring the design in the Figma sketches.

Edit: I've updated the back link title to include the name of the home page (e.g. frammr.no, atb.no). 

<details>
<summary>Screenshots</summary>

**Figma**

<img width="1167" alt="image" src="https://github.com/AtB-AS/planner-web/assets/43166974/120a83e1-86dd-4e70-8dca-53eb3a3f1484">

**New website**

<img width="1797" alt="image" src="https://github.com/AtB-AS/planner-web/assets/43166974/919ad502-8e4e-4e3d-bcd6-9dc88820d1a5">

<img width="362" alt="image" src="https://github.com/AtB-AS/planner-web/assets/43166974/c86400b2-6e18-4e82-869e-781cd7ec7002">

</details>