### PR TITLE
fix(widget): correct href in submit departure

### DIFF
--- a/src/widget/widget.ts
+++ b/src/widget/widget.ts
@@ -162,7 +162,11 @@ function submitDeparture(form: HTMLFormElement, from: GeocoderFeature) {
   const searchTime = getSearchTime(new FormData(form));
   const query = createTripQueryForDeparture(from, searchTime);
   const params = new URLSearchParams(query);
-  window.location.href = `${url}?${params.toString()}`;
+  if (from.layer === 'venue') {
+    window.location.href = `${url}/${from.id}?${params.toString()}`;
+  } else {
+    window.location.href = `${url}?${params.toString()}`;
+  }
 }
 
 type ErrorMessage = {
@@ -912,7 +916,6 @@ function createTripQueryForDeparture(
   if (from.layer == 'venue') {
     return {
       ...searchTimeQuery,
-      id: from.id,
     };
   }
 


### PR DESCRIPTION
This fixes the href for the submitDeparture function. Previously to this, the ID of the selected stop place was sent as a query param, but the path is departures/[id]. 

I haven't re-built the widget for this PR, but I think we should do that when the submit form functionality is fixed in the upcoming PR. Then we can release both of these PRs as a new version (v2.3.1).