### PR TITLE
temp: redirect departures

### DIFF
--- a/src/pages/departures/[[...id]].tsx
+++ b/src/pages/departures/[[...id]].tsx
@@ -12,6 +12,7 @@ import { fetchFromDepartureQuery } from '@atb/page-modules/departures/fetch-depa
 import { withDepartureClient } from '@atb/page-modules/departures/server';
 import { FromDepartureQuery } from '@atb/page-modules/departures/types';
 import type { NextPage } from 'next';
+import { encode } from 'querystring';
 
 type DeparturesStopPlaceProps = {
   stopPlace: true;
@@ -61,6 +62,16 @@ export const getServerSideProps = withGlobalData(
     DeparturesLayoutProps & DeparturesContentProps,
     { id: string[] | undefined }
   >(async function ({ client, params, query }) {
+    if (query?.id && !params?.id) {
+      const id = query.id;
+      delete query.id;
+      return {
+        redirect: {
+          destination: `/departures/${id}?${encode(query)}`,
+          permanent: true,
+        },
+      };
+    }
     const fromQuery = await fetchFromDepartureQuery(params?.id, query, client);
     if (!fromQuery.isAddress && fromQuery.from) {
       const departures = await client.departures({

--- a/src/pages/departures/[[...id]].tsx
+++ b/src/pages/departures/[[...id]].tsx
@@ -68,7 +68,7 @@ export const getServerSideProps = withGlobalData(
       return {
         redirect: {
           destination: `/departures/${id}?${encode(query)}`,
-          permanent: true,
+          permanent: false,
         },
       };
     }


### PR DESCRIPTION
Currently, the widget sends the users to `/departures?id=SomeId&searchMode=now` instead of `/departures/SomeId?searchMode=now`. To handle this I've set up a redirect until we have made a release of the widget. 