### PR TITLE
fix: trip query transferSlack and walkReluctance config

### DIFF
--- a/src/page-modules/assistant/server/journey-planner/index.ts
+++ b/src/page-modules/assistant/server/journey-planner/index.ts
@@ -48,9 +48,10 @@ const MAX_NUMBER_OF_SEARCH_ATTEMPTS = 5;
 const DEFAULT_JOURNEY_CONFIG = {
   numTripPatterns: 8, // The maximum number of trip patterns to return.
   waitReluctance: 1.5, // Setting this to a value lower than 1 indicates that waiting is better than staying on a vehicle.
-  walkReluctance: 1.5, // This is the main parameter to use for limiting walking.
+  walkReluctance: 4, // This is the main parameter to use for limiting walking.
   walkSpeed: 1.3, // The maximum walk speed along streets, in meters per second.
   transferPenalty: 10, // An extra penalty added on transfers (i.e. all boardings except the first one)
+  transferSlack: 0, // An expected transfer time (in seconds) that specifies the amount of time that must pass between exiting one public transport vehicle and boarding another.
 };
 
 export type JourneyPlannerApi = {
@@ -356,8 +357,8 @@ type RecursivePartial<T> = {
   [P in keyof T]?: T[P] extends (infer U)[]
     ? RecursivePartial<U>[]
     : T[P] extends object | undefined
-      ? RecursivePartial<T[P]>
-      : T[P];
+    ? RecursivePartial<T[P]>
+    : T[P];
 };
 
 function inputToLocation(

--- a/src/page-modules/assistant/server/journey-planner/journey-gql/trip.gql
+++ b/src/page-modules/assistant/server/journey-planner/journey-gql/trip.gql
@@ -5,6 +5,7 @@ query Trips(
   $when: DateTime
   $cursor: String
   $transferPenalty: Int
+  $transferSlack: Int
   $waitReluctance: Float
   $walkReluctance: Float
   $walkSpeed: Float
@@ -18,6 +19,7 @@ query Trips(
     arriveBy: $arriveBy
     pageCursor: $cursor
     transferPenalty: $transferPenalty
+    transferSlack: $transferSlack
     waitReluctance: $waitReluctance
     walkReluctance: $walkReluctance
     walkSpeed: $walkSpeed


### PR DESCRIPTION
Currently, the parameter to use for limiting walking is set to 1.5, which we thought was the default for the app. It turns out the default is 5 and Entur uses 4. With the current config (1.5) we have had reports that some transfers are missing, such as when traveling from Kristiansund to Molde Sjukehus. This change fixes that, so that line 702 is suggested instead of walking (see screenshots).

I've also added the transferSlack configuration, in line with what the app uses now and what the PO wanted. 

Closes https://github.com/AtB-AS/kundevendt/issues/15500

**Before**

![image](https://github.com/AtB-AS/planner-web/assets/43166974/94a2c992-6706-47eb-b1af-7cfd3e25987a)

**Now**

![image](https://github.com/AtB-AS/planner-web/assets/43166974/6e1150df-66fb-4f56-abb3-e2895a3caa80)
