### PR TITLE
feat: display both aimed start time and expected start time of departure in case of delay. 

### DIFF
--- a/src/page-modules/assistant/trip/trip-pattern/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/index.tsx
@@ -127,10 +127,7 @@ export default function TripPattern({
                         </Typo.span>
                       </>
                     ) : (
-                      <Typo.span
-                        textType="body__tertiary"
-                        className={style.outdatet}
-                      >
+                      <Typo.span textType="body__tertiary">
                         {formatToClock(leg.aimedStartTime, language, 'floor')}
                       </Typo.span>
                     )}

--- a/src/page-modules/assistant/trip/trip-pattern/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/index.tsx
@@ -143,6 +143,7 @@ export default function TripPattern({
 
           <div className={style.legs__lastLegLineContainer}>
             <div className={style.legs__lastLegLine} />
+            <div className={style.legs__lastLegLine} />
           </div>
         </div>
 

--- a/src/page-modules/assistant/trip/trip-pattern/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/index.tsx
@@ -20,6 +20,16 @@ type TripPatternProps = {
   index: number;
 };
 
+const isEqualOnMinuteLevel = (
+  aimedStartTime: string,
+  expectedStartTime: string,
+): boolean => {
+  return (
+    new Date(aimedStartTime).getMinutes() ===
+    new Date(expectedStartTime).getMinutes()
+  );
+};
+
 export default function TripPattern({
   tripPattern,
   delay,
@@ -108,14 +118,27 @@ export default function TripPattern({
                     )}
                   </div>
 
-                  <Typo.span textType="body__tertiary">
-                    {formatToClock(leg.expectedStartTime, language, 'floor')}
-                  </Typo.span>
+                  <div className={style.timeStartContainer}>
+                    <Typo.span textType="body__tertiary">
+                      {formatToClock(leg.expectedStartTime, language, 'floor')}
+                    </Typo.span>
+                    {i === 0 &&
+                      !isEqualOnMinuteLevel(
+                        leg.aimedStartTime,
+                        leg.expectedStartTime,
+                      ) && (
+                        <Typo.span
+                          textType="body__tertiary"
+                          className={style.lineThrough}
+                        >
+                          {formatToClock(leg.aimedStartTime, language, 'floor')}
+                        </Typo.span>
+                      )}
+                  </div>
                 </div>
 
                 {(i < expandedLegs.length - 1 || collapsedLegs.length > 0) && (
                   <div className={style.legs__legLineContainer}>
-                    <div className={style.legs__legLine} />
                     <div className={style.legs__legLine} />
                   </div>
                 )}

--- a/src/page-modules/assistant/trip/trip-pattern/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/index.tsx
@@ -13,6 +13,7 @@ import { TransportIconWithLabel } from '@atb/modules/transport-mode';
 import { andIf } from '@atb/utils/css';
 
 const LAST_LEG_PADDING = 20;
+const DEFAULT_THRESHOLD_AIMED_EXPECTED_IN_SECONDS = 60;
 
 type TripPatternProps = {
   tripPattern: TripPatternType;

--- a/src/page-modules/assistant/trip/trip-pattern/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/index.tsx
@@ -114,10 +114,7 @@ export default function TripPattern({
                     </Typo.span>
                     {secondsBetween(leg.aimedStartTime, leg.expectedStartTime) >
                       60 && (
-                      <Typo.span
-                        textType="body__tertiary"
-                        className={style.lineThrough}
-                      >
+                      <Typo.span textType="body__tertiary--strike">
                         {formatToClock(leg.aimedStartTime, language, 'floor')}
                       </Typo.span>
                     )}

--- a/src/page-modules/assistant/trip/trip-pattern/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/index.tsx
@@ -109,14 +109,27 @@ export default function TripPattern({
                   </div>
 
                   <div className={style.timeStartContainer}>
-                    <Typo.span textType="body__tertiary">
-                      {formatToClock(leg.expectedStartTime, language, 'floor')}
-                    </Typo.span>
                     {secondsBetween(leg.aimedStartTime, leg.expectedStartTime) >
-                      60 && (
+                    60 ? (
+                      <>
+                        <Typo.span textType="body__tertiary">
+                          {formatToClock(
+                            leg.expectedStartTime,
+                            language,
+                            'floor',
+                          )}
+                        </Typo.span>
+                        <Typo.span
+                          textType="body__tertiary--strike"
+                          className={style.outdatet}
+                        >
+                          {formatToClock(leg.aimedStartTime, language, 'floor')}
+                        </Typo.span>
+                      </>
+                    ) : (
                       <Typo.span
-                        textType="body__tertiary--strike"
-                        className={style.lineThrough}
+                        textType="body__tertiary"
+                        className={style.outdatet}
                       >
                         {formatToClock(leg.aimedStartTime, language, 'floor')}
                       </Typo.span>

--- a/src/page-modules/assistant/trip/trip-pattern/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/index.tsx
@@ -122,18 +122,17 @@ export default function TripPattern({
                     <Typo.span textType="body__tertiary">
                       {formatToClock(leg.expectedStartTime, language, 'floor')}
                     </Typo.span>
-                    {i === 0 &&
-                      !isEqualOnMinuteLevel(
-                        leg.aimedStartTime,
-                        leg.expectedStartTime,
-                      ) && (
-                        <Typo.span
-                          textType="body__tertiary"
-                          className={style.lineThrough}
-                        >
-                          {formatToClock(leg.aimedStartTime, language, 'floor')}
-                        </Typo.span>
-                      )}
+                    {!isEqualOnMinuteLevel(
+                      leg.aimedStartTime,
+                      leg.expectedStartTime,
+                    ) && (
+                      <Typo.span
+                        textType="body__tertiary"
+                        className={style.lineThrough}
+                      >
+                        {formatToClock(leg.aimedStartTime, language, 'floor')}
+                      </Typo.span>
+                    )}
                   </div>
                 </div>
 

--- a/src/page-modules/assistant/trip/trip-pattern/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/index.tsx
@@ -114,7 +114,10 @@ export default function TripPattern({
                     </Typo.span>
                     {secondsBetween(leg.aimedStartTime, leg.expectedStartTime) >
                       60 && (
-                      <Typo.span textType="body__tertiary--strike">
+                      <Typo.span
+                        textType="body__tertiary--strike"
+                        className={style.lineThrough}
+                      >
                         {formatToClock(leg.aimedStartTime, language, 'floor')}
                       </Typo.span>
                     )}

--- a/src/page-modules/assistant/trip/trip-pattern/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/index.tsx
@@ -124,6 +124,7 @@ export default function TripPattern({
                 {(i < expandedLegs.length - 1 || collapsedLegs.length > 0) && (
                   <div className={style.legs__legLineContainer}>
                     <div className={style.legs__legLine} />
+                    <div className={style.legs__legLine} />
                   </div>
                 )}
               </Fragment>
@@ -139,7 +140,6 @@ export default function TripPattern({
           </div>
 
           <div className={style.legs__lastLegLineContainer}>
-            <div className={style.legs__lastLegLine} />
             <div className={style.legs__lastLegLine} />
           </div>
         </div>

--- a/src/page-modules/assistant/trip/trip-pattern/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/index.tsx
@@ -5,7 +5,7 @@ import { getFilteredLegsByWalkOrWaitTime, tripSummary } from './utils';
 import { PageText, useTranslation } from '@atb/translations';
 import { type TripPattern as TripPatternType } from '../../server/journey-planner/validators';
 import style from './trip-pattern.module.css';
-import { formatToClock, isInPast } from '@atb/utils/date';
+import { formatToClock, isInPast, secondsBetween } from '@atb/utils/date';
 import { TripPatternHeader } from './trip-pattern-header';
 import { MonoIcon } from '@atb/components/icon';
 import { Typo } from '@atb/components/typography';
@@ -18,16 +18,6 @@ type TripPatternProps = {
   tripPattern: TripPatternType;
   delay: number;
   index: number;
-};
-
-const isEqualOnMinuteLevel = (
-  aimedStartTime: string,
-  expectedStartTime: string,
-): boolean => {
-  return (
-    new Date(aimedStartTime).getMinutes() ===
-    new Date(expectedStartTime).getMinutes()
-  );
 };
 
 export default function TripPattern({
@@ -122,10 +112,8 @@ export default function TripPattern({
                     <Typo.span textType="body__tertiary">
                       {formatToClock(leg.expectedStartTime, language, 'floor')}
                     </Typo.span>
-                    {!isEqualOnMinuteLevel(
-                      leg.aimedStartTime,
-                      leg.expectedStartTime,
-                    ) && (
+                    {secondsBetween(leg.aimedStartTime, leg.expectedStartTime) >
+                      60 && (
                       <Typo.span
                         textType="body__tertiary"
                         className={style.lineThrough}

--- a/src/page-modules/assistant/trip/trip-pattern/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/index.tsx
@@ -110,7 +110,7 @@ export default function TripPattern({
 
                   <div className={style.timeStartContainer}>
                     {secondsBetween(leg.aimedStartTime, leg.expectedStartTime) >
-                    60 ? (
+                    DEFAULT_THRESHOLD_AIMED_EXPECTED_IN_SECONDS ? (
                       <>
                         <Typo.span textType="body__tertiary">
                           {formatToClock(

--- a/src/page-modules/assistant/trip/trip-pattern/trip-pattern.module.css
+++ b/src/page-modules/assistant/trip/trip-pattern/trip-pattern.module.css
@@ -149,4 +149,5 @@
 
 .lineThrough {
   text-decoration: line-through;
+  color: var(--text-colors-secondary);
 }

--- a/src/page-modules/assistant/trip/trip-pattern/trip-pattern.module.css
+++ b/src/page-modules/assistant/trip/trip-pattern/trip-pattern.module.css
@@ -144,7 +144,7 @@
 .timeStartContainer {
   display: flex;
   direction: row;
-  gap: 4px;
+  gap: var(--spacings-xSmall);
 }
 
 .lineThrough {

--- a/src/page-modules/assistant/trip/trip-pattern/trip-pattern.module.css
+++ b/src/page-modules/assistant/trip/trip-pattern/trip-pattern.module.css
@@ -146,8 +146,3 @@
   direction: row;
   gap: var(--spacings-xSmall);
 }
-
-.lineThrough {
-  text-decoration: line-through;
-  color: var(--text-colors-secondary);
-}

--- a/src/page-modules/assistant/trip/trip-pattern/trip-pattern.module.css
+++ b/src/page-modules/assistant/trip/trip-pattern/trip-pattern.module.css
@@ -146,3 +146,7 @@
   direction: row;
   gap: var(--spacings-xSmall);
 }
+
+.outdatet {
+  color: var(--text-colors-secondary);
+}

--- a/src/page-modules/assistant/trip/trip-pattern/trip-pattern.module.css
+++ b/src/page-modules/assistant/trip/trip-pattern/trip-pattern.module.css
@@ -140,3 +140,13 @@
   gap: var(--spacings-small);
   align-items: center;
 }
+
+.timeStartContainer {
+  display: flex;
+  direction: row;
+  gap: 4px;
+}
+
+.lineThrough {
+  text-decoration: line-through;
+}


### PR DESCRIPTION
### Background

The search results currently only show the expected start time, but they should show both aimed (striked-through) and expected.

#### Illustrations
<details>
<summary>screenshot</summary>

![Screenshot 2023-12-19 at 12 59 18](https://github.com/AtB-AS/planner-web/assets/59939294/77c8f304-e12d-43b1-9e65-1fa12e4698e5)

</details>

### Proposed solution

For all delayed departures, display both the expectedStartTime and the aimedStartTime (strike-through). Other departures that are on time only displays expectedStartTime, as for these departures expectedStartTime === aimedStartTime.  

### Acceptance Criteria
- [ ] Both the aimed start time and expected start time are shown if the start is delayed.
- [ ] Only the aimed start time (or expected, they should be the same) should show if the trip is on time.