### PR TITLE
feat: link to service journey details from a trip suggestion

### DIFF
--- a/src/modules/cookies/index.tsx
+++ b/src/modules/cookies/index.tsx
@@ -15,6 +15,7 @@ export type { InitialCookieData };
 export type GlobalCookiesData = {
   initialCookies: InitialCookieData;
   headersAcceptLanguage: string;
+  referer: string;
 };
 export function getGlobalCookies(req?: {
   cookies: NextApiRequestCookies;
@@ -29,5 +30,6 @@ export function getGlobalCookies(req?: {
       language: req?.cookies[LANGUAGE_COOKIE_NAME] ?? null,
     },
     headersAcceptLanguage: req?.headers['accept-language'] ?? '',
+    referer: req?.headers.referer ?? '',
   };
 }

--- a/src/page-modules/assistant/details/trip-section/estimated-calls-section.tsx
+++ b/src/page-modules/assistant/details/trip-section/estimated-calls-section.tsx
@@ -2,30 +2,52 @@ import { Typo } from '@atb/components/typography';
 import { TripRow } from '@atb/modules/trip-details';
 import { PageText, useTranslation } from '@atb/translations';
 import { secondsToDuration } from '@atb/utils/date';
+import Link from 'next/link';
 
 import style from './trip-section.module.css';
 
 export type EstimatedCallsSectionProps = {
   numberOfIntermediateEstimatedCalls: number;
   duration: number;
+  serviceJourneyId: string | null;
+  date: string;
+  fromQuayId: string | null;
 };
 
 export function EstimatedCallsSection({
   numberOfIntermediateEstimatedCalls,
   duration,
+  serviceJourneyId,
+  date,
+  fromQuayId,
 }: EstimatedCallsSectionProps) {
   const { t, language } = useTranslation();
+
+  const shouldShowLinkToServiceJourney = serviceJourneyId ? true : false;
+  const serviceJourneyHref = fromQuayId
+    ? `/departures/details/${serviceJourneyId}?date=${date}&fromQuayId=${fromQuayId}`
+    : `/departures/details/${serviceJourneyId}?date=${date}`;
 
   if (numberOfIntermediateEstimatedCalls === 0) return null;
   return (
     <TripRow>
-      <Typo.p textType="body__secondary" className={style.intermediateStops}>
-        {t(
-          PageText.Assistant.details.tripSection.intermediateStops(
-            numberOfIntermediateEstimatedCalls,
-          ),
-        )}
-      </Typo.p>
+      {shouldShowLinkToServiceJourney ? (
+        <Link className={style.intermediateStops} href={serviceJourneyHref}>
+          {t(
+            PageText.Assistant.details.tripSection.intermediateStops(
+              numberOfIntermediateEstimatedCalls,
+            ),
+          )}
+        </Link>
+      ) : (
+        <Typo.p textType="body__secondary" className={style.intermediateStops}>
+          {t(
+            PageText.Assistant.details.tripSection.intermediateStops(
+              numberOfIntermediateEstimatedCalls,
+            ),
+          )}
+        </Typo.p>
+      )}
       <Typo.p textType="body__secondary" className={style.intermediateStops}>
         {secondsToDuration(duration, language)}
       </Typo.p>

--- a/src/page-modules/assistant/details/trip-section/estimated-calls-section.tsx
+++ b/src/page-modules/assistant/details/trip-section/estimated-calls-section.tsx
@@ -24,9 +24,10 @@ export function EstimatedCallsSection({
   const { t, language } = useTranslation();
 
   const shouldShowLinkToServiceJourney = serviceJourneyId ? true : false;
-  const serviceJourneyHref = fromQuayId
-    ? `/departures/details/${serviceJourneyId}?date=${date}&fromQuayId=${fromQuayId}`
-    : `/departures/details/${serviceJourneyId}?date=${date}`;
+  let serviceJourneyHref = `/departures/details/${serviceJourneyId}?date=${date}`;
+  if (fromQuayId) {
+    serviceJourneyHref += `&fromQuayId=${fromQuayId}`;
+  }
 
   if (numberOfIntermediateEstimatedCalls === 0) return null;
   return (

--- a/src/page-modules/assistant/details/trip-section/index.tsx
+++ b/src/page-modules/assistant/details/trip-section/index.tsx
@@ -145,6 +145,9 @@ export default function TripSection({
             leg.numberOfIntermediateEstimatedCalls
           }
           duration={leg.duration}
+          serviceJourneyId={leg.serviceJourney?.id ?? null}
+          date={leg.aimedStartTime.split('T')[0]}
+          fromQuayId={leg.fromPlace.quay?.id ?? null}
         />
 
         {showTo && (

--- a/src/page-modules/assistant/details/trip-section/trip-section.module.css
+++ b/src/page-modules/assistant/details/trip-section/trip-section.module.css
@@ -1,3 +1,5 @@
+@value typo-body__secondary from "@atb/theme/typography.module.css";
+
 .container {
   display: flex;
   flex-direction: column;
@@ -15,5 +17,6 @@
 .walkTime,
 .waitTime,
 .intermediateStops {
+  composes: typo-body__secondary;
   color: var(--text-colors-secondary);
 }

--- a/src/page-modules/assistant/server/journey-planner/index.ts
+++ b/src/page-modules/assistant/server/journey-planner/index.ts
@@ -295,6 +295,7 @@ export function createJourneyApi(
             longitude: leg.fromPlace.longitude,
             quay: leg.fromPlace.quay
               ? {
+                  id: leg.fromPlace.quay.id,
                   name: leg.fromPlace.quay.name,
                   publicCode: leg.fromPlace.quay.publicCode ?? '',
                 }
@@ -309,9 +310,11 @@ export function createJourneyApi(
                 }
               : null,
           },
-          serviceJourney: {
-            id: leg.serviceJourney?.id ?? null,
-          },
+          serviceJourney: leg.serviceJourney
+            ? {
+                id: leg.serviceJourney.id,
+              }
+            : null,
           fromEstimatedCall: leg.fromEstimatedCall?.destinationDisplay
             ?.frontText
             ? {
@@ -356,8 +359,8 @@ type RecursivePartial<T> = {
   [P in keyof T]?: T[P] extends (infer U)[]
     ? RecursivePartial<U>[]
     : T[P] extends object | undefined
-      ? RecursivePartial<T[P]>
-      : T[P];
+    ? RecursivePartial<T[P]>
+    : T[P];
 };
 
 function inputToLocation(

--- a/src/page-modules/assistant/server/journey-planner/journey-gql/trip-with-details.gql
+++ b/src/page-modules/assistant/server/journey-planner/journey-gql/trip-with-details.gql
@@ -54,6 +54,7 @@ query TripsWithDetails(
           latitude
           longitude
           quay {
+            id
             name
             publicCode
           }

--- a/src/page-modules/assistant/server/journey-planner/validators.ts
+++ b/src/page-modules/assistant/server/journey-planner/validators.ts
@@ -106,6 +106,7 @@ export const tripPatternWithDetailsSchema = z.object({
         longitude: z.number(),
         quay: z
           .object({
+            id: z.string(),
             name: z.string(),
             publicCode: z.string().nullable(),
           })
@@ -120,9 +121,11 @@ export const tripPatternWithDetailsSchema = z.object({
           })
           .nullable(), // quay is null when toPlace is a POI (e.g. address)
       }),
-      serviceJourney: z.object({
-        id: z.string().nullable(),
-      }),
+      serviceJourney: z
+        .object({
+          id: z.string(),
+        })
+        .nullable(),
       fromEstimatedCall: z
         .object({
           destinationDisplay: z.object({ frontText: z.string() }),

--- a/src/page-modules/departures/details/index.tsx
+++ b/src/page-modules/departures/details/index.tsx
@@ -15,11 +15,13 @@ import { MessageBox } from '@atb/components/message-box';
 export type DeparturesDetailsProps = {
   fromQuayId?: string;
   serviceJourney: ServiceJourneyData;
+  referer?: string;
 };
 
 export function DeparturesDetails({
   fromQuayId,
   serviceJourney,
+  referer,
 }: DeparturesDetailsProps) {
   const { t } = useTranslation();
   const focusedCall =
@@ -49,13 +51,22 @@ export function DeparturesDetails({
     .map((s) => s.situationNumber)
     .filter((s): s is string => !!s);
 
+  const backLink =
+    referer && referer.includes('assistant/')
+      ? referer
+      : `/departures/${focusedCall.quay.stopPlace.id}`;
+
   return (
     <section className={style.container}>
       <div className={style.headerContainer}>
         <ButtonLink
           mode="transparent"
-          href={`/departures/${focusedCall.quay.stopPlace.id}`}
-          title={t(PageText.Departures.details.back)}
+          href={backLink}
+          title={
+            backLink.includes('assistant/')
+              ? t(PageText.Departures.details.backToAssistant)
+              : t(PageText.Departures.details.backToDepartures)
+          }
           icon={{ left: <MonoIcon icon="navigation/ArrowLeft" /> }}
         />
         <div className={style.header}>

--- a/src/page-modules/departures/details/index.tsx
+++ b/src/page-modules/departures/details/index.tsx
@@ -51,10 +51,9 @@ export function DeparturesDetails({
     .map((s) => s.situationNumber)
     .filter((s): s is string => !!s);
 
-  const backLink =
-    referer && referer.includes('assistant/')
-      ? referer
-      : `/departures/${focusedCall.quay.stopPlace.id}`;
+  const backLink = referer?.includes('assistant/')
+    ? referer
+    : `/departures/${focusedCall.quay.stopPlace.id}`;
 
   return (
     <section className={style.container}>

--- a/src/translations/pages/departures.ts
+++ b/src/translations/pages/departures.ts
@@ -93,10 +93,15 @@ export const Departures = {
     },
   },
   details: {
-    back: _(
+    backToDepartures: _(
       'Tilbake til avganger',
       'Back to departures',
       'Tilbake til avgangar',
+    ),
+    backToAssistant: _(
+      'Tilbake til reiseforslag',
+      'Back to travel suggestion',
+      'Tilbake til reiseforslag',
     ),
     lastPassedStop: (stopPlaceName: string, time: string) =>
       _(


### PR DESCRIPTION
This PR adds the functionality to see details about the intermediate stops of a service journey from a trip pattern. 

I've added the headers referer to the global data so that we have the correct back link in the departures details page. If a user navigates to the departures details page from a trip suggestion one should be redirected back to the trip suggestion. In other cases (from departures or opening the link from someone) one should be navigated to the departures page. 

Closes https://github.com/AtB-AS/kundevendt/issues/15872