### PR TITLE
fix: update accessibility statement url for FRAM

### DIFF
--- a/orgs/fram.json
+++ b/orgs/fram.json
@@ -17,7 +17,7 @@
     },
 
     "accessibilityStatementUrl": {
-      "default": "https://uustatus.no/nb/erklaringer/publisert/a98e360d-c8d9-4a6f-aaf4-324582ebf297"
+      "default": "https://uustatus.no/nb/erklaringer/publisert/1b5c3a7f-cb6b-45c7-afd6-752931242235"
     },
 
     "supportUrl": {


### PR DESCRIPTION
We are currently using the webshop accessibility statement for the planner web. PO wants to use the one from frammr.no instead. 