### PR TITLE
fix: display the departure time that was expected when searching after past departures

### DIFF
--- a/src/page-modules/departures/stop-place/index.tsx
+++ b/src/page-modules/departures/stop-place/index.tsx
@@ -8,7 +8,9 @@ import style from './stop-place.module.css';
 import { ColorIcon, MonoIcon } from '@atb/components/icon';
 import {
   formatLocaleTime,
+  formatSimpleTime,
   formatToClockOrRelativeMinutes,
+  isInPast,
   secondsBetween,
 } from '@atb/utils/date';
 import { PageText, useTranslation } from '@atb/translations';
@@ -263,11 +265,13 @@ export function DepartureTime({
             : ''
         }
       >
-        {formatToClockOrRelativeMinutes(
-          expectedDepartureTime,
-          language,
-          t(dictionary.date.units.now),
-        )}
+        {isInPast(expectedDepartureTime)
+          ? formatSimpleTime(expectedDepartureTime)
+          : formatToClockOrRelativeMinutes(
+              expectedDepartureTime,
+              language,
+              t(dictionary.date.units.now),
+            )}
       </Typo.p>
       {isMoreThanOneMinuteDelayed(
         expectedDepartureTime,


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/16110


### Background
Received feedback that it says "Now" on all departures when you search for previous departures backwards in time.

#### Illustrations
<details>
<summary>screenrecording</summary>

https://github.com/AtB-AS/planner-web/assets/59939294/82cdc9cc-0305-42a2-8db4-8824ba72b7a1

</details>

### Proposed solution

Whenever searching after past departures, the start times that were expected for each departure is displayed.  

### Acceptance Criteria
- [ ] Display expected start time instead whenever searching after past departures. 