### PR TITLE
fix: ensure that live icon and description is not rendered when displaying canceled departures.

### DIFF
--- a/src/page-modules/departures/details/index.tsx
+++ b/src/page-modules/departures/details/index.tsx
@@ -49,6 +49,10 @@ export function DeparturesDetails({
     .map((s) => s.situationNumber)
     .filter((s): s is string => !!s);
 
+  const isJourneyCancelled = situations.some((item) =>
+    item.summary.some((i) => i.value === 'Journey cancelled'),
+  );
+
   return (
     <section className={style.container}>
       <div className={style.headerContainer}>
@@ -66,7 +70,7 @@ export function DeparturesDetails({
           />
           <Typo.h2 textType="heading--big">{title}</Typo.h2>
         </div>
-        {realtimeText && (
+        {realtimeText && !isJourneyCancelled && (
           <div className={style.realtimeText}>
             <ColorIcon icon="status/Realtime" size="small" />
             <Typo.h3 textType="body__secondary">{realtimeText}</Typo.h3>

--- a/src/page-modules/departures/details/index.tsx
+++ b/src/page-modules/departures/details/index.tsx
@@ -35,6 +35,7 @@ export function DeparturesDetails({
       realtime: c.realtime,
     })),
   );
+
   const estimatedCallsWithMetadata = addMetadataToEstimatedCalls(
     serviceJourney.estimatedCalls,
     fromQuayId,
@@ -48,10 +49,6 @@ export function DeparturesDetails({
   const alreadyShownSituationNumbers = situations
     .map((s) => s.situationNumber)
     .filter((s): s is string => !!s);
-
-  const isJourneyCancelled = situations.some((item) =>
-    item.summary.some((i) => i.value === 'Journey cancelled'),
-  );
 
   return (
     <section className={style.container}>
@@ -70,7 +67,7 @@ export function DeparturesDetails({
           />
           <Typo.h2 textType="heading--big">{title}</Typo.h2>
         </div>
-        {realtimeText && !isJourneyCancelled && (
+        {realtimeText && !focusedCall.cancellation && (
           <div className={style.realtimeText}>
             <ColorIcon icon="status/Realtime" size="small" />
             <Typo.h3 textType="body__secondary">{realtimeText}</Typo.h3>


### PR DESCRIPTION
Fixes https://github.com/AtB-AS/kundevendt/issues/15983

### Background:

Currently, both the live icon and the description "I rute" is displayed when routes are cancelled in realtime. When cancelled, neither th icon or the description should be displayed. 
 
#### Illustrations
<details>
<summary>screenshot</summary>

<img width="613" alt="Screenshot 2023-12-20 at 12 28 43" src="https://github.com/AtB-AS/planner-web/assets/59939294/7420649f-e606-4927-b562-b11d1c4b29f2">

</details>

### Proposed solution:

Added a condition to verify that the departure is not cancelled. If cancelled, the icon and description are not included.  

### Acceptance criteria 
- [ ] The live icon and description should never display for cancelled departures.  

