### PR TITLE
feat: reset search when switching tab

### DIFF
--- a/src/widget/widget.module.css
+++ b/src/widget/widget.module.css
@@ -223,10 +223,12 @@
 .button.button--disabled {
   background-color: var(--interactive-interactive_0-disabled-background);
   color: var(--interactive-interactive_0-disabled-text);
+  cursor: default;
 }
 .button:focus {
   outline: 0;
-  box-shadow: inset 0 0 0 var(--border-width-medium) var(--interactive-interactive_0-outline-background);
+  box-shadow: inset 0 0 0 var(--border-width-medium)
+    var(--interactive-interactive_0-outline-background);
 }
 
 /* Autocomplete */

--- a/src/widget/widget.module.css
+++ b/src/widget/widget.module.css
@@ -223,7 +223,6 @@
 .button.button--disabled {
   background-color: var(--interactive-interactive_0-disabled-background);
   color: var(--interactive-interactive_0-disabled-text);
-  cursor: default;
 }
 .button:focus {
   outline: 0;

--- a/src/widget/widget.ts
+++ b/src/widget/widget.ts
@@ -456,8 +456,7 @@ function createOutput({ URL_BASE }: SettingConstants, texts: Texts) {
           <label class="${style.selector_option}">
             <input
               type="radio"
-              name="searchTimeSelector"
-              aria-labelled-by="${prefix}-now"
+              name="${prefix}-searchTimeSelector"
               aria-labelledby="${prefix}-now"
               class="${style.selector_option__input}"
               value="now"
@@ -472,8 +471,7 @@ function createOutput({ URL_BASE }: SettingConstants, texts: Texts) {
           <label class="${style.selector_option}">
             <input
               type="radio"
-              name="searchTimeSelector"
-              aria-labelled-by="${prefix}-depart"
+              name="${prefix}-searchTimeSelector"
               aria-labelledby="${prefix}-depart"
               class="${style.selector_option__input}"
               value="departBy"
@@ -492,8 +490,7 @@ function createOutput({ URL_BASE }: SettingConstants, texts: Texts) {
                 <label class="${style.selector_option}">
                   <input
                     type="radio"
-                    name="searchTimeSelector"
-                    aria-labelled-by="${prefix}-arrival"
+                    name="${prefix}-searchTimeSelector"
                     aria-labelledby="${prefix}-arrival"
                     class="${style.selector_option__input}"
                     value="arriveBy"

--- a/src/widget/widget.ts
+++ b/src/widget/widget.ts
@@ -85,6 +85,30 @@ function init() {
     }
   });
 
+  document.addEventListener('reset-search', function () {
+    // Reset state.
+    fromTo = {
+      from: undefined,
+      to: undefined,
+    };
+
+    // Reset input values to empty.
+    document
+      .querySelectorAll<HTMLInputElement>(
+        'input[name="from"], input[name="to"]',
+      )
+      .forEach((input) => {
+        input.value = '';
+      });
+
+    // Set submit buttons to disabled.
+    document
+      .querySelectorAll<HTMLButtonElement>('button[type="submit"]')
+      .forEach((button) => {
+        button.disabled = true;
+      });
+  });
+
   document.querySelectorAll('[name=searchTimeSelector]').forEach(function (el) {
     el.addEventListener('change', function (e) {
       const input = e.currentTarget as HTMLInputElement;
@@ -1042,7 +1066,7 @@ const texts: Record<Languages, Texts> = {
     departure: {
       link: 'Avganger',
       title: 'Hvor vil du reise fra?',
-      from: 'string',
+      from: 'Fra',
     },
     searchTime: {
       title: 'Når vil du reise?',

--- a/src/widget/widget.ts
+++ b/src/widget/widget.ts
@@ -458,6 +458,7 @@ function createOutput({ URL_BASE }: SettingConstants, texts: Texts) {
               type="radio"
               name="searchTimeSelector"
               aria-labelled-by="${prefix}-now"
+              aria-labelledby="${prefix}-now"
               class="${style.selector_option__input}"
               value="now"
               checked=""
@@ -473,6 +474,7 @@ function createOutput({ URL_BASE }: SettingConstants, texts: Texts) {
               type="radio"
               name="searchTimeSelector"
               aria-labelled-by="${prefix}-depart"
+              aria-labelledby="${prefix}-depart"
               class="${style.selector_option__input}"
               value="departBy"
             />
@@ -492,6 +494,7 @@ function createOutput({ URL_BASE }: SettingConstants, texts: Texts) {
                     type="radio"
                     name="searchTimeSelector"
                     aria-labelled-by="${prefix}-arrival"
+                    aria-labelledby="${prefix}-arrival"
                     class="${style.selector_option__input}"
                     value="arriveBy"
                   />

--- a/src/widget/widget.ts
+++ b/src/widget/widget.ts
@@ -74,6 +74,15 @@ function init() {
   document.addEventListener('search-selected', function (event) {
     const data = event as CustomEvent<SelectedSearchEvent>;
     fromTo[data.detail.key] = data.detail.item;
+
+    if (data.detail.key === 'from') {
+      const submitButtons = document.querySelectorAll<HTMLButtonElement>(
+        'button[type="submit"]',
+      );
+      submitButtons.forEach((button) => {
+        button.disabled = false;
+      });
+    }
   });
 
   document.querySelectorAll('[name=searchTimeSelector]').forEach(function (el) {
@@ -240,10 +249,9 @@ function createOutput({ URL_BASE }: SettingConstants, texts: Texts) {
 
     connectedCallback() {
       const self = this;
-      const mode = self.getAttribute('data-mode') ?? 'assistant';
       const button = this.querySelector('button')!;
 
-      button.addEventListener('click', async (event) => {
+      button.addEventListener('click', async () => {
         MessageBox.clearMessageBox();
 
         try {
@@ -257,7 +265,6 @@ function createOutput({ URL_BASE }: SettingConstants, texts: Texts) {
             new CustomEvent('search-selected', {
               bubbles: true,
               detail: {
-                mode,
                 key: 'from',
                 item,
               },
@@ -314,6 +321,7 @@ function createOutput({ URL_BASE }: SettingConstants, texts: Texts) {
       )!;
 
       let combobox = new Combobox(input, list, {
+        tabInsertsSuggestions: true,
         scrollIntoViewOptions: false,
       });
 
@@ -358,6 +366,7 @@ function createOutput({ URL_BASE }: SettingConstants, texts: Texts) {
           showEmpty();
         }
       }, debounceTime);
+
       input.addEventListener('keydown', (event) => {
         if (event.key === 'Escape') {
           toggleList(false);
@@ -388,7 +397,6 @@ function createOutput({ URL_BASE }: SettingConstants, texts: Texts) {
           new CustomEvent('search-selected', {
             bubbles: true,
             detail: {
-              mode: 'assistant',
               key: input.name,
               item,
             },
@@ -406,11 +414,12 @@ function createOutput({ URL_BASE }: SettingConstants, texts: Texts) {
 
   const buttons = html`
     <div class="${style.buttonGroup}">
-      <button type="submit" class="${style.button}" aria-disabled="true">
+      <button type="submit" class="${style.button}" disabled>
         <span>${texts.searchButton}</span>
       </button>
     </div>
   `;
+
   const searchTime = (prefix: string, withArriveBy: boolean = true) => html`
     <div class="${style.inputBoxes}">
       <p class="${style.heading}">${texts.searchTime.title}</p>


### PR DESCRIPTION
## Changed this PR to not remove form, but add some minor changes to the widget, e.g. what happens when a tab is changed and disabled mode for the submit button.

## ~This just probably bloats the widget. Should probably abandon it.~

## Summary

This PR introduces a couple of features and bug fixes:

-  **Features:**
    - Added functionality to reset search when switching between tabs.
    - Make it possible to click the search button at all times, routing to the travel planner even though from/to might not be set. Some users experienced trouble showing the autocomplete box, and wasn't able to click the search button because they couldn't set a location.

-  **Fixes:**
    - Fixed proper use of ARIA property.
    - Added missing translation for "From" label.



# ~~*Pull Request Description:*~~ 

### ~~*Overview*~~
~~*This PR addresses the issue with the widget failing due to being nested within a `form` element in the FRAM page. The problem arises from the HTML specification restriction of not allowing a form inside another form.*~~

### ~~*Changes*~~
~~*1. The widget has been rewritten to remove the `form` dependency. Event handlers have now been added to the input fields and the search button.*~~

### ~~*Impact*~~
~~*Here's how the modified widget fulfils the acceptance criteria:*~~

-    ~~*The reformatted widget performs in the same manner as its previous implementation. This ensures seamless user experience, with no change detected on the frontend.*~~

-    ~~*The widget can now function efficiently inside a `form` block without necessitating any excessive workarounds.*~~

-    ~~*Clicking on the 'search' button triggers a search action, signifying successful event binding.*~~

-    ~~*Pressing 'Enter' while focusing on an input field initiates a search, indicating successful Key Event handling.*~~

-    ~~*If the 'From' field is left blank, the search operation is not executed, maintaining the original search logic.*~~

-    ~~*The proper state of date/time selectors is sustained while toggling between different tabs.*~~

~~*Revising the widget to leverage event handlers for inputs and buttons, rather than relying on a `form`, has rectified the nesting issues without compromising on functionality or user experience.*~~

~~*Please review the changes and give your feedback.*~~

