### PR TITLE
feat: get default focus point from Firebase

### DIFF
--- a/src/modules/firebase/default-focus-point.ts
+++ b/src/modules/firebase/default-focus-point.ts
@@ -1,0 +1,26 @@
+import { getFirestore, getDoc, doc } from 'firebase/firestore';
+import app from './firebase';
+import { DefaultFocusPoint, defaultFocusPointSchema } from './types';
+
+const DEFAULT_FOCUS_POINT_FALLBACK = { lat: 63.43457, lon: 10.39844 };
+export async function getDefaultFocusPoint(): Promise<DefaultFocusPoint> {
+  const firestore = getFirestore(app);
+  const docRef = doc(firestore, 'configuration', 'other');
+
+  const snapshot = await getDoc(docRef);
+
+  if (snapshot.exists()) {
+    const data = snapshot.data();
+    try {
+      const validated = defaultFocusPointSchema.safeParse(
+        data.defaultFocusPoint,
+      );
+      if (validated.success) {
+        return validated.data;
+      }
+    } catch (e) {
+      throw new Error('Could not parse default focus point from Firebase');
+    }
+  }
+  return DEFAULT_FOCUS_POINT_FALLBACK;
+}

--- a/src/modules/firebase/types.ts
+++ b/src/modules/firebase/types.ts
@@ -12,4 +12,10 @@ export const tariffZoneSchema = z.object({
   isDefault: z.boolean().optional(),
 });
 
+export const defaultFocusPointSchema = z.object({
+  lat: z.number(),
+  lon: z.number(),
+});
+
 export type TariffZone = z.infer<typeof tariffZoneSchema>;
+export type DefaultFocusPoint = z.infer<typeof defaultFocusPointSchema>;

--- a/src/page-modules/departures/server/geocoder/index.ts
+++ b/src/page-modules/departures/server/geocoder/index.ts
@@ -3,9 +3,9 @@ import type { GeocoderFeature } from '../../types';
 import { GeocoderRoot, geocoderRootSchema } from './encoders';
 import { FeatureCategory } from '@atb/components/venue-icon';
 import { first } from 'lodash';
+import { getDefaultFocusPoint } from '@atb/modules/firebase/default-focus-point';
 
 const FOCUS_WEIGHT = 18;
-const DEFAULT_FOCUS_POINT = { lat: 62.4705, lon: 6.1533 }; // TODO: Replace with configuration.
 
 export type GeocoderApi = {
   autocomplete(
@@ -27,7 +27,7 @@ export function createGeocoderApi(
 ): GeocoderApi {
   return {
     async autocomplete(query, focus) {
-      const focusQuery = createFocusQuery(focus);
+      const focusQuery = await createFocusQuery(focus);
       const result = await request(
         `/geocoder/v1/autocomplete?text=${query}&${focusQuery}&size=10&lang=no`,
       );
@@ -57,8 +57,12 @@ export function createGeocoderApi(
   };
 }
 
-function createFocusQuery(focus?: { lat: number; lon: number }): string {
-  const { lat, lon } = focus ?? DEFAULT_FOCUS_POINT;
+async function createFocusQuery(focus?: {
+  lat: number;
+  lon: number;
+}): Promise<string> {
+  const defaultFocusPoint = await getDefaultFocusPoint();
+  const { lat, lon } = focus ?? defaultFocusPoint;
   return `focus.point.lat=${lat}&focus.point.lon=${lon}&focus.weight=${FOCUS_WEIGHT}&focus.function=exp&focus.scale=200km`;
 }
 


### PR DESCRIPTION
This PR adds functionality that fetches the default focus point from Firebase and uses it for autocomplete, if it exists. If it does not exist in Firebase, a fallback is used. This fallback is currently hardcoded, not sure if we should handle it a different way. If we do, it means we have several ways of configuring the default focus point, which I mean is unnecessary. I think it's fine to have a hardcoded fallback, to e.g. Trondheim as it is now, and if it's needed/wanted to have it somewhere else Firebase should be used.

Fixes https://github.com/AtB-AS/kundevendt/issues/15997
