### PR TITLE
fix: ensure that the icon box is as wide or wider than the departure time bellow the box 

### DIFF
--- a/src/modules/transport-mode/icon/icon.module.css
+++ b/src/modules/transport-mode/icon/icon.module.css
@@ -12,6 +12,7 @@
 
 .transportIconWithLabel {
   display: flex;
+  justify-content: center;
   align-items: center;
   padding: var(--spacings-small) var(--spacings-medium);
 }

--- a/src/page-modules/assistant/trip/trip-pattern/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/index.tsx
@@ -88,26 +88,22 @@ export default function TripPattern({
             {expandedLegs.map((leg, i) => (
               <Fragment key={`leg-${leg.expectedStartTime}-${i}`}>
                 <div className={style.legs__leg}>
-                  <div className={style.legs__leg__icon}>
-                    {leg.mode ? (
-                      <TransportIconWithLabel
-                        mode={{
-                          transportMode: leg.mode,
-                          transportSubModes: leg.transportSubmode
-                            ? [leg.transportSubmode]
-                            : undefined,
-                        }}
-                        label={leg.line?.publicCode ?? undefined}
-                        duration={
-                          leg.mode === 'foot' ? leg.duration : undefined
-                        }
-                      />
-                    ) : (
-                      <div className={style.legs__leg__walkIcon}>
-                        <MonoIcon icon="transportation/Walk" />
-                      </div>
-                    )}
-                  </div>
+                  {leg.mode ? (
+                    <TransportIconWithLabel
+                      mode={{
+                        transportMode: leg.mode,
+                        transportSubModes: leg.transportSubmode
+                          ? [leg.transportSubmode]
+                          : undefined,
+                      }}
+                      label={leg.line?.publicCode ?? undefined}
+                      duration={leg.mode === 'foot' ? leg.duration : undefined}
+                    />
+                  ) : (
+                    <div className={style.legs__leg__walkIcon}>
+                      <MonoIcon icon="transportation/Walk" />
+                    </div>
+                  )}
 
                   <div className={style.timeStartContainer}>
                     {secondsBetween(leg.aimedStartTime, leg.expectedStartTime) >

--- a/src/page-modules/assistant/trip/trip-pattern/trip-pattern.module.css
+++ b/src/page-modules/assistant/trip/trip-pattern/trip-pattern.module.css
@@ -54,12 +54,6 @@
   gap: var(--spacings-small);
 }
 
-.legs__leg__icon {
-  display: flex;
-  border-radius: var(--border-radius-small);
-  position: relative;
-}
-
 .legs__legLineContainer,
 .legs__lastLegLineContainer {
   /* The height of the icon in a leg. */


### PR DESCRIPTION
Fixes https://github.com/AtB-AS/kundevendt/issues/16000

### Background

We received feedback that the boxes that do not contain a transport icon and route number did not adjust in width according to the text below the box.

#### Illustrations

<details>
<summary>screenshots</summary>

<img width="344" alt="old" src="https://github.com/AtB-AS/planner-web/assets/59939294/43f0af02-88f8-4091-97ca-2e5ec3b6cbbe">

<img width="303" alt="new" src="https://github.com/AtB-AS/planner-web/assets/59939294/e54f16fe-8a74-4afe-a9dd-f3f18d6141c4">

<img width="323" alt="new_three_digit_route" src="https://github.com/AtB-AS/planner-web/assets/59939294/6f72e8aa-d573-4b71-9d09-fab10254f5a0">

</details>
prior fix / after fix / after fix three_digit_route

### Proposed solution

Fix box styling to ensure that box containing both the icon and route number is at least as wide or wider than the aimed start time + the expected start time.

### Acceptance Criteria
- [ ] aimed start time + the expected start time never exceeds the box in width. 
- [ ] the update does not affect other parts of the layout except the box cards. 