### PR TITLE
fix: includes message from message box into buttons aria-label, to make message accessible for voiceover.

### DIFF
--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -26,7 +26,6 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         disabled={props.disabled || props.state === 'loading'}
         aria-disabled={props.disabled || props.state === 'loading'}
         data-testid={testID}
-        aria-label={buttonProps?.['aria-label']}
         {...buttonProps}
       >
         <ButtonBase {...props} />

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -12,10 +12,14 @@ export type ButtonProps = {
    * Pass properties to button element directly
    */
   buttonProps?: JSX.IntrinsicElements['button'];
+  /**
+   * Define aria-label for voiceover to read.
+   */
+  ariaLabel?: string;
 } & ButtonBaseProps;
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  function Button({ onClick, testID, buttonProps, ...props }, ref) {
+  function Button({ onClick, testID, buttonProps, ariaLabel, ...props }, ref) {
     const className = getBaseButtonClassName(props);
     return (
       <button
@@ -26,6 +30,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         disabled={props.disabled || props.state === 'loading'}
         aria-disabled={props.disabled || props.state === 'loading'}
         data-testid={testID}
+        aria-label={ariaLabel}
         {...buttonProps}
       >
         <ButtonBase {...props} />

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -12,14 +12,10 @@ export type ButtonProps = {
    * Pass properties to button element directly
    */
   buttonProps?: JSX.IntrinsicElements['button'];
-  /**
-   * Define aria-label for voiceover to read.
-   */
-  ariaLabel?: string;
 } & ButtonBaseProps;
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  function Button({ onClick, testID, buttonProps, ariaLabel, ...props }, ref) {
+  function Button({ onClick, testID, buttonProps, ...props }, ref) {
     const className = getBaseButtonClassName(props);
     return (
       <button
@@ -30,7 +26,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         disabled={props.disabled || props.state === 'loading'}
         aria-disabled={props.disabled || props.state === 'loading'}
         data-testid={testID}
-        aria-label={ariaLabel}
+        aria-label={buttonProps?.['aria-label']}
         {...buttonProps}
       >
         <ButtonBase {...props} />

--- a/src/components/message-box/index.tsx
+++ b/src/components/message-box/index.tsx
@@ -10,6 +10,7 @@ import { Typo } from '@atb/components/typography';
 
 import style from './message-box.module.css';
 import { colorToOverrideMode } from '@atb/utils/color';
+import { screenReaderPause } from '../typography/utils';
 
 export type MessageMode = keyof Theme['static']['status'];
 
@@ -64,6 +65,9 @@ export const MessageBox = ({
         </Typo.p>
         {onClick && (
           <Button
+            ariaLabel={`${message}${screenReaderPause}${t(
+              dictionary.readMore,
+            )}`}
             mode="transparent--underline"
             onClick={() => onClick()}
             title={t(dictionary.readMore)}

--- a/src/components/message-box/index.tsx
+++ b/src/components/message-box/index.tsx
@@ -10,7 +10,7 @@ import { Typo } from '@atb/components/typography';
 
 import style from './message-box.module.css';
 import { colorToOverrideMode } from '@atb/utils/color';
-import { screenReaderPause } from '../typography/utils';
+import { screenReaderPause } from '@atb/components/typography/utils';
 
 export type MessageMode = keyof Theme['static']['status'];
 

--- a/src/components/message-box/index.tsx
+++ b/src/components/message-box/index.tsx
@@ -65,14 +65,16 @@ export const MessageBox = ({
         </Typo.p>
         {onClick && (
           <Button
-            ariaLabel={`${message}${screenReaderPause}${t(
-              dictionary.readMore,
-            )}`}
             mode="transparent--underline"
             onClick={() => onClick()}
             title={t(dictionary.readMore)}
             className={style.messageBox__button}
             size="compact"
+            buttonProps={{
+              'aria-label': `${message}${screenReaderPause}${t(
+                dictionary.readMore,
+              )}`,
+            }}
           />
         )}
       </div>


### PR DESCRIPTION
Fixes https://github.com/AtB-AS/kundevendt/issues/15810

### Background

When the voiceover reads message boxes, only the button text is read. It is desirable that both the message and the button text is read by the voiceover.  

#### Illustrations
<details>
<summary>screenrecording</summary>

https://github.com/AtB-AS/planner-web/assets/59939294/7be3d20b-4f43-4845-81ac-a05bae115605


</details>

### Proposed solution

The proposed solution passes the message as prop to the button component, where it is included in the buttons arial-label, which is read by the voiceover. 

### Acceptance Criteria

- [ ] Both the massage and the button text is read by the voiceover. 