### PR TITLE
fix: show whole trip on map load

### DIFF
--- a/src/components/map/map.tsx
+++ b/src/components/map/map.tsx
@@ -21,6 +21,7 @@ export type MapProps = {
   onSelectStopPlace?: (id: string) => void;
   mapLegs?: MapLegType[];
   initialZoom?: number;
+  bounds?: [[number, number], [number, number]];
 };
 
 export function Map({
@@ -29,6 +30,7 @@ export function Map({
   onSelectStopPlace,
   mapLegs,
   initialZoom = ZOOM_LEVEL,
+  bounds,
 }: MapProps) {
   const mapWrapper = useRef<HTMLDivElement>(null);
   const mapContainer = useRef<HTMLDivElement>(null);
@@ -47,6 +49,7 @@ export function Map({
       style: mapboxData.style,
       center: position,
       zoom: initialZoom,
+      bounds: bounds, // If bounds is specified, it overrides center and zoom constructor options.
     });
 
     return () => map.current?.remove();
@@ -59,16 +62,6 @@ export function Map({
   );
   useMapPin(map, position, layer);
   useMapLegs(map, mapLegs);
-
-  useEffect(() => {
-    if (map.current) {
-      map.current.flyTo({
-        center: position,
-        zoom: initialZoom,
-        speed: 2,
-      });
-    }
-  }, [position, initialZoom]);
 
   return (
     <div className={style.map} aria-hidden="true">

--- a/src/components/map/map.tsx
+++ b/src/components/map/map.tsx
@@ -49,7 +49,7 @@ export function Map({
       style: mapboxData.style,
       center: position,
       zoom: initialZoom,
-      bounds: bounds ? [bounds.sw, bounds.ne] : undefined, // If bounds is specified, it overrides center and zoom constructor options.
+      bounds, // If bounds is specified, it overrides center and zoom constructor options.
     });
 
     return () => map.current?.remove();

--- a/src/components/map/map.tsx
+++ b/src/components/map/map.tsx
@@ -7,7 +7,7 @@ import { Button } from '@atb/components/button';
 import { MonoIcon } from '@atb/components/icon';
 import { ComponentText, useTranslation } from '@atb/translations';
 import { FocusScope } from '@react-aria/focus';
-import { ZOOM_LEVEL, defaultPosition } from './utils';
+import { ZOOM_LEVEL, defaultPosition, getMapBounds } from './utils';
 import { useMapInteractions } from './use-map-interactions';
 import { useFullscreenMap } from './use-fullscreen-map';
 import { useMapPin } from './use-map-pin';
@@ -19,9 +19,8 @@ export type MapProps = {
   position?: Position;
   layer?: string;
   onSelectStopPlace?: (id: string) => void;
-  mapLegs?: MapLegType[];
   initialZoom?: number;
-  bounds?: [[number, number], [number, number]];
+  mapLegs?: MapLegType[];
 };
 
 export function Map({
@@ -30,12 +29,13 @@ export function Map({
   onSelectStopPlace,
   mapLegs,
   initialZoom = ZOOM_LEVEL,
-  bounds,
 }: MapProps) {
   const mapWrapper = useRef<HTMLDivElement>(null);
   const mapContainer = useRef<HTMLDivElement>(null);
   const map = useRef<mapboxgl.Map>();
   const { t } = useTranslation();
+
+  const bounds = mapLegs ? getMapBounds(mapLegs) : undefined;
 
   useEffect(() => {
     if (!mapContainer.current) return;
@@ -49,7 +49,7 @@ export function Map({
       style: mapboxData.style,
       center: position,
       zoom: initialZoom,
-      bounds: bounds, // If bounds is specified, it overrides center and zoom constructor options.
+      bounds: bounds ? [bounds.sw, bounds.ne] : undefined, // If bounds is specified, it overrides center and zoom constructor options.
     });
 
     return () => map.current?.remove();

--- a/src/components/map/map.tsx
+++ b/src/components/map/map.tsx
@@ -16,25 +16,29 @@ import { and } from '@atb/utils/css';
 import { MapLegType, Position } from './types';
 
 export type MapProps = {
-  position?: Position;
   layer?: string;
   onSelectStopPlace?: (id: string) => void;
-  initialZoom?: number;
-  mapLegs?: MapLegType[];
-};
+} & (
+  | {
+      position: Position;
+      initialZoom: number;
+    }
+  | {
+      mapLegs: MapLegType[];
+    }
+  | {}
+);
 
-export function Map({
-  position = defaultPosition,
-  layer,
-  onSelectStopPlace,
-  mapLegs,
-  initialZoom = ZOOM_LEVEL,
-}: MapProps) {
+export function Map({ layer, onSelectStopPlace, ...props }: MapProps) {
   const mapWrapper = useRef<HTMLDivElement>(null);
   const mapContainer = useRef<HTMLDivElement>(null);
   const map = useRef<mapboxgl.Map>();
   const { t } = useTranslation();
 
+  const mapLegs = hasMapLegs(props) ? props.mapLegs : undefined;
+  const { position, initialZoom } = hasInitialPosition(props)
+    ? props
+    : { position: defaultPosition, initialZoom: ZOOM_LEVEL };
   const bounds = mapLegs ? getMapBounds(mapLegs) : undefined;
 
   useEffect(() => {
@@ -112,4 +116,14 @@ export function Map({
       </div>
     </div>
   );
+}
+
+function hasInitialPosition(
+  a: any,
+): a is { position: Position; initialZoom: number } {
+  return a.position && a.initialZoom;
+}
+
+function hasMapLegs(a: any): a is { mapLegs: MapLegType[] } {
+  return a.mapLegs;
 }

--- a/src/components/map/utils.ts
+++ b/src/components/map/utils.ts
@@ -94,10 +94,7 @@ const findIndex = (
 
 export const getMapBounds = (
   mapLegs: MapLegType[],
-): {
-  sw: [number, number];
-  ne: [number, number];
-} => {
+): [[number, number], [number, number]] => {
   const lineLongitudes = mapLegs
     .map((leg) => leg.points.map((point) => point[0]))
     .flat();
@@ -124,8 +121,5 @@ export const getMapBounds = (
     easternMost - lonPadding,
   ];
 
-  return {
-    sw,
-    ne,
-  };
+  return [sw, ne];
 };

--- a/src/components/map/utils.ts
+++ b/src/components/map/utils.ts
@@ -91,3 +91,41 @@ const findIndex = (
     { index: -1, distance: 100 },
   ).index;
 };
+
+export const getMapBounds = (
+  mapLegs: MapLegType[],
+): {
+  sw: [number, number];
+  ne: [number, number];
+} => {
+  const lineLongitudes = mapLegs
+    .map((leg) => leg.points.map((point) => point[0]))
+    .flat();
+  const lineLatitudes = mapLegs
+    .map((leg) => leg.points.map((point) => point[1]))
+    .flat();
+
+  const westernMost = Math.min(...lineLongitudes);
+  const easternMost = Math.max(...lineLongitudes);
+  const northernMost = Math.max(...lineLatitudes);
+  const southernMost = Math.min(...lineLatitudes);
+
+  // Dividing by 3 here is arbitrary, seems to work
+  // like a fine value for "padding"
+  const latPadding = (northernMost - southernMost) / 3;
+  const lonPadding = (westernMost - easternMost) / 3;
+
+  const sw: [number, number] = [
+    southernMost - latPadding,
+    westernMost + lonPadding,
+  ];
+  const ne: [number, number] = [
+    northernMost + latPadding,
+    easternMost - lonPadding,
+  ];
+
+  return {
+    sw,
+    ne,
+  };
+};

--- a/src/page-modules/assistant/details/index.tsx
+++ b/src/page-modules/assistant/details/index.tsx
@@ -5,7 +5,7 @@ import TripSection from './trip-section';
 import style from './details.module.css';
 import DetailsHeader from './details-header';
 import { ButtonLink } from '@atb/components/button';
-import { Map, getMapBounds } from '@atb/components/map';
+import { Map } from '@atb/components/map';
 import { formatTripDuration } from '@atb/utils/date';
 import { Typo } from '@atb/components/typography';
 import { getInterchangeDetails } from './trip-section/interchange-section';
@@ -31,7 +31,6 @@ export function AssistantDetails({ tripPattern }: AssistantDetailsProps) {
     ? tripQueryStringToQueryParams(String(router.query.id))
     : undefined;
 
-  const bounds = getMapBounds(mapLegs);
   return (
     <div className={style.container}>
       <div className={style.headerContainer}>
@@ -48,7 +47,7 @@ export function AssistantDetails({ tripPattern }: AssistantDetailsProps) {
         <DetailsHeader tripPattern={tripPattern} />
       </div>
       <div className={style.mapContainer}>
-        <Map mapLegs={mapLegs} bounds={[bounds.sw, bounds.ne]} />
+        <Map mapLegs={mapLegs} />
         <div className={style.tripDetails}>
           <div className={style.duration}>
             <MonoIcon icon="time/Duration" />

--- a/src/page-modules/assistant/details/index.tsx
+++ b/src/page-modules/assistant/details/index.tsx
@@ -5,7 +5,7 @@ import TripSection from './trip-section';
 import style from './details.module.css';
 import DetailsHeader from './details-header';
 import { ButtonLink } from '@atb/components/button';
-import { Map } from '@atb/components/map';
+import { Map, getMapBounds } from '@atb/components/map';
 import { formatTripDuration } from '@atb/utils/date';
 import { Typo } from '@atb/components/typography';
 import { getInterchangeDetails } from './trip-section/interchange-section';
@@ -31,6 +31,7 @@ export function AssistantDetails({ tripPattern }: AssistantDetailsProps) {
     ? tripQueryStringToQueryParams(String(router.query.id))
     : undefined;
 
+  const bounds = getMapBounds(mapLegs);
   return (
     <div className={style.container}>
       <div className={style.headerContainer}>
@@ -47,14 +48,7 @@ export function AssistantDetails({ tripPattern }: AssistantDetailsProps) {
         <DetailsHeader tripPattern={tripPattern} />
       </div>
       <div className={style.mapContainer}>
-        <Map
-          position={{
-            lon: tripPattern.legs[0].fromPlace.longitude,
-            lat: tripPattern.legs[0].fromPlace.latitude,
-          }}
-          initialZoom={13.5}
-          mapLegs={mapLegs}
-        />
+        <Map mapLegs={mapLegs} bounds={[bounds.sw, bounds.ne]} />
         <div className={style.tripDetails}>
           <div className={style.duration}>
             <MonoIcon icon="time/Duration" />


### PR DESCRIPTION
This PR makes the whole trip visible on the map on load instead of the first stop place. 

![image](https://github.com/AtB-AS/planner-web/assets/43166974/467acbd4-e590-4fd9-b209-1e37036a00ab)

Closes https://github.com/AtB-AS/kundevendt/issues/16058