### PR TITLE
feat: multimodal stops search results

### DIFF
--- a/src/page-modules/departures/server/geocoder/index.ts
+++ b/src/page-modules/departures/server/geocoder/index.ts
@@ -29,7 +29,7 @@ export function createGeocoderApi(
     async autocomplete(query, focus) {
       const focusQuery = await createFocusQuery(focus);
       const result = await request(
-        `/geocoder/v1/autocomplete?text=${query}&${focusQuery}&size=10&lang=no&multiModal=all`,
+        `/geocoder/v1/autocomplete?text=${query}&${focusQuery}&size=10&lang=no&multiModal=child`,
       );
 
       const parsed = geocoderRootSchema.safeParse(await result.json());

--- a/src/page-modules/departures/server/geocoder/index.ts
+++ b/src/page-modules/departures/server/geocoder/index.ts
@@ -29,7 +29,7 @@ export function createGeocoderApi(
     async autocomplete(query, focus) {
       const focusQuery = await createFocusQuery(focus);
       const result = await request(
-        `/geocoder/v1/autocomplete?text=${query}&${focusQuery}&size=10&lang=no`,
+        `/geocoder/v1/autocomplete?text=${query}&${focusQuery}&size=10&lang=no&multiModal=all`,
       );
 
       const parsed = geocoderRootSchema.safeParse(await result.json());


### PR DESCRIPTION
This makes it so that the search returns children of a multimodal stop instead of the multimodal stop itself. This is done because returning only the multimodal stop would list "Dryna ferjekai" (and similar stops) with a bus icon, which also is a ferry stop.

In the future, we could consider improving this to show only one result for a multimodal stop but include multiple icons.

![image](https://github.com/AtB-AS/planner-web/assets/43166974/dd45b99d-509d-44ad-9bf0-ea363e38631e)


Closes https://github.com/AtB-AS/kundevendt/issues/16156