### PR TITLE
refactor: fetch trip patterns from the client

### DIFF
--- a/src/page-modules/assistant/client/journey-planner/index.ts
+++ b/src/page-modules/assistant/client/journey-planner/index.ts
@@ -1,9 +1,8 @@
-import { TripData } from '../../server/journey-planner/validators';
-import { TripQuery } from '../../types';
+import { NonTransitTripData, TripQuery, TripData } from '../../types';
 
 export type TripApiReturnType = TripData;
 
-export async function nextTripPatterns(
+export async function getTripPatterns(
   query: TripQuery,
 ): Promise<TripApiReturnType> {
   const queryString = tripQueryToQueryString(query);
@@ -22,4 +21,13 @@ function tripQueryToQueryString(input: TripQuery): string {
         encodeURIComponent(String(input[key as keyof TripQuery])),
     )
     .join('&');
+}
+
+export type NonTransitTripApiReturnType = NonTransitTripData;
+export async function getNonTransitTrip(
+  query: TripQuery,
+): Promise<NonTransitTripApiReturnType> {
+  const queryString = tripQueryToQueryString(query);
+  const result = await fetch(`/api/assistant/non-transit-trip?${queryString}`);
+  return await result.json();
 }

--- a/src/page-modules/assistant/index.ts
+++ b/src/page-modules/assistant/index.ts
@@ -6,4 +6,7 @@ export { default as AssistantLayout } from './layout';
 
 export { default as Trip, type TripProps } from './trip';
 
-export { type TripApiReturnType } from './client/journey-planner';
+export {
+  type TripApiReturnType,
+  type NonTransitTripApiReturnType,
+} from './client/journey-planner';

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -203,16 +203,15 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
             title={t(PageText.Assistant.search.buttons.find.title)}
             className={style.button}
             mode="interactive_0--bordered"
-            disabled={!tripQuery.from || !tripQuery.to}
+            disabled={!tripQuery.from || !tripQuery.to || isSearching}
             buttonProps={{ type: 'submit' }}
-            state={isSearching ? 'loading' : undefined}
           />
         </div>
       </form>
 
       <section className={style.contentContainer}>
         <EmptySearch
-          isSearching={isSearching}
+          isSearching={false}
           isGeolocationError={geolocationError !== null}
           type="trip"
         >

--- a/src/page-modules/assistant/server/journey-planner/index.ts
+++ b/src/page-modules/assistant/server/journey-planner/index.ts
@@ -363,8 +363,8 @@ type RecursivePartial<T> = {
   [P in keyof T]?: T[P] extends (infer U)[]
     ? RecursivePartial<U>[]
     : T[P] extends object | undefined
-    ? RecursivePartial<T[P]>
-    : T[P];
+      ? RecursivePartial<T[P]>
+      : T[P];
 };
 
 function inputToLocation(
@@ -386,8 +386,8 @@ function mapResultToTrips(
   queryVariables: TripsQueryVariables,
 ): RecursivePartial<TripData> {
   return {
-    nextPageCursor: trip.nextPageCursor ?? null,
-    previousPageCursor: trip.previousPageCursor ?? null,
+    nextPageCursor: trip.nextPageCursor,
+    previousPageCursor: trip.previousPageCursor,
     tripPatterns: trip.tripPatterns.map((tripPattern) => ({
       expectedStartTime: tripPattern.expectedStartTime,
       expectedEndTime: tripPattern.expectedEndTime,
@@ -525,9 +525,7 @@ function generateSingleTripQueryString(
   );
 }
 
-export function parseTripQueryString(
-  compressedQueryString: string,
-):
+export function parseTripQueryString(compressedQueryString: string):
   | {
       query: TripsQueryVariables;
       journeyIds: string[];

--- a/src/page-modules/assistant/server/journey-planner/validators.ts
+++ b/src/page-modules/assistant/server/journey-planner/validators.ts
@@ -67,8 +67,8 @@ export const tripPatternSchema = z.object({
 });
 
 export const tripSchema = z.object({
-  nextPageCursor: z.string().nullable(),
-  previousPageCursor: z.string().nullable(),
+  nextPageCursor: z.string(),
+  previousPageCursor: z.string(),
   tripPatterns: z.array(tripPatternSchema),
 });
 

--- a/src/page-modules/assistant/types.ts
+++ b/src/page-modules/assistant/types.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import type {
   NonTransitData,
   TripData,
+  TripPattern,
 } from './server/journey-planner/validators';
 import { searchModeSchema, type SearchTime } from '@atb/modules/search-time';
 import type {
@@ -75,4 +76,8 @@ export type NonTransitTripData = {
   cycleTrip?: NonTransitData;
   footTrip?: NonTransitData;
   bikeRentalTrip?: NonTransitData;
+};
+
+export type TripPatternWithTransitionDelay = TripPattern & {
+  transitionDelay: number;
 };

--- a/src/page-modules/assistant/utils.ts
+++ b/src/page-modules/assistant/utils.ts
@@ -5,19 +5,28 @@ import {
   filterToQueryString,
 } from '@atb/modules/transport-mode';
 import { GeocoderFeature } from '@atb/page-modules/departures';
-import { FromToTripQuery, TripData, TripQuery, TripQuerySchema } from './types';
+import {
+  FromToTripQuery,
+  TripData,
+  TripQuery,
+  TripQuerySchema,
+  TripPatternWithTransitionDelay,
+} from './types';
 
 export function filterOutDuplicates(
-  arrayToFilter: TripData['tripPatterns'],
-  referenceArray: TripData['tripPatterns'],
-): TripData['tripPatterns'] {
+  arrayToFilter: TripData['tripPatterns'] | TripPatternWithTransitionDelay[],
+  referenceArray: TripData['tripPatterns'] | TripPatternWithTransitionDelay[],
+): TripData['tripPatterns'] | TripPatternWithTransitionDelay[] {
   const existing = new Set<string>(
     referenceArray.map((tp) => tp.expectedStartTime),
   );
   return arrayToFilter.filter((tp) => !existing.has(tp.expectedStartTime));
 }
 
-export function getCursorBySearchMode(trip: TripData, searchMode: SearchMode) {
+export function getCursorBySearchMode(
+  trip: TripData,
+  searchMode: SearchMode,
+): string {
   if (searchMode === 'arriveBy') {
     return trip.previousPageCursor;
   } else {

--- a/src/pages/api/assistant/non-transit-trip.ts
+++ b/src/pages/api/assistant/non-transit-trip.ts
@@ -1,0 +1,34 @@
+import { errorResultAsJson, tryResult } from '@atb/modules/api-server';
+import {
+  fetchFromToTripQuery,
+  StreetMode,
+  type NonTransitTripApiReturnType,
+} from '@atb/page-modules/assistant';
+import { handlerWithAssistantClient } from '@atb/page-modules/assistant/server';
+import { ServerText } from '@atb/translations';
+import { constants } from 'http2';
+
+export default handlerWithAssistantClient<NonTransitTripApiReturnType>({
+  async GET(req, res, { client, ok }) {
+    const tripQuery = await fetchFromToTripQuery(req.query, client);
+
+    if (!tripQuery.from || !tripQuery.to) {
+      return errorResultAsJson(
+        res,
+        constants.HTTP_STATUS_BAD_REQUEST,
+        ServerText.Endpoints.invalidData,
+      );
+    }
+
+    return tryResult(req, res, async () => {
+      return ok(
+        await client.nonTransitTrips({
+          from: tripQuery.from!,
+          to: tripQuery.to!,
+          searchTime: tripQuery.searchTime,
+          directModes: [StreetMode.Foot, StreetMode.Bicycle],
+        }),
+      );
+    });
+  },
+});

--- a/src/pages/assistant/index.tsx
+++ b/src/pages/assistant/index.tsx
@@ -1,14 +1,11 @@
 import DefaultLayout from '@atb/layouts/default';
 import { withGlobalData, type WithGlobalData } from '@atb/layouts/global-data';
-import { getAllTransportModesFromFilterOptions } from '@atb/modules/transport-mode';
 import {
   AssistantLayout,
   fetchFromToTripQuery,
-  StreetMode,
   Trip,
   type AssistantLayoutProps,
   type FromToTripQuery,
-  type TripData,
   type TripProps,
 } from '@atb/page-modules/assistant';
 import { withAssistantClient } from '@atb/page-modules/assistant/server';
@@ -23,13 +20,9 @@ export type AssistantPageProps = WithGlobalData<
 >;
 
 function AssistantContent(props: AssistantContentProps) {
-  if (isTripDataProps(props)) {
+  if (!('empty' in props) && props.tripQuery) {
     return <Trip {...props} />;
   }
-}
-
-function isTripDataProps(a: any): a is { trip: TripData } {
-  return 'trip' in a && a.trip;
 }
 
 const AssistantPage: NextPage<AssistantPageProps> = (props) => {
@@ -58,29 +51,9 @@ export const getServerSideProps = withGlobalData(
         };
       }
 
-      const { from, to, searchTime, transportModeFilter } = tripQuery;
-
-      const [trip, nonTransitTrips] = await Promise.all([
-        client.trip({
-          from,
-          to,
-          searchTime,
-          transportModes:
-            getAllTransportModesFromFilterOptions(transportModeFilter),
-        }),
-        client.nonTransitTrips({
-          from,
-          to,
-          searchTime,
-          directModes: [StreetMode.Foot, StreetMode.Bicycle],
-        }),
-      ]);
-
       return {
         props: {
           tripQuery,
-          trip,
-          nonTransitTrips,
         },
       };
     },


### PR DESCRIPTION
This changes the trip pattern fetching from being done on the server to the client. This is done to decrease the initial load time of the page. 

Closes https://github.com/AtB-AS/kundevendt/issues/16300