### PR TITLE
fix: assistant details page not loading travel suggestion

### DIFF
--- a/src/components/map/use-map-legs.ts
+++ b/src/components/map/use-map-legs.ts
@@ -6,6 +6,7 @@ import { useTheme } from '@atb/modules/theme';
 import { ComponentText, useTranslation } from '@atb/translations';
 import type { MapLegType } from './types';
 import type { Map, AnySourceData, AnyLayer } from 'mapbox-gl';
+import { addLayerIfNotExists, addSourceIfNotExists } from '.';
 
 export const useMapLegs = (
   mapRef: MutableRefObject<Map | undefined>,
@@ -37,10 +38,14 @@ export const useMapLegs = (
         mapLeg.points[0],
         mapLeg.points[mapLeg.points.length - 1],
       );
-      map.addSource(`route-${id}`, routeLine);
-      map.addSource(`route-${id}-start-end`, startEndCircles);
-      map.addLayer(createRouteLayer(id, lineColor, isDotted));
-      map.addLayer(createStartEndLayer(id, lineColor));
+      const routeLayer = createRouteLayer(id, lineColor, isDotted);
+      const startEndLayer = createStartEndLayer(id, lineColor);
+
+      addSourceIfNotExists(map, `route-${id}`, routeLine);
+      addSourceIfNotExists(map, `route-${id}-start-end`, startEndCircles);
+
+      addLayerIfNotExists(map, routeLayer);
+      addLayerIfNotExists(map, startEndLayer);
     },
     [transport],
   );
@@ -62,10 +67,11 @@ export const useMapLegs = (
         staticColors.background.background_accent_0,
       );
 
-      map.addSource(startTextSourceId, startTextPoint);
-      map.addSource(endTextSourceId, endTextPoint);
-      map.addLayer(startTextLayer);
-      map.addLayer(endTextLayer);
+      addSourceIfNotExists(map, startTextSourceId, startTextPoint);
+      addSourceIfNotExists(map, endTextSourceId, endTextPoint);
+
+      addLayerIfNotExists(map, startTextLayer);
+      addLayerIfNotExists(map, endTextLayer);
     },
     [staticColors, t],
   );

--- a/src/components/map/utils.ts
+++ b/src/components/map/utils.ts
@@ -1,4 +1,9 @@
-import { MapboxGeoJSONFeature } from 'mapbox-gl';
+import {
+  MapboxGeoJSONFeature,
+  type Map,
+  AnySourceData,
+  AnyLayer,
+} from 'mapbox-gl';
 import { mapboxData } from '@atb/modules/org-data';
 import { MapLegType, Position } from './types';
 import haversineDistance from 'haversine-distance';
@@ -123,3 +128,19 @@ export const getMapBounds = (
 
   return [sw, ne];
 };
+
+export function addSourceIfNotExists(
+  map: Map,
+  sourceId: string,
+  source: AnySourceData,
+) {
+  if (!map.getSource(sourceId)) {
+    map.addSource(sourceId, source);
+  }
+}
+
+export function addLayerIfNotExists(map: Map, layer: AnyLayer) {
+  if (!map.getLayer(layer.id)) {
+    map.addLayer(layer);
+  }
+}

--- a/src/page-modules/assistant/server/journey-planner/index.ts
+++ b/src/page-modules/assistant/server/journey-planner/index.ts
@@ -230,6 +230,7 @@ export function createJourneyApi(
         variables: {
           ...tripQuery.query,
           arriveBy: false,
+          ...DEFAULT_JOURNEY_CONFIG,
         },
       });
 
@@ -363,8 +364,8 @@ type RecursivePartial<T> = {
   [P in keyof T]?: T[P] extends (infer U)[]
     ? RecursivePartial<U>[]
     : T[P] extends object | undefined
-    ? RecursivePartial<T[P]>
-    : T[P];
+      ? RecursivePartial<T[P]>
+      : T[P];
 };
 
 function inputToLocation(
@@ -525,9 +526,7 @@ function generateSingleTripQueryString(
   );
 }
 
-export function parseTripQueryString(
-  compressedQueryString: string,
-):
+export function parseTripQueryString(compressedQueryString: string):
   | {
       query: TripsQueryVariables;
       journeyIds: string[];

--- a/src/page-modules/assistant/server/journey-planner/journey-gql/trip-with-details.gql
+++ b/src/page-modules/assistant/server/journey-planner/journey-gql/trip-with-details.gql
@@ -5,6 +5,7 @@ query TripsWithDetails(
   $when: DateTime
   $cursor: String
   $transferPenalty: Int
+  $transferSlack: Int
   $waitReluctance: Float
   $walkReluctance: Float
   $walkSpeed: Float
@@ -18,6 +19,7 @@ query TripsWithDetails(
     arriveBy: $arriveBy
     pageCursor: $cursor
     transferPenalty: $transferPenalty
+    transferSlack: $transferSlack
     waitReluctance: $waitReluctance
     walkReluctance: $walkReluctance
     walkSpeed: $walkSpeed


### PR DESCRIPTION
This ensures that the trip and trip with details query use the same configuration. Before this, we could not view the details of some of the travel suggestions, because we couldn't retrieve the same suggestions again. 

Edit: test cases can be found in the issue

I also experienced a bug with the map when testing this fix, where it tried to draw the same route multiple times. To fix this I added a check to see if it is already drawn or not, before trying to add it. 

Fixes https://github.com/AtB-AS/kundevendt/issues/16414