### PR TITLE
fix: make aria-labels in the search time selector visible to the screen reader

### DIFF
--- a/public/widget/GYJwhgtkA/2.8.0/planner-web.mjs
+++ b/public/widget/GYJwhgtkA/2.8.0/planner-web.mjs
@@ -405,7 +405,7 @@ function Oe({ URL_BASE: t }, e) {
               value="now"
               checked=""
             />
-            <span aria-hidden="true" class="${o.selector_option__label}">
+            <span class="${o.selector_option__label}">
               <span class="${o.selector_option__text}" id="${r}-now">
                 ${e.searchTime.now}
               </span>
@@ -419,7 +419,7 @@ function Oe({ URL_BASE: t }, e) {
               class="${o.selector_option__input}"
               value="departBy"
             />
-            <span aria-hidden="true" class="${o.selector_option__label}">
+            <span class="${o.selector_option__label}">
               <span
                 class="${o.selector_option__text}"
                 id="${r}-depart"
@@ -437,10 +437,7 @@ function Oe({ URL_BASE: t }, e) {
                     class="${o.selector_option__input}"
                     value="arriveBy"
                   />
-                  <span
-                    aria-hidden="true"
-                    class="${o.selector_option__label}"
-                  >
+                  <span class="${o.selector_option__label}">
                     <span
                       class="${o.selector_option__text}"
                       id="${r}-arrival"

--- a/public/widget/GYJwhgtkA/2.8.0/planner-web.umd.js
+++ b/public/widget/GYJwhgtkA/2.8.0/planner-web.umd.js
@@ -20,7 +20,7 @@
               value="now"
               checked=""
             />
-            <span aria-hidden="true" class="${o.selector_option__label}">
+            <span class="${o.selector_option__label}">
               <span class="${o.selector_option__text}" id="${a}-now">
                 ${e.searchTime.now}
               </span>
@@ -34,7 +34,7 @@
               class="${o.selector_option__input}"
               value="departBy"
             />
-            <span aria-hidden="true" class="${o.selector_option__label}">
+            <span class="${o.selector_option__label}">
               <span
                 class="${o.selector_option__text}"
                 id="${a}-depart"
@@ -52,10 +52,7 @@
                     class="${o.selector_option__input}"
                     value="arriveBy"
                   />
-                  <span
-                    aria-hidden="true"
-                    class="${o.selector_option__label}"
-                  >
+                  <span class="${o.selector_option__label}">
                     <span
                       class="${o.selector_option__text}"
                       id="${a}-arrival"

--- a/src/modules/search-time/selector/index.tsx
+++ b/src/modules/search-time/selector/index.tsx
@@ -110,7 +110,7 @@ export default function SearchTimeSelector({
               className={style.option__input}
             />
 
-            <span aria-hidden className={style.option__label}>
+            <span className={style.option__label}>
               {selectedMode.mode === state && (
                 <motion.span
                   layoutId="searchTimeSelector"

--- a/src/widget/widget.ts
+++ b/src/widget/widget.ts
@@ -453,7 +453,7 @@ function createOutput({ URL_BASE }: SettingConstants, texts: Texts) {
               value="now"
               checked=""
             />
-            <span aria-hidden="true" class="${style.selector_option__label}">
+            <span class="${style.selector_option__label}">
               <span class="${style.selector_option__text}" id="${prefix}-now">
                 ${texts.searchTime.now}
               </span>
@@ -467,7 +467,7 @@ function createOutput({ URL_BASE }: SettingConstants, texts: Texts) {
               class="${style.selector_option__input}"
               value="departBy"
             />
-            <span aria-hidden="true" class="${style.selector_option__label}">
+            <span class="${style.selector_option__label}">
               <span
                 class="${style.selector_option__text}"
                 id="${prefix}-depart"
@@ -486,10 +486,7 @@ function createOutput({ URL_BASE }: SettingConstants, texts: Texts) {
                     class="${style.selector_option__input}"
                     value="arriveBy"
                   />
-                  <span
-                    aria-hidden="true"
-                    class="${style.selector_option__label}"
-                  >
+                  <span class="${style.selector_option__label}">
                     <span
                       class="${style.selector_option__text}"
                       id="${prefix}-arrival"


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/16349

### Background

Received feedback that the screen reader was unable to read the search time radio buttons, due the attribute specification: 'aria-hidden:true'. 
  
### Proposed solution

Remove the attribute specification: 'aria-hidden:true'. 
  
### Acceptance Criteria

- [ ] The screen reader is able to read the aria label of the radio button. 
