### PR TITLE
feat: debounce search when filter change

### DIFF
--- a/src/modules/transport-mode/filter/__tests__/filter.test.tsx
+++ b/src/modules/transport-mode/filter/__tests__/filter.test.tsx
@@ -69,7 +69,7 @@ describe('transport mode filter', () => {
   it('should uncheck all when clicking "All"', () => {
     const onChange = vi.fn();
     const initialState = null;
-    const expected = ['none'];
+    const expected: string[] = [];
 
     render(
       <TransportModeFilter
@@ -120,7 +120,7 @@ describe('transport mode filter', () => {
   it('should check all when all initially are unchecked', async () => {
     const onChange = vi.fn();
 
-    const initial = ['none'];
+    const initial: string[] = [];
 
     const expected = null;
 

--- a/src/modules/transport-mode/filter/filter.tsx
+++ b/src/modules/transport-mode/filter/filter.tsx
@@ -5,7 +5,7 @@ import { MonoIcon } from '@atb/components/icon';
 import { Typo } from '@atb/components/typography';
 import { getTransportModeIcon } from '../icon';
 import { TransportModeFilterOptionType } from '@atb-as/config-specs';
-import { ChangeEventHandler } from 'react';
+import { ChangeEventHandler, useState } from 'react';
 
 type TransportModeFilterProps = {
   filterState: string[] | null;
@@ -19,6 +19,15 @@ export default function TransportModeFilter({
   data,
 }: TransportModeFilterProps) {
   const { t, language } = useTranslation();
+
+  // Local filter state used for updating the checkbox states before the URL
+  // state is updated to reflect the changed filters.
+  const [localFilterState, setLocalFilterState] = useState(filterState);
+
+  const onChangeWrapper = (transportModeFilter: string[] | null) => {
+    setLocalFilterState(transportModeFilter);
+    onChange(transportModeFilter);
+  };
 
   if (!data) {
     return null;
@@ -38,9 +47,11 @@ export default function TransportModeFilter({
             name="all"
             value="all"
             aria-label={t(ComponentText.TransportModeFilter.allA11y)}
-            checked={!filterState || filterState.length === data.length}
+            checked={
+              !localFilterState || localFilterState.length === data.length
+            }
             onChange={(event) => {
-              onChange(event.target.checked ? null : ['none']);
+              onChangeWrapper(event.target.checked ? null : []);
             }}
           />
 
@@ -59,21 +70,24 @@ export default function TransportModeFilter({
               <FilterCheckbox
                 option={option}
                 checked={
-                  !filterState || (filterState?.includes(option.id) ?? false)
+                  !localFilterState ||
+                  (localFilterState?.includes(option.id) ?? false)
                 }
                 onChange={(event) => {
                   // No filter is applied when filterState is `null`, same
                   // as "All" being checked.
-                  if (!filterState) {
+                  if (!localFilterState) {
                     // Only set the clicked filter as filter.
-                    onChange([option.id]);
+                    onChangeWrapper([option.id]);
                   } else {
                     if (event.target.checked) {
                       // Add the checked filter to the filter state.
-                      onChange([...filterState, option.id]);
+                      onChangeWrapper([...localFilterState, option.id]);
                     } else {
                       // Remove the unchecked filter from the filter state.
-                      onChange(filterState.filter((id) => id !== option.id));
+                      onChangeWrapper(
+                        localFilterState.filter((id) => id !== option.id),
+                      );
                     }
                   }
                 }}

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -21,6 +21,7 @@ import { logSpecificEvent } from '@atb/modules/firebase';
 import { getOrgData } from '@atb/modules/org-data';
 import { getTransportModeFilter } from '@atb/modules/firebase/transport-mode-filter';
 import useSWRImmutable from 'swr/immutable';
+import { debounce } from 'lodash';
 
 export type AssistantLayoutProps = PropsWithChildren<{
   tripQuery: FromToTripQuery;
@@ -90,9 +91,11 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
     setValuesWithLoading({ from });
   const onToSelected = async (to: GeocoderFeature) =>
     setValuesWithLoading({ to });
-  const onTransportFilterChanged = async (
-    transportModeFilter: string[] | null,
-  ) => setValuesWithLoading({ transportModeFilter }, true);
+  const onTransportFilterChanged = debounce(
+    async (transportModeFilter: string[] | null) =>
+      setValuesWithLoading({ transportModeFilter }, true),
+    500,
+  );
 
   const { urls } = getOrgData();
 

--- a/src/page-modules/assistant/utils.ts
+++ b/src/page-modules/assistant/utils.ts
@@ -49,7 +49,7 @@ function featuresToFromToQuery(
 
 export function createTripQuery(tripQuery: FromToTripQuery): TripQuery {
   let transportModeFilterQuery = {};
-  if (tripQuery.transportModeFilter) {
+  if (tripQuery.transportModeFilter && tripQuery.transportModeFilter.length) {
     transportModeFilterQuery = {
       filter: tripQuery.transportModeFilter.join(','),
     };


### PR DESCRIPTION
Added a debounce to the function that updates the URL (performing a search) so that a search is not performed immediately after changing a filter, but after a set time. I set this time to be 500ms. In addition, with the debounce the function is not called for every single filter change, but only the last change within the last 500ms.

Closes https://github.com/AtB-AS/kundevendt/issues/16003