### PR TITLE
fix:  remove duplicate comboboxes. 

### DIFF
--- a/src/widget/widget.ts
+++ b/src/widget/widget.ts
@@ -552,7 +552,6 @@ function createOutput({ URL_BASE }: SettingConstants, texts: Texts) {
             </label>
             <div
               class="${style.search_inputContainer}"
-              role="combobox"
               aria-expanded="false"
               aria-haspopup="listbox"
               aria-labelledby="pw-from-1-label"
@@ -605,7 +604,6 @@ function createOutput({ URL_BASE }: SettingConstants, texts: Texts) {
             </label>
             <div
               class="${style.search_inputContainer}"
-              role="combobox"
               aria-expanded="false"
               aria-haspopup="listbox"
               aria-labelledby="pw-to-1-label"
@@ -657,7 +655,6 @@ function createOutput({ URL_BASE }: SettingConstants, texts: Texts) {
             </label>
             <div
               class="${style.search_inputContainer}"
-              role="combobox"
               aria-expanded="false"
               aria-haspopup="listbox"
               aria-labelledby="pw-from-2-label"


### PR DESCRIPTION
### Background

Received feedback that role=combobox is used as an attribute in several html elements. That attribute is only required in an input element 


#### Illustrations
<details>
<summary>screenshots</summary>

![Screenshot 2024-01-19 at 12 57 30](https://github.com/AtB-AS/planner-web/assets/59939294/1717b7f9-a882-4984-b04d-6c08c83cf723)

![Screenshot 2024-01-19 at 12 32 05](https://github.com/AtB-AS/planner-web/assets/59939294/98c0afc1-f520-4596-80b9-54a2f9f7cc2f)
</details>

Before / after
### Proposed solution

Remove role=combobox from all elements other than input.  

