### PR TITLE
fix: increase the contrast between placeholder text and the background  

### DIFF
--- a/src/components/search/search.module.css
+++ b/src/components/search/search.module.css
@@ -43,6 +43,11 @@
   outline: 0;
 }
 
+.input::placeholder {
+  color: var(--text-colors-secondary);
+  opacity: 1;
+}
+
 .menu {
   width: 100%;
   background-color: var(--static-background-background_0-background);

--- a/src/widget/widget.module.css
+++ b/src/widget/widget.module.css
@@ -109,6 +109,11 @@
   composes: input from search;
 }
 
+.search_input::placeholder {
+  color: var(--text-colors-secondary);
+  opacity: 1;
+}
+
 .search_inputLast {
   border-top-right-radius: 0.75rem;
   border-bottom-right-radius: 0.75rem;


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/16358

### Background
Received feedback that the contrast between the placeholder text and the background was too weak.

#### Illustrations
<details>
<summary>screenshots/video/figm</summary>
<img width="413" alt="Screenshot 2024-01-30 at 16 44 34" src="https://github.com/AtB-AS/planner-web/assets/59939294/c5f348fb-5a80-4b3f-8b99-2afad7c83a0e">

<img width="414" alt="Screenshot 2024-01-30 at 16 44 12" src="https://github.com/AtB-AS/planner-web/assets/59939294/acf0076d-dc16-4d63-9c14-57a3eeb11987">
</details>

### Proposed solution
- [x] Set placeholder colour to --text-colors-secondary and set opacity to 1 to avoid the placeholder opacity, which is set by default.

### Acceptance Criteria
- The colour contrast ratio should minimum be at  4.5:1.