### PR TITLE
feat: ticket information url in footer

### DIFF
--- a/orgs/atb.json
+++ b/orgs/atb.json
@@ -29,6 +29,11 @@
     "homePageUrl": {
       "name": "atb.no",
       "href": "https://atb.no/"
+    },
+    "ticketsUrl": {
+      "en-US": "https://www.atb.no/en/fares/",
+      "no": "https://www.atb.no/priser/",
+      "default": "https://www.atb.no/priser/"
     }
   },
   "journeyApiConfigurations": {

--- a/orgs/fram.json
+++ b/orgs/fram.json
@@ -28,6 +28,11 @@
     "homePageUrl": {
       "name": "frammr.no",
       "href": "https://www.frammr.no/"
+    },
+    "ticketsUrl": {
+      "en-US": "https://frammr.no/billettar/billettar-og-prisar/?sprak=3",
+      "nn": "https://frammr.no/billettar/billettar-og-prisar/?sprak=11",
+      "default": "https://frammr.no/billettar/billettar-og-prisar/"
     }
   },
   "journeyApiConfigurations": {

--- a/orgs/nfk.json
+++ b/orgs/nfk.json
@@ -28,6 +28,11 @@
     "homePageUrl": {
       "name": "reisnordland.no",
       "href": "https://www.reisnordland.no/"
+    },
+    "ticketsUrl": {
+      "en-US": "https://www.reisnordland.com/prices-bus",
+      "no": "https://www.reisnordland.no/priser-pa-buss",
+      "default": "https://www.reisnordland.no/priser-pa-buss"
     }
   },
   "journeyApiConfigurations": {

--- a/orgs/schema-validation.json
+++ b/orgs/schema-validation.json
@@ -67,6 +67,9 @@
                   "type": "string"
                 }
               }
+            },
+            "ticketsUrl": {
+              "$ref": "#/definitions/TranslatableUrl"
             }
           },
           "required": [

--- a/src/layouts/shared/footer.tsx
+++ b/src/layouts/shared/footer.tsx
@@ -27,7 +27,7 @@ export default function Footer({ withoutSettings = false }: FooterProps) {
             </h4>
 
             <ul className={style.footer__linkList}>
-              {urls.helpUrl ? (
+              {urls.helpUrl && (
                 <li>
                   <a
                     href={getConfigUrl(urls.helpUrl, language)}
@@ -40,7 +40,21 @@ export default function Footer({ withoutSettings = false }: FooterProps) {
                     )}
                   </a>
                 </li>
-              ) : null}
+              )}
+              {urls.ticketsUrl && (
+                <li>
+                  <a
+                    href={getConfigUrl(urls.ticketsUrl, language)}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    {t(
+                      ModuleText.Layout.base.footer.sections.general
+                        .ticketPricesPageLink,
+                    )}
+                  </a>
+                </li>
+              )}
             </ul>
           </section>
 

--- a/src/modules/org-data/index.tsx
+++ b/src/modules/org-data/index.tsx
@@ -39,6 +39,7 @@ export type OrgData = {
       name: string;
       href: string;
     };
+    ticketsUrl?: TranslatableUrl;
   };
   journeyApiConfigurations: {
     waitReluctance?: number;

--- a/src/translations/modules/layout.ts
+++ b/src/translations/modules/layout.ts
@@ -13,6 +13,11 @@ export const LayoutInternal = {
             'Help for the travel planner',
             'Hjelp for reiseplanleggaren',
           ),
+          ticketPricesPageLink: _(
+            'Billetter og priser',
+            'Tickets and prices',
+            'Billettar og prisar',
+          ),
         },
         contact: {
           header: _('Kontakt AtB', 'Contact AtB', 'Kontakt AtB'),


### PR DESCRIPTION
This adds a link to ticket prices in the footer for FRAM, NFK and AtB.

![image](https://github.com/AtB-AS/planner-web/assets/43166974/dacfe17e-a247-4051-b75a-a7782dbf9335)


Closes https://github.com/AtB-AS/kundevendt/issues/16680