### PR TITLE
Update trip parameters for AtB

### DIFF
--- a/orgs/atb.json
+++ b/orgs/atb.json
@@ -37,10 +37,10 @@
     }
   },
   "journeyApiConfigurations": {
-    "waitReluctance": 1.5,
-    "walkingReluctance": 1.5,
+    "waitReluctance": 1.0,
+    "walkingReluctance": 4.0,
     "walkingSpeed": 1.3,
-    "transferPenalty": 10,
+    "transferPenalty": 0,
     "transferSlack": 120
   }
 }


### PR DESCRIPTION
Update the query parameters for trip search to be equal as in the AtB app. The changes are as the default parameters from Entur. See also [Slack](https://mittatb.slack.com/archives/CHLDG8C30/p1706776408713929).

Maybe we should change the values, but this takes a bit of testing, and for now it's better to have the values equal.

<details>
<summary>From Shamash</summary>

<img width="265" alt="Screenshot 2024-02-01 at 09 24 49" src="https://github.com/AtB-AS/planner-web/assets/5812433/92c9d099-8805-4676-9f4e-b9296b86341a">

</details>

## Acceptance criteria

- [ ] Should test and see that the trip search results are the same in travel planner and app for AtB