### PR TITLE
chore: adds initial e2e case

### DIFF
--- a/.github/workflows/playwright-scheduled-staging.yml
+++ b/.github/workflows/playwright-scheduled-staging.yml
@@ -1,0 +1,47 @@
+name: Periodic Playwright Tests (Staging)
+on:
+  workflow_dispatch:
+    inputs:
+      env:
+        description: 'Environment to run tests against'
+        required: true
+        default: 'fram, nfk, atb'
+        type: choice
+        options:
+          - fram
+          - nfk
+          - atb
+  schedule:
+    # Run every 3 hours
+    - cron: '0 */3 * * *'
+
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        env: ${{ fromJSON(format('[{0}]', inputs.env || 'fram, nfk, atb')) }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'yarn'
+      - run: yarn
+      - name: Install Playwright Browsers
+        run: yarn playwright install --with-deps
+      - name: Run Playwright tests
+        run: yarn playwright test
+        env:
+          NEXT_PUBLIC_PLANNER_ORG_ID: atb
+          E2E_URL: 'https://${{ matrix.env }}-staging.planner-web.mittatb.no/'
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,27 @@
+name: Playwright Tests
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18
+    - name: Install dependencies
+      run: npm install -g yarn && yarn
+    - name: Install Playwright Browsers
+      run: yarn playwright install --with-deps
+    - name: Run Playwright tests
+      run: yarn playwright test
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,6 +9,12 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'yarn'
+      - run: yarn
       - name: Waiting for 200 from the Vercel Preview
         uses: patrickedqvist/wait-for-vercel-preview@v1.3.1
         id: waitFor200

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -20,7 +20,8 @@ jobs:
         id: waitFor200
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          max_timeout: 60
+          check_interval: 10
+          max_timeout: 120
       - name: Install Playwright Browsers
         run: yarn playwright install --with-deps
       - name: Run Playwright tests

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,9 +1,7 @@
 name: Playwright Tests
 on:
-  push:
-    branches: [main, master]
   pull_request:
-    branches: [main, master]
+    branches: main
 jobs:
   test:
     timeout-minutes: 60

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,33 +9,19 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: Waiting for 200 from the Vercel Preview
+        uses: patrickedqvist/wait-for-vercel-preview@v1.3.1
+        id: waitFor200
         with:
-          node-version: 20
-          cache: 'yarn'
-      - run: yarn
-      - run: yarn generate
-      - run: yarn setup
-        env:
-          NEXT_PUBLIC_PLANNER_ORG_ID: atb
+          token: ${{ secrets.GITHUB_TOKEN }}
+          max_timeout: 60
       - name: Install Playwright Browsers
         run: yarn playwright install --with-deps
       - name: Run Playwright tests
         run: yarn playwright test
         env:
           NEXT_PUBLIC_PLANNER_ORG_ID: atb
-          NEXT_PUBLIC_MAPBOX_API_TOKEN: ${{ vars.NEXT_PUBLIC_MAPBOX_API_TOKEN }}
-          NEXT_PUBLIC_MAPBOX_STOP_PLACES_STYLE_URL:
-            ${{ vars.NEXT_PUBLIC_MAPBOX_STOP_PLACES_STYLE_URL }}
-          NEXT_PUBLIC_MAPBOX_DEFAULT_LAT:
-            ${{ vars.NEXT_PUBLIC_MAPBOX_DEFAULT_LAT }}
-          NEXT_PUBLIC_MAPBOX_DEFAULT_LNG:
-            ${{ vars.NEXT_PUBLIC_MAPBOX_DEFAULT_LNG }}
-          NEXT_PUBLIC_FIREBASE_PUBLIC_API_KEY: ${{vars.NEXT_PUBLIC_FIREBASE_PUBLIC_API_KEY}}
-          NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: ${{vars.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN}}
-          NEXT_PUBLIC_FIREBASE_PROJECT_ID: ${{vars.NEXT_PUBLIC_FIREBASE_PROJECT_ID}}
-          NEXT_PUBLIC_FIREBASE_APP_ID: ${{vars.NEXT_PUBLIC_FIREBASE_APP_ID}}
+          E2E_URL: ${{ steps.waitFor200.outputs.url }}
 
       - uses: actions/upload-artifact@v3
         if: always()

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,27 +1,31 @@
 name: Playwright Tests
 on:
   push:
-    branches: [ main, master ]
+    branches: [main, master]
   pull_request:
-    branches: [ main, master ]
+    branches: [main, master]
 jobs:
   test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: 18
-    - name: Install dependencies
-      run: npm install -g yarn && yarn
-    - name: Install Playwright Browsers
-      run: yarn playwright install --with-deps
-    - name: Run Playwright tests
-      run: yarn playwright test
-    - uses: actions/upload-artifact@v3
-      if: always()
-      with:
-        name: playwright-report
-        path: playwright-report/
-        retention-days: 30
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'yarn'
+      - run: yarn
+      - run: yarn generate
+      - run: yarn setup
+        env:
+          NEXT_PUBLIC_PLANNER_ORG_ID: atb
+      - name: Install Playwright Browsers
+        run: yarn playwright install --with-deps
+      - name: Run Playwright tests
+        run: yarn playwright test
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -23,6 +23,8 @@ jobs:
         run: yarn playwright install --with-deps
       - name: Run Playwright tests
         run: yarn playwright test
+        env:
+          NEXT_PUBLIC_PLANNER_ORG_ID: atb
       - uses: actions/upload-artifact@v3
         if: always()
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -15,6 +15,8 @@ jobs:
           node-version: 20
           cache: 'yarn'
       - run: yarn
+      - name: Install Playwright Browsers
+        run: yarn playwright install --with-deps
       - name: Waiting for 200 from the Vercel Preview
         uses: patrickedqvist/wait-for-vercel-preview@v1.3.1
         id: waitFor200
@@ -22,8 +24,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           check_interval: 10
           max_timeout: 120
-      - name: Install Playwright Browsers
-        run: yarn playwright install --with-deps
       - name: Run Playwright tests
         run: yarn playwright test
         env:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -25,6 +25,18 @@ jobs:
         run: yarn playwright test
         env:
           NEXT_PUBLIC_PLANNER_ORG_ID: atb
+          NEXT_PUBLIC_MAPBOX_API_TOKEN: ${{ vars.NEXT_PUBLIC_MAPBOX_API_TOKEN }}
+          NEXT_PUBLIC_MAPBOX_STOP_PLACES_STYLE_URL:
+            ${{ vars.NEXT_PUBLIC_MAPBOX_STOP_PLACES_STYLE_URL }}
+          NEXT_PUBLIC_MAPBOX_DEFAULT_LAT:
+            ${{ vars.NEXT_PUBLIC_MAPBOX_DEFAULT_LAT }}
+          NEXT_PUBLIC_MAPBOX_DEFAULT_LNG:
+            ${{ vars.NEXT_PUBLIC_MAPBOX_DEFAULT_LNG }}
+          NEXT_PUBLIC_FIREBASE_PUBLIC_API_KEY: ${{vars.NEXT_PUBLIC_FIREBASE_PUBLIC_API_KEY}}
+          NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: ${{vars.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN}}
+          NEXT_PUBLIC_FIREBASE_PROJECT_ID: ${{vars.NEXT_PUBLIC_FIREBASE_PROJECT_ID}}
+          NEXT_PUBLIC_FIREBASE_APP_ID: ${{vars.NEXT_PUBLIC_FIREBASE_APP_ID}}
+
       - uses: actions/upload-artifact@v3
         if: always()
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,7 @@ src/components/icon/generated-icons.ts
 
 
 *.generated.ts
-
-
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/e2e-tests/search-test.spec.ts
+++ b/e2e-tests/search-test.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from '@playwright/test';
 
-test('test', async ({ page }) => {
+test('Test fetching Kristiansund - Molde and loading more after first result', async ({
+  page,
+}) => {
   await page.goto(process.env.E2E_URL ?? 'http://localhost:3000');
   await page.getByRole('textbox', { name: 'From' }).click();
   await page.getByRole('textbox', { name: 'From' }).fill('Kristiansund');
@@ -15,13 +17,10 @@ test('test', async ({ page }) => {
   // let tripPromise = page.waitForResponse(/api\/assistant\/trip/);
   await page.getByText('Bus', { exact: true }).click();
   await page.getByRole('button', { name: 'Find departures' }).click();
-  // await tripPromise;
 
   const orderSent = page.getByTestId('trip-pattern-0');
 
   await orderSent.waitFor();
 
-  // tripPromise = page.waitForResponse(/api\/assistant\/trip/);
   await page.getByRole('button', { name: 'Load more results' }).click();
-  // await tripPromise;
 });

--- a/e2e-tests/search-test.spec.ts
+++ b/e2e-tests/search-test.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test('test', async ({ page }) => {
-  await page.goto('http://localhost:3000/');
+  await page.goto(process.env.E2E_URL ?? 'http://localhost:3000');
   await page.getByRole('textbox', { name: 'From' }).click();
   await page.getByRole('textbox', { name: 'From' }).fill('Kristiansund');
   await page.getByRole('option', { name: 'Kristiansund Kristiansund' }).click();

--- a/e2e-tests/search-test.spec.ts
+++ b/e2e-tests/search-test.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test('test', async ({ page }) => {
+  await page.goto('http://localhost:3000/');
+  await page.getByRole('textbox', { name: 'From' }).click();
+  await page.getByRole('textbox', { name: 'From' }).fill('Kristiansund');
+  await page.getByRole('option', { name: 'Kristiansund Kristiansund' }).click();
+  await page.getByRole('textbox', { name: 'To' }).click();
+  await page.getByRole('textbox', { name: 'To' }).click();
+  await page.getByRole('textbox', { name: 'To' }).fill('Molde');
+  await page.getByRole('option', { name: 'Molde Molde', exact: true }).click();
+  await page.getByRole('button', { name: 'More choices' }).click();
+  await page.getByText('Bus', { exact: true }).click();
+  await page.getByRole('button', { name: 'Find departures' }).click();
+  await page.getByRole('button', { name: 'Load more results' }).click();
+});

--- a/e2e-tests/search-test.spec.ts
+++ b/e2e-tests/search-test.spec.ts
@@ -7,10 +7,21 @@ test('test', async ({ page }) => {
   await page.getByRole('option', { name: 'Kristiansund Kristiansund' }).click();
   await page.getByRole('textbox', { name: 'To' }).click();
   await page.getByRole('textbox', { name: 'To' }).click();
+
   await page.getByRole('textbox', { name: 'To' }).fill('Molde');
   await page.getByRole('option', { name: 'Molde Molde', exact: true }).click();
   await page.getByRole('button', { name: 'More choices' }).click();
+
+  // let tripPromise = page.waitForResponse(/api\/assistant\/trip/);
   await page.getByText('Bus', { exact: true }).click();
   await page.getByRole('button', { name: 'Find departures' }).click();
+  // await tripPromise;
+
+  const orderSent = page.getByTestId('trip-pattern-0');
+
+  await orderSent.waitFor();
+
+  // tripPromise = page.waitForResponse(/api\/assistant\/trip/);
   await page.getByRole('button', { name: 'Load more results' }).click();
+  // await tripPromise;
 });

--- a/e2e-tests/search-test.spec.ts
+++ b/e2e-tests/search-test.spec.ts
@@ -4,22 +4,26 @@ test('Test fetching Kristiansund - Molde and loading more after first result', a
   page,
 }) => {
   await page.goto(process.env.E2E_URL ?? 'http://localhost:3000');
+
   await page.getByRole('textbox', { name: 'From' }).click();
   await page.getByRole('textbox', { name: 'From' }).fill('Kristiansund');
   await page.getByRole('option', { name: 'Kristiansund Kristiansund' }).click();
-  await page.getByRole('textbox', { name: 'To' }).click();
-  await page.getByRole('textbox', { name: 'To' }).click();
 
+  await page.getByRole('textbox', { name: 'To' }).click();
   await page.getByRole('textbox', { name: 'To' }).fill('Molde');
   await page.getByRole('option', { name: 'Molde Molde', exact: true }).click();
-  await page.getByRole('button', { name: 'More choices' }).click();
 
+  await page.getByRole('button', { name: 'More choices' }).click();
   await page.getByText('Bus', { exact: true }).click();
   await page.getByRole('button', { name: 'Find departures' }).click();
 
-  const orderSent = page.getByTestId('trip-pattern-0');
+  const tripPatternItem = page.getByTestId('trip-pattern-0');
+  await tripPatternItem.waitFor();
 
-  await orderSent.waitFor();
-
+  const additionalRequest = page.waitForRequest((request) => {
+    return request.url().includes('trip') && request.url().includes('cursor');
+  });
   await page.getByRole('button', { name: 'Load more results' }).click();
+
+  await additionalRequest;
 });

--- a/e2e-tests/search-test.spec.ts
+++ b/e2e-tests/search-test.spec.ts
@@ -14,7 +14,6 @@ test('Test fetching Kristiansund - Molde and loading more after first result', a
   await page.getByRole('option', { name: 'Molde Molde', exact: true }).click();
   await page.getByRole('button', { name: 'More choices' }).click();
 
-  // let tripPromise = page.waitForResponse(/api\/assistant\/trip/);
   await page.getByText('Bus', { exact: true }).click();
   await page.getByRole('button', { name: 'Find departures' }).click();
 

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@graphql-codegen/typescript": "^4.0.1",
     "@graphql-codegen/typescript-generic-sdk": "^4.0.0",
     "@graphql-codegen/typescript-operations": "^4.0.1",
+    "@playwright/test": "^1.41.1",
     "@testing-library/dom": "^9.3.3",
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^14.1.2",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "EUPL-1.2",
   "scripts": {
     "test": "vitest",
+    "test:e2e-local": "E2E_URL=https://localhost:3000 yarn playwright test",
     "dev": "next dev",
     "build": "next build",
     "build:widget": "yarn vite build ./src/widget --emptyOutDir",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -68,10 +68,10 @@ export default defineConfig({
     // },
   ],
 
-  /* Run your local dev server before starting the tests */
-  webServer: {
-    command: 'yarn dev',
-    url: 'http://localhost:3000',
-    reuseExistingServer: !process.env.CI,
-  },
+  // /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'yarn dev',
+  //   url: 'http://localhost:3000',
+  //   reuseExistingServer: !process.env.CI,
+  // },
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,77 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './e2e-tests',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    // baseURL: 'http://127.0.0.1:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'yarn dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/src/page-modules/assistant/trip/trip-pattern/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/index.tsx
@@ -70,6 +70,7 @@ export default function TripPattern({
     <motion.a
       href={`/assistant/${tripPattern.compressedQuery}`}
       className={className}
+      data-testid={`trip-pattern-${index}`}
       initial={{ opacity: 0, x: -10 }}
       animate={{ opacity: maxOpacity, x: 0 }}
       exit={{ opacity: 0, x: -10 }}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     globalSetup: './src/tests/global-setup.ts',
     setupFiles: './src/tests/setup.ts',
     environment: 'happy-dom',
+    exclude: ['e2e-tests/**', '**/node_modules/**'],
   },
   resolve: {
     alias: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2019,6 +2019,13 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
+"@playwright/test@^1.41.1":
+  version "1.41.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.41.1.tgz#6954139ed4a67999f1b17460aa3d184f4b334f18"
+  integrity sha512-9g8EWTjiQ9yFBXc6HjCWe41msLpxEX0KhmfmPl9RPLJdfzL4F0lg2BdJ91O9azFdl11y1pmpwdjBiSxvqc+btw==
+  dependencies:
+    playwright "1.41.1"
+
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
@@ -5671,6 +5678,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
@@ -7596,6 +7608,20 @@ pkg-types@^1.0.3:
     jsonc-parser "^3.2.0"
     mlly "^1.2.0"
     pathe "^1.1.0"
+
+playwright-core@1.41.1:
+  version "1.41.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.41.1.tgz#9c152670010d9d6f970f34b68e3e935d3c487431"
+  integrity sha512-/KPO5DzXSMlxSX77wy+HihKGOunh3hqndhqeo/nMxfigiKzogn8kfL0ZBDu0L1RKgan5XHCPmn6zXd2NUJgjhg==
+
+playwright@1.41.1:
+  version "1.41.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.41.1.tgz#83325f34165840d019355c2a78a50f21ed9b9c85"
+  integrity sha512-gdZAWG97oUnbBdRL3GuBvX3nDDmUOuqzV/D24dytqlKt+eI5KbwusluZRGljx1YoJKZ2NRPaeWiFTeGZO7SosQ==
+  dependencies:
+    playwright-core "1.41.1"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 point-in-polygon@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Adds initial structure for running E2E tests on pull requests and all staging environments every 3 hours. At some point this could also be extended to running as smoke tests for the production environment.

Currently only includes one test, but want to merge this before adding more test cases

Part of https://github.com/AtB-AS/kundevendt/issues/16713