### PR TITLE
fix: journey planner API config for FRAM and NFK

### DIFF
--- a/orgs/fram.json
+++ b/orgs/fram.json
@@ -36,10 +36,10 @@
     }
   },
   "journeyApiConfigurations": {
-    "waitReluctance": 1.5,
-    "walkingReluctance": 1.5,
+    "waitReluctance": 1.0,
+    "walkingReluctance": 4.0,
     "walkingSpeed": 1.3,
-    "transferPenalty": 10,
+    "transferPenalty": 0,
     "transferSlack": 0
   }
 }

--- a/orgs/nfk.json
+++ b/orgs/nfk.json
@@ -36,10 +36,10 @@
     }
   },
   "journeyApiConfigurations": {
-    "waitReluctance": 1.5,
-    "walkingReluctance": 1.5,
+    "waitReluctance": 1.0,
+    "walkingReluctance": 4.0,
     "walkingSpeed": 1.3,
-    "transferPenalty": 10,
+    "transferPenalty": 0,
     "transferSlack": 0
   }
 }


### PR DESCRIPTION
The current values that are used are Entur default values. This updates the values to be the same as in the app. 

Closes https://github.com/orgs/AtB-AS/projects/10/views/13?pane=issue&itemId=49668512 for FRAM and NFK. 