### PR TITLE
fix: filter out locations where locality is undefined from the travel planner's input field.

### DIFF
--- a/src/components/search/search.tsx
+++ b/src/components/search/search.tsx
@@ -70,37 +70,35 @@ export default function Search({
 
           <ul className={style.menu} {...getMenuProps()}>
             {isOpen &&
-              data
-                ?.filter((item) => item.locality !== undefined)
-                .map((item, index) => (
-                  <li
-                    className={andIf({
-                      [style.item]: true,
-                      [style.itemHighlighted]: highlightedIndex === index,
-                    })}
-                    key={item.id}
-                    {...getItemProps({
-                      index,
-                      item,
-                    })}
-                  >
-                    <div className={style.itemIcon} aria-hidden>
-                      <VenueIcon categories={item.category} />
-                    </div>
-                    <span className={style.itemName}>
-                      {highlightSearchText(inputValue, item.name).map(
-                        ({ part, highlight }) => {
-                          if (!part) return null;
-                          if (highlight)
-                            return <span key={item.id + part}>{part}</span>;
-                          else
-                            return <strong key={item.id + part}>{part}</strong>;
-                        },
-                      )}
-                    </span>
-                    <span className={style.itemLocality}>{item.locality}</span>
-                  </li>
-                ))}
+              data?.map((item, index) => (
+                <li
+                  className={andIf({
+                    [style.item]: true,
+                    [style.itemHighlighted]: highlightedIndex === index,
+                  })}
+                  key={item.id}
+                  {...getItemProps({
+                    index,
+                    item,
+                  })}
+                >
+                  <div className={style.itemIcon} aria-hidden>
+                    <VenueIcon categories={item.category} />
+                  </div>
+                  <span className={style.itemName}>
+                    {highlightSearchText(inputValue, item.name).map(
+                      ({ part, highlight }) => {
+                        if (!part) return null;
+                        if (highlight)
+                          return <span key={item.id + part}>{part}</span>;
+                        else
+                          return <strong key={item.id + part}>{part}</strong>;
+                      },
+                    )}
+                  </span>
+                  <span className={style.itemLocality}>{item.locality}</span>
+                </li>
+              ))}
           </ul>
         </div>
       )}
@@ -136,5 +134,7 @@ function highlightSearchText(input: string | null, name: string) {
 function geocoderFeatureToString(
   feature: GeocoderFeature | null | undefined,
 ): string {
-  return feature ? `${feature.name}, ${feature.locality}` : '';
+  return feature
+    ? `${feature.name}${feature.locality ? ', ' + feature.locality : ''}`
+    : '';
 }

--- a/src/components/search/search.tsx
+++ b/src/components/search/search.tsx
@@ -70,35 +70,37 @@ export default function Search({
 
           <ul className={style.menu} {...getMenuProps()}>
             {isOpen &&
-              data?.map((item, index) => (
-                <li
-                  className={andIf({
-                    [style.item]: true,
-                    [style.itemHighlighted]: highlightedIndex === index,
-                  })}
-                  key={item.id}
-                  {...getItemProps({
-                    index,
-                    item,
-                  })}
-                >
-                  <div className={style.itemIcon} aria-hidden>
-                    <VenueIcon categories={item.category} />
-                  </div>
-                  <span className={style.itemName}>
-                    {highlightSearchText(inputValue, item.name).map(
-                      ({ part, highlight }) => {
-                        if (!part) return null;
-                        if (highlight)
-                          return <span key={item.id + part}>{part}</span>;
-                        else
-                          return <strong key={item.id + part}>{part}</strong>;
-                      },
-                    )}
-                  </span>
-                  <span className={style.itemLocality}>{item.locality}</span>
-                </li>
-              ))}
+              data
+                ?.filter((item) => item.locality !== undefined)
+                .map((item, index) => (
+                  <li
+                    className={andIf({
+                      [style.item]: true,
+                      [style.itemHighlighted]: highlightedIndex === index,
+                    })}
+                    key={item.id}
+                    {...getItemProps({
+                      index,
+                      item,
+                    })}
+                  >
+                    <div className={style.itemIcon} aria-hidden>
+                      <VenueIcon categories={item.category} />
+                    </div>
+                    <span className={style.itemName}>
+                      {highlightSearchText(inputValue, item.name).map(
+                        ({ part, highlight }) => {
+                          if (!part) return null;
+                          if (highlight)
+                            return <span key={item.id + part}>{part}</span>;
+                          else
+                            return <strong key={item.id + part}>{part}</strong>;
+                        },
+                      )}
+                    </span>
+                    <span className={style.itemLocality}>{item.locality}</span>
+                  </li>
+                ))}
           </ul>
         </div>
       )}

--- a/src/page-modules/departures/server/geocoder/index.ts
+++ b/src/page-modules/departures/server/geocoder/index.ts
@@ -70,7 +70,7 @@ function mapGeocoderFeature(data: GeocoderRoot) {
   return data.features.map((f) => ({
     id: f.properties.id,
     name: f.properties.name,
-    locality: f.properties.locality,
+    locality: f.properties.locality ?? null,
     category: f.properties.category as FeatureCategory[],
     layer: f.properties.layer,
     geometry: f.geometry,

--- a/src/page-modules/departures/types.ts
+++ b/src/page-modules/departures/types.ts
@@ -5,7 +5,7 @@ import type { SearchTime } from '@atb/modules/search-time';
 export type GeocoderFeature = {
   id: string;
   name: string;
-  locality?: string;
+  locality: string | null;
   category: FeatureCategory[];
   layer: 'address' | 'venue';
   geometry: {


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/16688

### What was wrong, and what was expected behavior?

When clicking on the Ålesund geopoint in travel planner web, the locality attribute  was undefined in the input box.
This is probably due to missing municipality field in OSM. 

How to replicate:
Enter Ålesund in input. Click geopoint at top. See undefined in input box. If running locally, the application may crash. 

### Illustration problem
<details>
<Summary>screenshots/problem</Summary>

<img width="507" alt="img2undefined" src="https://github.com/AtB-AS/planner-web/assets/59939294/40059d5c-f4b9-4540-9af4-6af3b1995a3b">

<img width="518" alt="img1Undefined" src="https://github.com/AtB-AS/planner-web/assets/59939294/07f90d01-eafd-40d5-b223-c6698ab2267f">

</details>

### Illustration solution

<details>
<Summary>screenshot/solution</Summary>

<img width="507" alt="Screenshot 2024-02-05 at 16 06 29" src="https://github.com/AtB-AS/planner-web/assets/59939294/afddd950-7632-427b-8501-fabe381cfb1e">

</details>


### Solution
- Set locality to null if noe defined
- Only display search locality if not it is defined."



