### PR TITLE
fix: improve button border contrast when organization is set to fram.

### DIFF
--- a/src/components/button/button.module.css
+++ b/src/components/button/button.module.css
@@ -101,30 +101,46 @@
 
 /* Interactive button 0 bordered */
 .button--interactive_0--bordered,
-.button--interactive_0--bordered:visited {
+.button--interactive_0--bordered:visited,
+.button--fram_interactive_0--bordered,
+.button--fram_interactive_0--bordered:visited {
   background-color: var(--interactive-interactive_0-default-background);
   color: var(--interactive-interactive_0-default-text);
   box-shadow: inset 0 0 0 var(--border-width-slim)
     var(--interactive-interactive_0-default-text);
 }
-.button--interactive_0--bordered:hover {
+
+.button--interactive_0--bordered:hover,
+.button--fram_interactive_0--bordered:hover {
   background-color: var(--interactive-interactive_0-hover-background);
   color: var(--interactive-interactive_0-hover-text);
 }
-.button--interactive_0--bordered:active {
+
+.button--interactive_0--bordered:active,
+.button--fram_interactive_0--bordered:active {
   background-color: var(--interactive-interactive_0-active-background);
   color: var(--interactive-interactive_0-active-text);
 }
+
 .button--interactive_0--bordered:disabled,
-.button--interactive_0--bordered.button--disabled {
+.button--interactive_0--bordered.button--disabled,
+.button--fram_interactive_0--bordered:disabled,
+.button--fram_interactive_0--bordered.button--disabled {
   background-color: var(--interactive-interactive_0-disabled-background);
   color: var(--interactive-interactive_0-disabled-text);
 }
+
 .button--interactive_0--bordered:focus {
   outline: 0;
-  box-shadow: inset 0 0 0 var(--border-width-medium);
+  box-shadow: inset 0 0 0 var(--border-width-medium)
+    var(--interactive-interactive_0-outline-background);
 }
 
+.button--fram_interactive_0--bordered:focus {
+  outline: 0;
+  box-shadow: inset 0 0 0 var(--border-width-medium)
+    var(--interactive-interactive_2-default-background);
+}
 /* Interactive button 1 */
 
 .button--interactive_1,

--- a/src/components/button/utils.tsx
+++ b/src/components/button/utils.tsx
@@ -6,6 +6,7 @@ import { LoadingIcon } from '../loading';
 export type ButtonModes =
   | 'interactive_0'
   | 'interactive_0--bordered'
+  | 'fram_interactive_0--bordered'
   | 'interactive_1'
   | 'interactive_2'
   | 'interactive_3'

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -254,7 +254,11 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
           <Button
             title={t(PageText.Assistant.search.buttons.find.title)}
             className={style.button}
-            mode="interactive_0--bordered"
+            mode={
+              urls.homePageUrl.name === 'frammr.no'
+                ? 'fram_interactive_0--bordered'
+                : 'interactive_0--bordered'
+            }
             disabled={
               !tripQuery.from || !tripQuery.to || isPerformingSearchNavigation
             }

--- a/src/page-modules/departures/layout.tsx
+++ b/src/page-modules/departures/layout.tsx
@@ -103,7 +103,11 @@ function DeparturesLayout({ children, fromQuery }: DeparturesLayoutProps) {
           <Button
             title={t(PageText.Departures.search.buttons.find.title)}
             className={style.button}
-            mode="interactive_0--bordered"
+            mode={
+              urls.homePageUrl.name === 'frammr.no'
+                ? 'fram_interactive_0--bordered'
+                : 'interactive_0--bordered'
+            }
             disabled={!fromQuery.from}
             buttonProps={{ type: 'submit' }}
             state={isSearching ? 'loading' : undefined}

--- a/src/widget/widget.module.css
+++ b/src/widget/widget.module.css
@@ -234,7 +234,8 @@
 }
 .button:focus {
   outline: 0;
-  box-shadow: inset 0 0 0 var(--border-width-medium);
+  box-shadow: inset 0 0 0 var(--border-width-medium)
+    var(--interactive-interactive_0-outline-background);
 }
 
 /* Autocomplete */


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/16871

### Background

Fram's color palette is such that certain buttons do not meet the requirements of UU when the buttons are in :focus

#### Illustrations
<details>
<summary>screenshots/video/figma</summary>

https://github.com/AtB-AS/planner-web/assets/59939294/e28796c8-8c87-4c6b-a082-b360728d9143


https://github.com/AtB-AS/planner-web/assets/59939294/8d84d41c-2332-424f-a1b8-0fe324254098


</details>

### Proposed solution

Apply a special .css class to the button component when the component is rendered on frammr.no. 



