### PR TITLE
 feat: uncheck flight as default way of transport when organization is nfk 

### DIFF
--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -16,7 +16,12 @@ import { PageText, useTranslation } from '@atb/translations';
 import { FocusScope } from '@react-aria/focus';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useRouter } from 'next/router';
-import { FormEventHandler, PropsWithChildren, useState } from 'react';
+import {
+  FormEventHandler,
+  PropsWithChildren,
+  useEffect,
+  useState,
+} from 'react';
 import style from './assistant.module.css';
 import { FromToTripQuery } from './types';
 import { createTripQuery } from './utils';
@@ -35,6 +40,7 @@ export type AssistantLayoutProps = PropsWithChildren<{
 function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
   const { t } = useTranslation();
   const router = useRouter();
+  const { orgId } = getOrgData();
 
   const [showAlternatives, setShowAlternatives] = useState(false);
   const [searchTime, setSearchTime] = useState<SearchTime>(
@@ -52,6 +58,15 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
     'transportModeFilter',
     getTransportModeFilter,
   );
+
+  useEffect(() => {
+    if (orgId === 'nfk') {
+      tripQuery.transportModeFilter =
+        transportModeFilter
+          ?.filter((mode) => mode.icon.transportMode !== 'air')
+          .map((mode) => mode.id) ?? null;
+    }
+  }, [transportModeFilter]);
 
   const setValuesWithLoading = async (
     override: Partial<FromToTripQuery>,


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/16683

### Background

NFK have requested that flights are not part of the default transport methods in travel planner web. It should still be possible to enable for the users, but not selected as default.

This is default also in app and at Entur.

#### Illustrations
<details>
<summary>screenshots/video/figma</summary>

![Screenshot 2024-02-13 at 14 01 16](https://github.com/AtB-AS/planner-web/assets/59939294/00a84cc5-961f-44ab-b48e-003dffa06fe9)

</details>

### Proposed solution

At the initial render, if the organization is nfk, set the transport mode filter to all filters but the flight filter.

### Acceptance Criteria
- [ ] All filters but air is initially set when the organization is nfk.
- [ ] The user should be able to set the flight filter after the initial render.
- [ ] The trip planner works as it did before this update.





