### PR TITLE
fix: automatically resets to the current date if the current month or current year is reselected twice.

### DIFF
--- a/src/modules/search-time/selector/index.tsx
+++ b/src/modules/search-time/selector/index.tsx
@@ -56,11 +56,14 @@ export default function SearchTimeSelector({
 
   const isPastDate = (selectedDate: string) => {
     const today = new Date().toISOString().split('T')[0];
+    const year = initialDate.getFullYear().toString();
+    const month = initialDate.getMonth().toString().padStart(2, '0');
+    const day = initialDate.getDate().toString().padStart(2, '0');
+    const formatedInitialDate = `${year}-${month}-${day}`;
 
-    // If reselecting from (selectedYear < current year) to current year, the date will automatically be reset to the current date.
-    if (selectedDate.substring(0, 4) < initialDate.getFullYear().toString()) {
+    // If reselecting the current month or current year twice, the date will automatically be reset to the current date.
+    if (selectedDate.substring(0, 12) <= formatedInitialDate)
       resetToCurrentDate();
-    }
 
     // To ensure that the time is not past whenever reselecting back the current date.
     if (selectedDate <= today) resetToCurrentTime();


### PR DESCRIPTION
### Background

When reselecting the current the year twice, the date is automatically set to current date. At the moment,  this is not the case when reselecting the current month twice. To make the user flow as predictable as possible, this function should be the same for both year selection and month selection     

### Proposed solution

Update to automatically rest to current date if reselecting the current month or current year twice.
