### PR TITLE
fix: update styling to make the linefilter and the search component appear more similar.

### DIFF
--- a/src/components/search/search.module.css
+++ b/src/components/search/search.module.css
@@ -4,7 +4,7 @@
   --height: 2.75rem;
 
   min-width: 10rem;
-  max-width: 32rem;
+  max-width: 30rem;
   display: flex;
   position: relative;
   border-radius: 0.75rem;

--- a/src/page-modules/assistant/line-filter/index.tsx
+++ b/src/page-modules/assistant/line-filter/index.tsx
@@ -38,13 +38,20 @@ export default function LineFilter({ filterState, onChange }: LineFilterProps) {
       <Typo.h3 textType="body__primary--bold" className={style.heading}>
         {t(PageText.Assistant.search.lineFilter.label)}
       </Typo.h3>
-      <input
-        className={style.input}
-        type="text"
-        placeholder={t(PageText.Assistant.search.lineFilter.placeholder)}
-        value={localFilterState}
-        onChange={onChangeWrapper}
-      />
+
+      <div className={style.labelInputContainer}>
+        <label className={style.label}>
+          {t(PageText.Assistant.search.lineFilter.description)}
+        </label>
+
+        <input
+          className={style.input}
+          type="text"
+          placeholder={t(PageText.Assistant.search.lineFilter.placeholder)}
+          value={localFilterState}
+          onChange={onChangeWrapper}
+        />
+      </div>
 
       <Typo.p textType="body__tertiary" className={style.infoText}>
         {t(PageText.Assistant.search.lineFilter.example)}

--- a/src/page-modules/assistant/line-filter/line-filter.module.css
+++ b/src/page-modules/assistant/line-filter/line-filter.module.css
@@ -1,8 +1,27 @@
+@value typo-body__secondary from "@atb/theme/typography.module.css";
+
 .container {
+  --height: 2.75rem;
   display: flex;
   flex-direction: column;
   max-width: 30rem;
   gap: var(--spacings-small);
+}
+
+.labelInputContainer {
+  display: flex;
+  flex-direction: relative;
+  width: 100%;
+  height: var(--height);
+  border-radius: 0.75rem;
+  color: var(--static-background-background_0-text);
+  background-color: var(--static-background-background_0-background);
+}
+
+.labelInputContainer:focus-within {
+  outline: 0;
+  box-shadow: inset 0 0 0 var(--border-width-medium)
+    var(--interactive-interactive_2-outline-background);
 }
 
 .heading {
@@ -16,13 +35,39 @@
   padding: var(--spacings-small);
   border: none;
   width: 100%;
-  border-radius: 0.75rem;
-  background-color: var(--static-background-background_0-background);
   color: var(--static-background-background_0-text);
   outline: 0;
+  height: var(--height);
+  padding-left: 3.5rem;
+  background: none;
+  border-radius: 0;
 }
+
+.input::placeholder {
+  color: var(--text-colors-secondary);
+  opacity: 1;
+}
+
 .input:focus-within {
   outline: 0;
   box-shadow: inset 0 0 0 var(--border-width-medium)
     var(--interactive-interactive_2-outline-background);
+}
+
+.label {
+  composes: typo-body__secondary;
+  position: absolute;
+  height: var(--height);
+  min-width: 3rem;
+  display: flex;
+  align-items: center;
+  padding: var(--spacings-small);
+  border-bottom-left-radius: 0.75rem;
+  border-top-left-radius: 0.75rem;
+}
+
+@media (max-width: 650px) {
+  .container {
+    max-width: 100%;
+  }
 }

--- a/src/translations/pages/assistant.ts
+++ b/src/translations/pages/assistant.ts
@@ -48,6 +48,7 @@ export const Assistant = {
         'I travel with line',
         'Eg reiser med linje',
       ),
+      description: _('Linje', 'Line', 'Linje'),
       placeholder: _('linjenummer', 'line number', 'linjenummer'),
       example: _(
         'Eksempel: 901, 800',


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/16994

### Background

Currently, the via search input field and the line search input field have different appearances. These fields should look the same.

#### Illustrations
Current solution / proposed solution  
<details>
<summary>screenshots</summary>

<img width="538" alt="Screenshot 2024-02-22 at 09 33 08" src="https://github.com/AtB-AS/planner-web/assets/59939294/33fc5718-fe67-4aa9-9ee8-34afdef927e5">

<img width="510" alt="Screenshot 2024-02-22 at 09 32 49" src="https://github.com/AtB-AS/planner-web/assets/59939294/cbe55a4e-0d64-4443-ab7e-52dbf23b9b5b">
</details>

### Proposed solution

Use the same search component and styling to make sure that the input field for via search and the input field for line search appear similar.



