### PR TITLE
fix: update button style in widget to match button in travel planner when fram is the organization.  

### DIFF
--- a/src/components/button/button.module.css
+++ b/src/components/button/button.module.css
@@ -130,7 +130,6 @@
     var(--interactive-interactive_0-outline-background);
 }
 
-/* Interactive button 0 bordered alternative background. */
 .button--interactive_0--bordered-light-outline,
 .button--interactive_0--bordered-light-outline:visited {
   background-color: var(--interactive-interactive_0-default-background);

--- a/src/widget/vite.config.js
+++ b/src/widget/vite.config.js
@@ -32,6 +32,7 @@ export default defineConfig({
     'process.env': {
       MODULE_VERSION: version,
       COMPRESSED_ORG: compressedOrgId,
+      ORG_ID: orgId,
     },
   },
   build: {

--- a/src/widget/widget.module.css
+++ b/src/widget/widget.module.css
@@ -184,7 +184,8 @@
   padding: 0 var(--spacings-xLarge) var(--spacings-xLarge);
 }
 
-.button {
+.button,
+.buttonLightOutline {
   cursor: pointer;
   text-align: left;
   border: 0;
@@ -207,7 +208,8 @@
   padding: var(--spacings-medium);
   border-radius: var(--border-radius-regular);
 }
-.button span {
+.button,
+.buttonLightOutline span {
   display: block;
   flex: 1;
 }
@@ -236,6 +238,37 @@
   outline: 0;
   box-shadow: inset 0 0 0 var(--border-width-medium)
     var(--interactive-interactive_0-outline-background);
+}
+
+/* Interactive button 0 bordered alternative background. */
+.buttonLightOutline,
+.buttonLightOutline:visited {
+  background-color: var(--interactive-interactive_0-default-background);
+  color: var(--interactive-interactive_0-default-text);
+  box-shadow: inset 0 0 0 var(--border-width-slim)
+    var(--interactive-interactive_0-default-text);
+}
+
+.buttonLightOutline:hover {
+  background-color: var(--interactive-interactive_0-hover-background);
+  color: var(--interactive-interactive_0-hover-text);
+}
+
+.buttonLightOutline:active {
+  background-color: var(--interactive-interactive_1-hover-background);
+  color: var(--interactive-interactive_1-active-text);
+}
+
+.buttonLightOutline:disabled,
+.buttonLightOutline.button--disabled {
+  background-color: var(--interactive-interactive_0-disabled-background);
+  color: var(--interactive-interactive_0-disabled-text);
+}
+
+.buttonLightOutline:focus {
+  outline: 0;
+  box-shadow: inset 0 0 0 var(--border-width-medium)
+    var(--interactive-interactive_0-active-background);
 }
 
 /* Autocomplete */

--- a/src/widget/widget.ts
+++ b/src/widget/widget.ts
@@ -19,7 +19,8 @@ const html = String.raw;
 
 const MODULE_VERSION = process.env.MODULE_VERSION;
 const COMPRESSED_ORG = process.env.COMPRESSED_ORG;
-const useDefaultButtonStyle = COMPRESSED_ORG !== 'GYJwhgtkA' ? true : false;
+const ORG_ID = process.env.ORG_ID;
+const useDefaultButtonStyle = ORG_ID !== 'fram' ? true : false;
 
 function createSettingsConstants(urlBase: string) {
   if (!urlBase?.startsWith('http')) {

--- a/src/widget/widget.ts
+++ b/src/widget/widget.ts
@@ -19,6 +19,7 @@ const html = String.raw;
 
 const MODULE_VERSION = process.env.MODULE_VERSION;
 const COMPRESSED_ORG = process.env.COMPRESSED_ORG;
+const useDefaultButtonStyle = COMPRESSED_ORG !== 'GYJwhgtkA' ? true : false;
 
 function createSettingsConstants(urlBase: string) {
   if (!urlBase?.startsWith('http')) {
@@ -429,7 +430,12 @@ function createOutput({ URL_BASE }: SettingConstants, texts: Texts) {
 
   const buttons = html`
     <div class="${style.buttonGroup}">
-      <button type="submit" class="${style.button}">
+      <button
+        type="submit"
+        class="${useDefaultButtonStyle
+          ? style.button
+          : style.buttonLightOutline}"
+      >
         <span>${texts.searchButton}</span>
       </button>
     </div>


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/16996

### Background

Currently, the widget search button and the travel planner search button have dissimilar appearance when FRAM is the organisation. These buttons should have the same appearance.  

#### Illustrations
<details>
<summary>screenshots</summary>
 

https://github.com/AtB-AS/planner-web/assets/59939294/ef5d2679-709b-4b78-9528-85cec452275d


https://github.com/AtB-AS/planner-web/assets/59939294/7204ecb0-dc9e-4ba3-a374-01a70f75ba4f



</details>

### Proposed solution

Style the widget search button the same way as the search button currently implemented in the travel planner. 





### Acceptance Criteria

- [ ] Button in widget and travel planner have the same appearance. 
- [ ] The new styling does not affect the behavior of the button in the widget button. 


