### PR TITLE
fix: details page for trip search with line filter

### DIFF
--- a/src/page-modules/assistant/server/journey-planner/journey-gql/trip-with-details.gql
+++ b/src/page-modules/assistant/server/journey-planner/journey-gql/trip-with-details.gql
@@ -11,6 +11,7 @@ query TripsWithDetails(
   $walkSpeed: Float
   $modes: Modes
   $numTripPatterns: Int
+  $lineFilter: [ID]
 ) {
   trip(
     from: $from
@@ -28,6 +29,7 @@ query TripsWithDetails(
     searchWindow: 60 # 1 hour
     includeRealtimeCancellations: true
     includePlannedCancellations: true
+    whiteListed: { lines: $lineFilter }
   ) {
     tripPatterns {
       expectedStartTime


### PR DESCRIPTION
Currently, one cannot open the details page for a trip suggestion, which can only be found when searching with a line filter. This is because the trip details query doesn't consider the line filter, and therefore can't find the trip suggestion. 

Fixes https://github.com/AtB-AS/kundevendt/issues/17059