### PR TITLE
feat: add functionality to specify whether a filter that should be initially checked.   

### DIFF
--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -16,7 +16,12 @@ import { PageText, useTranslation } from '@atb/translations';
 import { FocusScope } from '@react-aria/focus';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useRouter } from 'next/router';
-import { FormEventHandler, PropsWithChildren, useState } from 'react';
+import {
+  FormEventHandler,
+  PropsWithChildren,
+  useEffect,
+  useState,
+} from 'react';
 import style from './assistant.module.css';
 import { FromToTripQuery } from './types';
 import { createTripQuery } from './utils';
@@ -53,6 +58,13 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
     'transportModeFilter',
     getTransportModeFilter,
   );
+
+  useEffect(() => {
+    tripQuery.transportModeFilter =
+      transportModeFilter
+        ?.filter((filter: any) => !filter.isUncheckedByDefault)
+        .map((filter: any) => filter.id) ?? null;
+  }, [transportModeFilter]);
 
   const setValuesWithLoading = async (
     override: Partial<FromToTripQuery>,


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/16683

### Background

NFK have requested that flights are not part of the default transport methods in travel planner web. It should still be possible to enable for the users, but not selected as default.

This is default also in app and at Entur.

- [ ] Uncheck flight as default way of transport in Nordland
- [ ] Uncheck flight FRAM
- [ ] Uncheck train FRAM

### Proposed solution
-  If the isUncheckedByDefault property of a filter is defined, set the filter to be initially unchecked.  


