### PR TITLE
feat: disable travel planner flight filter by default 

### DIFF
--- a/src/modules/transport-mode/filter/__tests__/filter.test.tsx
+++ b/src/modules/transport-mode/filter/__tests__/filter.test.tsx
@@ -122,7 +122,15 @@ describe('transport mode filter', () => {
 
     const initial: string[] = [];
 
-    const expected = null;
+    const expected = [
+      'bus',
+      'rail',
+      'expressboat',
+      'ferry',
+      'airportbus',
+      'air',
+      'other',
+    ];
 
     render(
       <TransportModeFilter

--- a/src/modules/transport-mode/filter/filter.tsx
+++ b/src/modules/transport-mode/filter/filter.tsx
@@ -51,7 +51,9 @@ export default function TransportModeFilter({
               !localFilterState || localFilterState.length === data.length
             }
             onChange={(event) => {
-              onChangeWrapper(event.target.checked ? null : []);
+              onChangeWrapper(
+                event.target.checked ? data?.map((option) => option.id) : [],
+              );
             }}
           />
 

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -59,15 +59,6 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
     getTransportModeFilter,
   );
 
-  useEffect(() => {
-    if (tripQuery.transportModeFilter === null)
-      onTransportFilterChanged(
-        transportModeFilter
-          ?.filter((filter) => filter.id !== 'air')
-          .map((filter) => filter.id) ?? null,
-      );
-  }, [transportModeFilter]);
-
   const setValuesWithLoading = async (
     override: Partial<FromToTripQuery>,
     replace = false,
@@ -131,8 +122,23 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
   const { urls, orgId } = getOrgData();
   const { isDarkMode } = useTheme();
 
+  /*
+   * Temporary solution until firebase configuration is in place.
+   */
+  useEffect(() => {
+    if (tripQuery.transportModeFilter === null)
+      onTransportFilterChanged(
+        transportModeFilter
+          ?.filter(
+            (filter) =>
+              !filter.modes.some((mode) => mode.transportMode === 'air'),
+          )
+          .map((filter) => filter.id) ?? null,
+      );
+  }, [transportModeFilter]);
+
   /**
-   * Temprorary solution to disable line filter for some orgs until
+   * Temporary solution to disable line filter for some orgs until
    * we have a working solution for all orgs.
    */
   const disableLineFilter =

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -50,7 +50,6 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
   const [isPerformingSearchNavigation, setIsPerformingSearchNavigation] =
     useState(false);
   const [geolocationError, setGeolocationError] = useState<string | null>(null);
-  const [defaultFilters, setDefaultFilters] = useState<string[] | null>(null);
 
   // Loading the transport mode filter data here instead of in the component
   // avoids the data loading when the filter is mounted which causes the
@@ -61,11 +60,10 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
   );
 
   useEffect(() => {
-    setDefaultFilters(
+    tripQuery.transportModeFilter =
       transportModeFilter
         ?.filter((filter) => filter.icon.transportMode !== 'air')
-        .map((filter) => filter.id) ?? null,
-    );
+        .map((filter) => filter.id) ?? null;
   }, [transportModeFilter]);
 
   const setValuesWithLoading = async (
@@ -221,7 +219,7 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
               >
                 <div className={style.alternatives}>
                   <TransportModeFilter
-                    filterState={defaultFilters}
+                    filterState={tripQuery.transportModeFilter}
                     data={transportModeFilter}
                     onChange={onTransportFilterChanged}
                   />

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -50,6 +50,7 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
   const [isPerformingSearchNavigation, setIsPerformingSearchNavigation] =
     useState(false);
   const [geolocationError, setGeolocationError] = useState<string | null>(null);
+  const [defaultFilters, setDefaultFilters] = useState<string[] | null>(null);
 
   // Loading the transport mode filter data here instead of in the component
   // avoids the data loading when the filter is mounted which causes the
@@ -60,10 +61,11 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
   );
 
   useEffect(() => {
-    tripQuery.transportModeFilter =
+    setDefaultFilters(
       transportModeFilter
         ?.filter((filter) => filter.icon.transportMode !== 'air')
-        .map((filter) => filter.id) ?? null;
+        .map((filter) => filter.id) ?? null,
+    );
   }, [transportModeFilter]);
 
   const setValuesWithLoading = async (
@@ -219,7 +221,7 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
               >
                 <div className={style.alternatives}>
                   <TransportModeFilter
-                    filterState={tripQuery.transportModeFilter}
+                    filterState={defaultFilters}
                     data={transportModeFilter}
                     onChange={onTransportFilterChanged}
                   />

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -62,7 +62,7 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
   useEffect(() => {
     tripQuery.transportModeFilter =
       transportModeFilter
-        ?.filter((filter) => filter.icon.transportMode !== 'air')
+        ?.filter((filter) => filter.id !== 'air')
         .map((filter) => filter.id) ?? null;
   }, [transportModeFilter]);
 

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -50,6 +50,7 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
   const [isPerformingSearchNavigation, setIsPerformingSearchNavigation] =
     useState(false);
   const [geolocationError, setGeolocationError] = useState<string | null>(null);
+  const [defaultFilters, setDefaultFilters] = useState<string[] | null>(null);
 
   // Loading the transport mode filter data here instead of in the component
   // avoids the data loading when the filter is mounted which causes the
@@ -60,10 +61,11 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
   );
 
   useEffect(() => {
-    tripQuery.transportModeFilter =
+    setDefaultFilters(
       transportModeFilter
         ?.filter((filter) => filter.id !== 'air')
-        .map((filter) => filter.id) ?? null;
+        .map((filter) => filter.id) ?? null,
+    );
   }, [transportModeFilter]);
 
   const setValuesWithLoading = async (
@@ -219,7 +221,11 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
               >
                 <div className={style.alternatives}>
                   <TransportModeFilter
-                    filterState={tripQuery.transportModeFilter}
+                    filterState={
+                      tripQuery.transportModeFilter === null
+                        ? defaultFilters
+                        : tripQuery.transportModeFilter
+                    }
                     data={transportModeFilter}
                     onChange={onTransportFilterChanged}
                   />

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -62,8 +62,8 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
   useEffect(() => {
     tripQuery.transportModeFilter =
       transportModeFilter
-        ?.filter((mode) => mode.icon.transportMode !== 'air')
-        .map((mode) => mode.id) ?? null;
+        ?.filter((filter) => filter.icon.transportMode !== 'air')
+        .map((filter) => filter.id) ?? null;
   }, [transportModeFilter]);
 
   const setValuesWithLoading = async (

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -16,7 +16,12 @@ import { PageText, useTranslation } from '@atb/translations';
 import { FocusScope } from '@react-aria/focus';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useRouter } from 'next/router';
-import { FormEventHandler, PropsWithChildren, useState } from 'react';
+import {
+  FormEventHandler,
+  PropsWithChildren,
+  useEffect,
+  useState,
+} from 'react';
 import style from './assistant.module.css';
 import { FromToTripQuery } from './types';
 import { createTripQuery } from './utils';
@@ -53,6 +58,13 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
     'transportModeFilter',
     getTransportModeFilter,
   );
+
+  useEffect(() => {
+    tripQuery.transportModeFilter =
+      transportModeFilter
+        ?.filter((mode) => mode.icon.transportMode !== 'air')
+        .map((mode) => mode.id) ?? null;
+  }, [transportModeFilter]);
 
   const setValuesWithLoading = async (
     override: Partial<FromToTripQuery>,

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -50,7 +50,6 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
   const [isPerformingSearchNavigation, setIsPerformingSearchNavigation] =
     useState(false);
   const [geolocationError, setGeolocationError] = useState<string | null>(null);
-  const [defaultFilters, setDefaultFilters] = useState<string[] | null>(null);
 
   // Loading the transport mode filter data here instead of in the component
   // avoids the data loading when the filter is mounted which causes the
@@ -61,11 +60,12 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
   );
 
   useEffect(() => {
-    setDefaultFilters(
-      transportModeFilter
-        ?.filter((filter) => filter.id !== 'air')
-        .map((filter) => filter.id) ?? null,
-    );
+    if (tripQuery.transportModeFilter === null)
+      onTransportFilterChanged(
+        transportModeFilter
+          ?.filter((filter) => filter.id !== 'air')
+          .map((filter) => filter.id) ?? null,
+      );
   }, [transportModeFilter]);
 
   const setValuesWithLoading = async (
@@ -221,11 +221,7 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
               >
                 <div className={style.alternatives}>
                   <TransportModeFilter
-                    filterState={
-                      tripQuery.transportModeFilter === null
-                        ? defaultFilters
-                        : tripQuery.transportModeFilter
-                    }
+                    filterState={tripQuery.transportModeFilter}
                     data={transportModeFilter}
                     onChange={onTransportFilterChanged}
                   />


### PR DESCRIPTION
Temporary solution for task https://github.com/orgs/AtB-AS/projects/10/views/13?pane=issue&itemId=51482158

### Background

NFK have requested that flights are not part of the default transport methods in travel planner web. It should still be possible to enable for the users, but not selected as default.

This is default also in app and at Entur.

#### Illustrations

<details>
<summary>screenshot</summary>

<img width="487" alt="Screenshot 2024-02-28 at 12 36 11" src="https://github.com/AtB-AS/planner-web/assets/59939294/8a2f82a2-4b45-40ee-82f3-f743079c5df4">

</details>

### Proposed solution

Disabling the travel planner flight filter for for all organisations until a more sophisticated solution where each organisation can configure filter preferences. 

### Acceptance Criteria

- [ ] Flight filter is unchecked by default.
- [ ] Searching after trips with flight can still be performed by checking the flight filter.
