### PR TITLE
fix: improve minor styling errors in widget

### DIFF
--- a/src/widget/widget.module.css
+++ b/src/widget/widget.module.css
@@ -63,12 +63,13 @@
 .tabSelected {
   text-decoration: none;
   border-bottom: 3px solid var(--static-background-background_accent_0-text);
+  font-weight: var(--baseTypo-body__primary--bold-fontWeight, 500);
 }
 .tabs a:hover {
   color: var(--static-background-background_accent_1-text);
 }
 .tabs a:active {
-  color: var(--interactive-interactive_0-active-text);
+  color: var(--static-background-background_accent_0-text);
 }
 
 .main {
@@ -208,7 +209,7 @@
   padding: var(--spacings-medium);
   border-radius: var(--border-radius-regular);
 }
-.button,
+.button span,
 .buttonLightOutline span {
   display: block;
   flex: 1;

--- a/src/widget/widget.ts
+++ b/src/widget/widget.ts
@@ -20,7 +20,7 @@ const html = String.raw;
 const MODULE_VERSION = process.env.MODULE_VERSION;
 const COMPRESSED_ORG = process.env.COMPRESSED_ORG;
 const ORG_ID = process.env.ORG_ID;
-const useDefaultButtonStyle = ORG_ID !== 'fram' ? true : false;
+const useDefaultButtonStyle = ORG_ID !== 'fram';
 
 function createSettingsConstants(urlBase: string) {
   if (!urlBase?.startsWith('http')) {


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/17110
### Background

-  When nfk is set as the organization, the width of the search button is too wide. 
-  The text colour of the active tab is set to black. The colour should be withe, as in the travel planner on web.  should.
- The selected tab should have bold font, as in the travel planner on web.   

#### Illustrations

<details>
Before / after
<summary>screenshots/video/figma</summary>

![Image](https://github.com/AtB-AS/kundevendt/assets/59939294/c546d107-807e-4076-ba09-8e69b5a44d52)

<img width="988" alt="Skjermbilde 2024-03-01 kl  09 51 48" src="https://github.com/AtB-AS/planner-web/assets/59939294/9d52c1f1-5503-43f1-bb4e-dc1c2b2af23b">

### Proposed solution

- Fix the mentioned bullet points. 

