### PR TITLE
fix: add allow url for CORS reisnordland com

### DIFF
--- a/src/pages/api/departures/autocomplete.ts
+++ b/src/pages/api/departures/autocomplete.ts
@@ -46,5 +46,7 @@ export default handlerWithDepartureClient<AutocompleteApiReturnType>(
     /\.frammr.no$/,
     'https://reisnordland.no',
     /\.reisnordland.no$/,
+    'https://reisnordland.com',
+    /\.reisnordland.com$/,
   ],
 );


### PR DESCRIPTION
Reis uses https://www.reisnordland.com/ when English is the selected language. To make the widget work we have to allow https://www.reisnordland.com/ as well