### PR TITLE
fix: conditional render assistant page when transport mode filters are defined.  

### DIFF
--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -147,6 +147,8 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
   const disableLineFilter =
     process.env.NEXT_PUBLIC_DISABLE_LINE_FILTER === 'true';
 
+  if (transportModeFilter === null) return null;
+
   return (
     <div>
       <div className={style.homeLink__container}>

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -50,6 +50,7 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
   const [isPerformingSearchNavigation, setIsPerformingSearchNavigation] =
     useState(false);
   const [geolocationError, setGeolocationError] = useState<string | null>(null);
+  const [noneFilters, setNoneFilters] = useState(false);
 
   // Loading the transport mode filter data here instead of in the component
   // avoids the data loading when the filter is mounted which causes the
@@ -107,9 +108,11 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
   const onToSelected = async (to: GeocoderFeature) =>
     setValuesWithLoading({ to });
   const onTransportFilterChanged = debounce(
-    async (transportModeFilter: string[] | null) =>
-      setValuesWithLoading({ transportModeFilter }, true),
-    500,
+    async (transportModeFilter: string[] | null) => {
+      setNoneFilters(transportModeFilter?.length === 0 ? true : false);
+      setValuesWithLoading({ transportModeFilter }, true);
+      500;
+    },
   );
   const onViaSelected = async (via: GeocoderFeature) =>
     setValuesWithLoading({ via });
@@ -126,7 +129,7 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
    * Temporary solution until firebase configuration is in place.
    */
   useEffect(() => {
-    if (tripQuery.transportModeFilter === null)
+    if (tripQuery.transportModeFilter === null && !noneFilters)
       onTransportFilterChanged(
         transportModeFilter
           ?.filter(
@@ -135,7 +138,7 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
           )
           .map((filter) => filter.id) ?? null,
       );
-  }, [transportModeFilter]);
+  }, [tripQuery, noneFilters, transportModeFilter, onTransportFilterChanged]);
 
   /**
    * Temporary solution to disable line filter for some orgs until


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/17141

### What is wrong, and what is expected behavior?
Some users sometimes experience that flight is checked by default. Must investigate. Flight should always be unchecked by default until a more sofisticated solution for configurating transport mode filters for each organization is ready.

### How to replicate:
According to feedback from customer service, all transport mode filters (including flight) are checked if the navigating directly to the travel planner, without using the widget.    

After testing in Safari, Chrome, Arc, Firefox and Microsoft Edge, I have not been able to replicate the described bug myself. 

A few times I have experienced that the trips query have completed before the transportModeFilter from the useSWRImmutable() is defined, making some trip results appear on the screen in halv a second, before the transportModeFilter is defined, repeating the query due to the useEffect().   

### Proposed Solution
Add a condition to only render the AssistantLayout when the useSWRImmutable() have completed and transportModeFilter is defined.
