### PR TITLE
fix: update the header elements to achieve a correct sequentially-descending order 

### DIFF
--- a/src/layouts/shared/footer.tsx
+++ b/src/layouts/shared/footer.tsx
@@ -22,9 +22,9 @@ export default function Footer({ withoutSettings = false }: FooterProps) {
       <div className={style.footer__content}>
         <div className={style.footer__top}>
           <section className={style.footer__section}>
-            <h4 className={style.footer__title}>
+            <h3 className={style.footer__title}>
               {t(ModuleText.Layout.base.footer.sections.general.header)}
-            </h4>
+            </h3>
 
             <ul className={style.footer__linkList}>
               {urls.helpUrl && (
@@ -59,9 +59,9 @@ export default function Footer({ withoutSettings = false }: FooterProps) {
           </section>
 
           <section className={style.footer__section}>
-            <h4 className={style.footer__title}>
+            <h3 className={style.footer__title}>
               {t(ModuleText.Layout.base.footer.sections.contact.header)}
-            </h4>
+            </h3>
 
             <ul className={style.footer__linkList}>
               {urls.supportUrl ? (
@@ -83,9 +83,9 @@ export default function Footer({ withoutSettings = false }: FooterProps) {
 
           {!withoutSettings && (
             <section className={style.footer__section}>
-              <h4 className={style.footer__title}>
+              <h3 className={style.footer__title}>
                 {t(ModuleText.Layout.base.footer.sections.settings.header)}
-              </h4>
+              </h3>
 
               <ul className={style.footer__linkList}>
                 <LanguageSelections />

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -164,9 +164,9 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
           <TabLink activePath="/assistant" />
 
           <div className={style.input}>
-            <Typo.h3 textType="body__primary--bold" className={style.heading}>
+            <Typo.h2 textType="body__primary--bold" className={style.heading}>
               {t(PageText.Assistant.search.input.label)}
-            </Typo.h3>
+            </Typo.h2>
             <Search
               label={t(PageText.Assistant.search.input.from)}
               placeholder={t(PageText.Assistant.search.input.placeholder)}
@@ -196,9 +196,9 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
             />
           </div>
           <div className={style.date}>
-            <Typo.h3 textType="body__primary--bold" className={style.heading}>
+            <Typo.h2 textType="body__primary--bold" className={style.heading}>
               {t(PageText.Assistant.search.date.label)}
-            </Typo.h3>
+            </Typo.h2>
             <SearchTimeSelector
               initialState={searchTime}
               onChange={setSearchTime}
@@ -233,12 +233,12 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
                   />
 
                   <div>
-                    <Typo.h3
+                    <Typo.h2
                       textType="body__primary--bold"
                       className={style.heading}
                     >
                       {t(PageText.Assistant.search.input.via.label)}
-                    </Typo.h3>
+                    </Typo.h2>
                     <Search
                       label={t(PageText.Assistant.search.input.via.description)}
                       placeholder={t(

--- a/src/page-modules/departures/layout.tsx
+++ b/src/page-modules/departures/layout.tsx
@@ -63,9 +63,9 @@ function DeparturesLayout({ children, fromQuery }: DeparturesLayoutProps) {
           <TabLink activePath="/departures" />
 
           <div className={style.input}>
-            <Typo.p textType="body__primary--bold" className={style.heading}>
+            <Typo.h2 textType="body__primary--bold" className={style.heading}>
               {t(PageText.Departures.search.input.label)}
-            </Typo.p>
+            </Typo.h2>
             <Search
               label={t(PageText.Departures.search.input.from)}
               placeholder={t(PageText.Departures.search.input.placeholder)}
@@ -82,9 +82,9 @@ function DeparturesLayout({ children, fromQuery }: DeparturesLayoutProps) {
           </div>
 
           <div className={style.date}>
-            <Typo.p textType="body__primary--bold" className={style.heading}>
+            <Typo.h2 textType="body__primary--bold" className={style.heading}>
               {t(PageText.Departures.search.date.label)}
-            </Typo.p>
+            </Typo.h2>
             <SearchTimeSelector
               initialState={searchTime}
               onChange={setSearchTime}


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/17181
Closes https://github.com/AtB-AS/kundevendt/issues/17198

### Background

The headings in the DeparturesLayout are using the p-tags instead of h-tags. In addition, some headers break the requirement for correct use of h-tags in sequentially descending order.
 
### Proposed solution
- Update code to use h-tags instead of p-tags.

### Acceptance criteria
- [x] The correct h-tags are used in headings.
- [x] Ensure correct sequential order of h-tags. 
- [ ] Update FRAM´s tilgjengelighetserklæring.  

