### PR TITLE
fix: update search component to not cut placeholder early

### DIFF
--- a/src/components/search/search.module.css
+++ b/src/components/search/search.module.css
@@ -3,7 +3,7 @@
 .container {
   --height: 2.75rem;
 
-  min-width: 10rem;
+  min-width: 20rem;
   max-width: 30rem;
   display: flex;
   position: relative;


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/17176

### Background

The placeholders and selected from/to destinations are cut off when the width of the screen is reduced to be slightly wider than mobile view. This is against requirement [1.4.12 - Text Spacing](https://www.uutilsynet.no/wcag-standarden/1412-tekstavstand-niva-aa/146), in the WCAG standard.

#### Illustrations
<details>
<summary>screenshots</summary>

https://github.com/AtB-AS/planner-web/assets/59939294/ae503c6e-0320-44db-9c1f-c9c50087c8b6

</details>

### Proposed solution

Adjust to mobile view earlier before the placeholders are cut of off due too narrow window width.     

### Acceptance criteria
- [x] The placeholder is not cut off early.
- [ ] Update FRAM´s tilgjengelighetserklæring.  