### PR TITLE
fix(widget): set correct line height

### DIFF
--- a/src/modules/search-time/selector/selector.module.css
+++ b/src/modules/search-time/selector/selector.module.css
@@ -29,6 +29,7 @@
 
 .option__text {
   z-index: 2;
+  line-height: 1;
 }
 
 .option__label {


### PR DESCRIPTION
Fixing issue with default values when integrating widget.

Before:

<img width="555" alt="Screenshot 2024-03-11 at 12 00 19" src="https://github.com/AtB-AS/planner-web/assets/606374/45976987-b96b-4c0d-90c3-9f750ffa9d2e">


After

<img width="518" alt="Screenshot 2024-03-11 at 12 00 23" src="https://github.com/AtB-AS/planner-web/assets/606374/210dc364-feb5-46f1-8e35-3a8ef6bd300a">
