### PR TITLE
fix: build with dynamic import of map

### DIFF
--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -7,7 +7,7 @@ export { MapHeader } from './map-header';
 export * from './utils';
 export * from './types';
 
-export const Map = dynamic(() => import('./map').then((mod) => mod.Map), {
+export const Map = dynamic(() => import('./map'), {
   ssr: false,
   loading: () => <MapLoading />,
 });

--- a/src/components/map/map-with-header.tsx
+++ b/src/components/map/map-with-header.tsx
@@ -1,7 +1,6 @@
 import style from './map.module.css';
-import { MapHeader, Map } from '.';
-import { MapHeaderProps } from './map-header';
-import { MapProps } from './map';
+import { MapHeader, MapHeaderProps } from './map-header';
+import Map, { MapProps } from './map';
 
 export type MapWithHeaderProps = MapHeaderProps & MapProps;
 

--- a/src/components/map/map.tsx
+++ b/src/components/map/map.tsx
@@ -30,7 +30,7 @@ export type MapProps = {
   | {}
 );
 
-export function Map({ layer, onSelectStopPlace, ...props }: MapProps) {
+export default function Map({ layer, onSelectStopPlace, ...props }: MapProps) {
   const mapWrapper = useRef<HTMLDivElement>(null);
   const mapContainer = useRef<HTMLDivElement>(null);
   const map = useRef<mapboxgl.Map>();


### PR DESCRIPTION
The current standalone build includes `map.tsx` which gives a type error (missing imports). To fix this we can use `export default` for the Map component.

Closes https://github.com/AtB-AS/kundevendt/issues/17228