### PR TITLE
feat: extend line filter to include national organizations

### DIFF
--- a/src/page-modules/assistant/line-filter/index.tsx
+++ b/src/page-modules/assistant/line-filter/index.tsx
@@ -11,6 +11,8 @@ type LineFilterProps = {
   onChange: (lineFilter: string[] | null) => void;
 };
 
+const regexValidChars = /^$|^[0-9a-zA-Z\s-]+$/;
+
 export default function LineFilter({ filterState, onChange }: LineFilterProps) {
   const { t } = useTranslation();
 
@@ -38,6 +40,7 @@ export default function LineFilter({ filterState, onChange }: LineFilterProps) {
       onChange(null);
     } else {
       const lines = input
+        .toUpperCase()
         .split(',')
         .flatMap((line) => data[line.trim()])
         .filter(Boolean);
@@ -91,6 +94,6 @@ export default function LineFilter({ filterState, onChange }: LineFilterProps) {
 
 function isValidFilter(filter: string): boolean {
   return filter.split(',').every((line) => {
-    return !isNaN(Number(line.trim()));
+    return regexValidChars.test(line);
   });
 }

--- a/src/page-modules/assistant/line-filter/index.tsx
+++ b/src/page-modules/assistant/line-filter/index.tsx
@@ -23,8 +23,6 @@ export default function LineFilter({ filterState, onChange }: LineFilterProps) {
   const [validationError, setValidationError] =
     useState<LabeledInputProps['validationError']>();
   const [localFilterState, setLocalFilterState] = useState('');
-  const [publicCodeLineMap, setPublicCodeLineMap] =
-    useState<Map<string, string[]>>();
 
   const onChangeWrapper = (event: ChangeEvent<HTMLInputElement>) => {
     const input = event.target.value;

--- a/src/pages/api/assistant/lines/[authorityId].ts
+++ b/src/pages/api/assistant/lines/[authorityId].ts
@@ -2,10 +2,24 @@ import { tryResult } from '@atb/modules/api-server';
 import { LinesApiReturnType } from '@atb/page-modules/assistant/client';
 import { handlerWithAssistantClient } from '@atb/page-modules/assistant/server';
 
+/*
+ * Todo:
+ *  1. Make sure that all authorities that should be possible to filter on are added.
+ *  2. Should the 'authorities' be set somewhere else?
+ */
+const authorities: string[] = [
+  'NSB:Authority:NSB',
+  'SJN:Authority:SJN',
+  'UNI:Authority:UNI',
+  'GFS:Authority:1',
+  'VYG:Authority:TAG',
+  'BSR:Authority:1',
+  'KOL:Authority:30',
+];
+
 export default handlerWithAssistantClient<LinesApiReturnType>({
   async GET(req, res, { client, ok }) {
     const { authorityId } = req.query;
-    const authorities: string[] = [];
 
     if (typeof authorityId === 'string') {
       authorities.push(authorityId);

--- a/src/pages/api/assistant/lines/[authorityId].ts
+++ b/src/pages/api/assistant/lines/[authorityId].ts
@@ -8,13 +8,18 @@ import { handlerWithAssistantClient } from '@atb/page-modules/assistant/server';
  *  2. Should the 'authorities' be set somewhere else?
  */
 const authorities: string[] = [
-  'NSB:Authority:NSB',
-  'SJN:Authority:SJN',
-  'UNI:Authority:UNI',
-  'GFS:Authority:1',
-  'VYG:Authority:TAG',
-  'BSR:Authority:1',
-  'KOL:Authority:30',
+  'NSB:Authority:NSB', // NSB
+  'SJN:Authority:SJN', // SJ Nord
+  'UNI:Authority:UNI', // Unibuss
+  'GFS:Authority:1', // Geiranger Fjordservice
+  'VYG:Authority:TAG', // Vy Tåg
+  'VYX:Authority:1', // Vy Buss
+  'BSR:Authority:1', // Bussring
+  'KOL:Authority:30', // Fjord 1
+  'BOR:Authority:1', // Boreal
+  'HUR:Authority:1', // Hurtigruten
+  'Geiranger-Hellesylt', // Geiranger-Hellesylt
+  'MOR:Authority:AM008', // Kvamsøya-Voksa-Åram-Larsnes
 ];
 
 export default handlerWithAssistantClient<LinesApiReturnType>({


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/17261

### Background

As of today, the travel planner can only filter lines that are planned by the relevant organization. Better explained, this means that the travel planner of FRAM can only filter on journeys planned by FRAM, while the travel planner of NFK can only filter on journeys planned by NFK.

But, there are other national organizations that organize trips across counties and regions. Example: Vy, Sj Nord, Boreal and Fjord 1. The line search should be extended to be able to filter on such organizations.

#### Illustrations
<details>
<summary>screenshots/video/figma</summary>

![Skjermbilde 2024-03-22 kl  15 11 26](https://github.com/AtB-AS/planner-web/assets/59939294/3bf3b7d4-67d2-44b5-b189-d1e333ba64e8)

![Skjermbilde 2024-03-22 kl  15 11 48](https://github.com/AtB-AS/planner-web/assets/59939294/7982f947-ab26-4cfb-84cd-f882901e708c)


</details>

### Proposed solution
- [x]  Find a different pattern to check whether a line number is valid or not.  
- [x] Identify which organizations that should always be possible to preform line filter on.  
- [x] Update the endpoint `lines()` in `src/pages/api/assistant/lines/[authorityId].ts` to include all the  authorityIds as params.

### Acceptance Criteria
- [x] Can filter on lines containing characters other than numbers.
- [x] Make sure that the user is able to provide line number in both upper end lower case when filtering.  
- [x] Able to filter lines organized by the relevant organization.
- [x] Able to filter lines organized by the national organizations.