### PR TITLE
fix: fixes wrong icon for GeoLocation button

### DIFF
--- a/src/components/map/map.tsx
+++ b/src/components/map/map.tsx
@@ -20,15 +20,15 @@ export type MapProps = {
   layer?: string;
   onSelectStopPlace?: (id: string) => void;
 } & (
-  | {
+    | {
       position: Position;
       initialZoom?: number;
     }
-  | {
+    | {
       mapLegs: MapLegType[];
     }
-  | {}
-);
+    | {}
+  );
 
 export default function Map({ layer, onSelectStopPlace, ...props }: MapProps) {
   const mapWrapper = useRef<HTMLDivElement>(null);
@@ -100,7 +100,7 @@ export default function Map({ layer, onSelectStopPlace, ...props }: MapProps) {
           <Button
             className={style.buttonsContainer}
             size="small"
-            icon={{ left: <MonoIcon icon="places/City" /> }}
+            icon={{ left: <MonoIcon icon="places/Location" /> }}
             onClick={() => centerMap(position)}
             buttonProps={{
               'aria-label': t(ComponentText.Map.map.centerMapButton),

--- a/src/components/search/geolocation-button/index.tsx
+++ b/src/components/search/geolocation-button/index.tsx
@@ -39,7 +39,7 @@ function GeolocationButton({
       aria-label={t(ComponentText.GeolocationButton.alt)}
       type="button"
     >
-      <MonoIcon icon="places/City" />
+      <MonoIcon icon="places/Location" />
     </button>
   );
 }

--- a/src/widget/widget.ts
+++ b/src/widget/widget.ts
@@ -584,7 +584,7 @@ function createOutput({ URL_BASE }: SettingConstants, texts: Texts) {
                 type="button"
               >
                 <img
-                  src="${URL_BASE}/assets/mono/light/places/City.svg"
+                  src="${URL_BASE}/assets/mono/light/places/Location.svg"
                   width="20"
                   height="20"
                   role="none"
@@ -686,7 +686,7 @@ function createOutput({ URL_BASE }: SettingConstants, texts: Texts) {
                 type="button"
               >
                 <img
-                  src="${URL_BASE}/assets/mono/light/places/City.svg"
+                  src="${URL_BASE}/assets/mono/light/places/Location.svg"
                   width="20"
                   height="20"
                   role="none"


### PR DESCRIPTION
Fixes issue with wrong icon for GeoLocation button 😳 Has been working before now as places/City has been wrong, but this has since been fixed in https://github.com/AtB-AS/design-system/pull/164

Before:

![Screenshot 2024-04-03 at 14 52 02](https://github.com/AtB-AS/planner-web/assets/606374/5326b460-a219-40cf-a853-03f0ccbcabea)


Now:

![Screenshot 2024-04-03 at 14 52 09](https://github.com/AtB-AS/planner-web/assets/606374/2b73c163-9438-4181-93f9-dee30515b3bf)
