### PR TITLE
fix: remove empty lines from build script

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,6 @@ jobs:
         ATB_NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=${{ github.event_name == 'release' && 'atb-mobility-platform.firebaseapp.com' || 'atb-mobility-platform-staging.firebaseapp.com' }}
         ATB_NEXT_PUBLIC_FIREBASE_APP_ID=${{ github.event_name == 'release' && '1:827196677776:web:c4b1d8924bb5778bf50215' || '1:939812594010:web:0308b2a9cdc80b0d069363' }}
         ATB_NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=${{ github.event_name == 'release' && '' || '' }}
-                        
         NFK_NEXT_PUBLIC_MAPBOX_DEFAULT_LAT=67.280357
         NFK_NEXT_PUBLIC_MAPBOX_DEFAULT_LNG=14.404916
         NFK_NEXT_PUBLIC_FIREBASE_PROJECT_ID=${{ github.event_name == 'release' && 'nfk-prod' || 'nfk-staging'}}
@@ -27,7 +26,6 @@ jobs:
         NFK_NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=${{ github.event_name == 'release' && 'nfk-prod.firebaseapp.com' || 'nfk-staging.firebaseapp.com' }}
         NFK_NEXT_PUBLIC_FIREBASE_APP_ID=${{ github.event_name == 'release' && '1:638315587956:web:51e95a11a03f27dc9ca421' || '1:793301954236:web:908723b8ded2824cadeab9' }}
         NFK_NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=${{ github.event_name == 'release' && '' || '' }}
-
         FRAM_NEXT_PUBLIC_MAPBOX_DEFAULT_LAT=62.4705
         FRAM_NEXT_PUBLIC_MAPBOX_DEFAULT_LNG=6.1533
         FRAM_NEXT_PUBLIC_FIREBASE_PROJECT_ID=${{ github.event_name == 'release' && 'fram-prod-a7850' || 'fram-staging'}}
@@ -35,7 +33,6 @@ jobs:
         FRAM_NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=${{ github.event_name == 'release' && 'fram-prod-a7850.firebaseapp.com' || 'fram-staging.firebaseapp.com' }}
         FRAM_NEXT_PUBLIC_FIREBASE_APP_ID=${{ github.event_name == 'release' && '1:717595301444:web:1e16129330d562f1b3ce11' || '1:312905478211:web:41c6f9db83ae5ef0efa4f6' }}
         FRAM_NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=${{ github.event_name == 'release' && 'G-KS45JBFWF4' || '' }}
-
         TROMS_NEXT_PUBLIC_MAPBOX_DEFAULT_LAT=69.665229
         TROMS_NEXT_PUBLIC_MAPBOX_DEFAULT_LNG=18.9070347
         TROMS_NEXT_PUBLIC_FIREBASE_PROJECT_ID=${{ github.event_name == 'release' && '' || 'troms-staging'}}
@@ -43,9 +40,7 @@ jobs:
         TROMS_NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=${{ github.event_name == 'release' && '' || 'troms-staging.firebaseapp.com' }}
         TROMS_NEXT_PUBLIC_FIREBASE_APP_ID=${{ github.event_name == 'release' && '' || '1:973624729382:web:a84d8a489613a14be12be7' }}
         TROMS_NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=''
-
         NEXT_PUBLIC_ENVIRONMENT=${{ github.event_name == 'release' && 'prod' || 'staging' }}
-
     secrets:
       github_pat: ${{ secrets.GH_PAT }}
       build_secrets: |


### PR DESCRIPTION
Removes empty lines from docker.yml. EMpty lines were added in the last PR, making the build script fail. 
 
<img width="1029" alt="Skjermbilde 2024-04-04 kl  16 14 39" src="https://github.com/AtB-AS/planner-web/assets/59939294/0629cb5b-4a96-40cb-b222-dd264f58c33e">
