### PR TITLE
feat: expand the search time selector to enable retrieval of search results from yesterday.

### DIFF
--- a/src/modules/search-time/selector/__tests__/selector.test.tsx
+++ b/src/modules/search-time/selector/__tests__/selector.test.tsx
@@ -169,7 +169,7 @@ describe('search time selector', function () {
     ).toBeInTheDocument();
   });
 
-  it('should not call onChange when selecting yesterday as date input.', () => {
+  it('should allow call onChange when selecting yesterday as date input.', () => {
     const onChange = vi.fn();
     const output = render(
       <SearchTimeSelector
@@ -179,6 +179,22 @@ describe('search time selector', function () {
     );
     const dateInput = output.getByLabelText('Dato');
     const yesterday = format(subDays(new Date(), 1), 'yyyy-MM-dd');
+
+    fireEvent.change(dateInput, { target: { value: yesterday } });
+
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it('should not call onChange when selecting the day before yesterday as date input.', () => {
+    const onChange = vi.fn();
+    const output = render(
+      <SearchTimeSelector
+        initialState={{ mode: 'arriveBy', dateTime: 0 }}
+        onChange={onChange}
+      />,
+    );
+    const dateInput = output.getByLabelText('Dato');
+    const yesterday = format(subDays(new Date(), 2), 'yyyy-MM-dd');
 
     fireEvent.change(dateInput, { target: { value: yesterday } });
 
@@ -201,7 +217,7 @@ describe('search time selector', function () {
     expect(onChange).toHaveBeenCalled();
   });
 
-  it('should reset clock to current time when reselecting today as date', () => {
+  it('should reset clock to current time when reselecting yesterday as date', () => {
     const onChange = vi.fn();
     const output = render(
       <SearchTimeSelector
@@ -211,12 +227,12 @@ describe('search time selector', function () {
     );
     const dateInput = output.getByLabelText('Dato');
     const timeInput = output.getByLabelText('Tid');
-    const today = format(new Date(), 'yyyy-MM-dd');
+    const yesterday = format(subDays(new Date(), 1), 'yyyy-MM-dd');
     const tomorrow = format(addDays(new Date(), 1), 'yyyy-MM-dd');
     const currentTime = format(new Date(), 'HH:mm');
 
     fireEvent.change(dateInput, { target: { value: tomorrow } });
-    fireEvent.change(dateInput, { target: { value: today } });
+    fireEvent.change(dateInput, { target: { value: yesterday } });
 
     expect(onChange).toHaveBeenCalled();
     expect(timeInput).toHaveValue(currentTime);

--- a/src/modules/search-time/selector/__tests__/selector.test.tsx
+++ b/src/modules/search-time/selector/__tests__/selector.test.tsx
@@ -216,25 +216,4 @@ describe('search time selector', function () {
 
     expect(onChange).toHaveBeenCalled();
   });
-
-  it('should reset clock to current time when reselecting yesterday as date', () => {
-    const onChange = vi.fn();
-    const output = render(
-      <SearchTimeSelector
-        initialState={{ mode: 'arriveBy', dateTime: 0 }}
-        onChange={onChange}
-      />,
-    );
-    const dateInput = output.getByLabelText('Dato');
-    const timeInput = output.getByLabelText('Tid');
-    const yesterday = format(subDays(new Date(), 1), 'yyyy-MM-dd');
-    const tomorrow = format(addDays(new Date(), 1), 'yyyy-MM-dd');
-    const currentTime = format(new Date(), 'HH:mm');
-
-    fireEvent.change(dateInput, { target: { value: tomorrow } });
-    fireEvent.change(dateInput, { target: { value: yesterday } });
-
-    expect(onChange).toHaveBeenCalled();
-    expect(timeInput).toHaveValue(currentTime);
-  });
 });

--- a/src/modules/search-time/selector/index.tsx
+++ b/src/modules/search-time/selector/index.tsx
@@ -16,6 +16,10 @@ type SearchTimeSelectorProps = {
   options?: SearchMode[];
 };
 
+const today = new Date();
+today.setDate(today.getDate() - 1);
+const yesterdayString = today.toISOString().split('T')[0];
+
 export default function SearchTimeSelector({
   onChange,
   initialState = { mode: 'now' },
@@ -72,7 +76,6 @@ export default function SearchTimeSelector({
   };
 
   const isPastDate = (selectedDate: string) => {
-    const today = new Date().toISOString().split('T')[0];
     const year = initialDate.getFullYear().toString();
     const month = initialDate.getMonth().toString().padStart(2, '0');
     const day = initialDate.getDate().toString().padStart(2, '0');
@@ -83,8 +86,8 @@ export default function SearchTimeSelector({
       resetToCurrentDate();
 
     // To ensure that the time is not past whenever reselecting back the current date.
-    if (selectedDate <= today) resetToCurrentTime();
-    return selectedDate < today;
+    if (selectedDate <= yesterdayString) resetToCurrentTime();
+    return selectedDate < yesterdayString;
   };
 
   const internalOnDateChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -171,7 +174,7 @@ export default function SearchTimeSelector({
                   type="date"
                   id="searchTimeSelector-date"
                   value={selectedDate.toISOString().slice(0, 10)}
-                  min={new Date().toISOString().slice(0, 10)}
+                  min={yesterdayString}
                   onChange={internalOnDateChange}
                 />
               </div>

--- a/src/modules/search-time/selector/index.tsx
+++ b/src/modules/search-time/selector/index.tsx
@@ -16,8 +16,6 @@ type SearchTimeSelectorProps = {
   options?: SearchMode[];
 };
 
-const yesterday = format(subDays(new Date(), 1), 'yyyy-MM-dd');
-
 export default function SearchTimeSelector({
   onChange,
   initialState = { mode: 'now' },
@@ -31,6 +29,7 @@ export default function SearchTimeSelector({
       : new Date(),
   ) as Date;
 
+  const yesterday = format(subDays(new Date(), 1), 'yyyy-MM-dd');
   const [selectedDate, setSelectedDate] = useState(initialDate);
   const [selectedTime, setSelectedTime] = useState(() =>
     format(initialDate, 'HH:mm'),
@@ -73,24 +72,14 @@ export default function SearchTimeSelector({
     onChange(newState);
   };
 
-  const isPastDate = (selectedDate: string) => {
-    const year = initialDate.getFullYear().toString();
-    const month = initialDate.getMonth().toString().padStart(2, '0');
-    const day = initialDate.getDate().toString().padStart(2, '0');
-    const formatedInitialDate = `${year}-${month}-${day}`;
-
-    // If reselecting the current month or current year twice, the date will automatically be reset to the current date.
-    if (selectedDate.substring(0, 12) <= formatedInitialDate)
-      resetToCurrentDate();
-
-    // To ensure that the time is not past whenever reselecting back the current date.
-    if (selectedDate <= yesterday) resetToCurrentTime();
-    return selectedDate < yesterday;
-  };
-
   const internalOnDateChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (!event.target.value) return;
-    if (isPastDate(event.target.value)) return;
+
+    if (event.target.value < yesterday) {
+      resetToCurrentDate();
+      resetToCurrentTime();
+      return;
+    }
 
     setSelectedDate(new Date(event.target.value));
 

--- a/src/modules/search-time/selector/index.tsx
+++ b/src/modules/search-time/selector/index.tsx
@@ -1,5 +1,5 @@
 import { ChangeEvent, CSSProperties, useState } from 'react';
-import { format } from 'date-fns';
+import { format, subDays } from 'date-fns';
 import { AnimatePresence, motion } from 'framer-motion';
 import {
   ModuleText,
@@ -16,9 +16,7 @@ type SearchTimeSelectorProps = {
   options?: SearchMode[];
 };
 
-const today = new Date();
-today.setDate(today.getDate() - 1);
-const yesterdayString = today.toISOString().split('T')[0];
+const yesterday = format(subDays(new Date(), 1), 'yyyy-MM-dd');
 
 export default function SearchTimeSelector({
   onChange,
@@ -86,8 +84,8 @@ export default function SearchTimeSelector({
       resetToCurrentDate();
 
     // To ensure that the time is not past whenever reselecting back the current date.
-    if (selectedDate <= yesterdayString) resetToCurrentTime();
-    return selectedDate < yesterdayString;
+    if (selectedDate <= yesterday) resetToCurrentTime();
+    return selectedDate < yesterday;
   };
 
   const internalOnDateChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -174,7 +172,7 @@ export default function SearchTimeSelector({
                   type="date"
                   id="searchTimeSelector-date"
                   value={selectedDate.toISOString().slice(0, 10)}
-                  min={yesterdayString}
+                  min={yesterday}
                   onChange={internalOnDateChange}
                 />
               </div>


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/17561

### Background

Match the behavior of the app with the departure filter time. Should be possible to see results back in time (two days). This changes from existing behavior where it is only allowed for 1 day.

#### Illustrations
Screenshots were the 9th of April.

<details>
<summary>screenshots</summary>

<img width="323" alt="Skjermbilde 2024-04-09 kl  14 59 56" src="https://github.com/AtB-AS/planner-web/assets/59939294/320e2d8b-2a8b-4e4a-a5b6-6d1cd2fdf120">
<img width="266" alt="Skjermbilde 2024-04-09 kl  15 00 26" src="https://github.com/AtB-AS/planner-web/assets/59939294/1184c7d3-60e4-478c-a31f-1d0455d2a8ea">

</details>

### Proposed solution

Expand the search time selector to enable retrieval of search results from yesterday.

### Acceptance Criteria

- [x] The user is able to search after trips that had departure time yesterday.  


