### PR TITLE
fix: theme color to match header for iOS safari

### DIFF
--- a/src/layouts/base/index.tsx
+++ b/src/layouts/base/index.tsx
@@ -34,7 +34,7 @@ export function BaseLayout({ children, title }: BaseLayoutProps) {
         <link rel="icon" href="/assets/colors/icons/favicon.svg" />
         <meta
           name="theme-color"
-          content={theme.static.background.background_1.background}
+          content={theme.static.background.background_accent_0.background}
         />
       </Head>
 

--- a/src/pages/api/departures/og-location.tsx
+++ b/src/pages/api/departures/og-location.tsx
@@ -47,8 +47,6 @@ export default handlerWithDepartureClient<{}>({
       },
     });
 
-    console.log(from);
-
     const image = await satori(
       <div
         style={{


### PR DESCRIPTION
Fixes the color of the header on iOS Safari to match the color of the header it self. Making it look a bit more intentional. 