### PR TITLE
feat: extend travel mode filter selection to use selected_as_default property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ yarn-error.log*
 .env*.local
 .env*.atb
 .env*.fram
+.env*.nfk
 
 # vercel
 .vercel

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.9.7",
-    "@atb-as/config-specs": "^3.16.0",
+    "@atb-as/config-specs": "^3.23.0",
     "@atb-as/theme": "^8.1.0",
     "@github/combobox-nav": "^2.3.1",
     "@isaacs/ttlcache": "^1.4.1",

--- a/src/modules/transport-mode/filter/__tests__/filter.fixture.ts
+++ b/src/modules/transport-mode/filter/__tests__/filter.fixture.ts
@@ -50,6 +50,7 @@ export const filter: TransportModeFilterOptionType[] = [
         transportMode: 'trolleybus',
       },
     ],
+    selectedAsDefault: true,
   },
   {
     id: 'rail',
@@ -79,6 +80,7 @@ export const filter: TransportModeFilterOptionType[] = [
         transportSubModes: ['railReplacementBus'],
       },
     ],
+    selectedAsDefault: false,
   },
   {
     id: 'expressboat',
@@ -112,6 +114,7 @@ export const filter: TransportModeFilterOptionType[] = [
         ],
       },
     ],
+    selectedAsDefault: true,
   },
   {
     id: 'ferry',
@@ -143,6 +146,7 @@ export const filter: TransportModeFilterOptionType[] = [
         ],
       },
     ],
+    selectedAsDefault: true,
   },
   {
     id: 'airportbus',
@@ -169,6 +173,7 @@ export const filter: TransportModeFilterOptionType[] = [
         transportSubModes: ['airportLinkBus'],
       },
     ],
+    selectedAsDefault: true,
   },
   {
     id: 'air',
@@ -194,6 +199,7 @@ export const filter: TransportModeFilterOptionType[] = [
         transportMode: 'air',
       },
     ],
+    selectedAsDefault: false,
   },
   {
     id: 'other',
@@ -248,5 +254,6 @@ export const filter: TransportModeFilterOptionType[] = [
         transportMode: 'lift',
       },
     ],
+    selectedAsDefault: true,
   },
 ];

--- a/src/page-modules/assistant/__tests__/set-transport-mode-filters.test.ts
+++ b/src/page-modules/assistant/__tests__/set-transport-mode-filters.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { setTransportModeFilters } from '../utils';
+import { TravelSearchFiltersType } from '@atb-as/config-specs';
+
+describe('setTransportModeFilters', () => {
+  it('should only return transport mode filters where `selectedAsDefault` is true.', () => {
+    const tmfInput = [
+      { id: 'bus', selectedAsDefault: true },
+      { id: 'air', selectedAsDefault: false },
+    ] as TravelSearchFiltersType['transportModes'];
+
+    const transportModeFilters = setTransportModeFilters(tmfInput);
+    expect(transportModeFilters).toEqual(['bus']);
+  });
+
+  it('should not return transport mode filters where `selectedAsDefault` is undefined.', () => {
+    const tmfInput = [
+      { id: 'bus', selectedAsDefault: true },
+      { id: 'air' },
+      { id: 'rail', selectedAsDefault: undefined },
+    ] as TravelSearchFiltersType['transportModes'];
+
+    const transportModeFilters = setTransportModeFilters(tmfInput);
+    expect(transportModeFilters).toEqual(['bus']);
+  });
+});

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -16,12 +16,7 @@ import { PageText, useTranslation } from '@atb/translations';
 import { FocusScope } from '@react-aria/focus';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useRouter } from 'next/router';
-import {
-  FormEventHandler,
-  PropsWithChildren,
-  useEffect,
-  useState,
-} from 'react';
+import { FormEventHandler, PropsWithChildren, useState } from 'react';
 import style from './assistant.module.css';
 import { FromToTripQuery } from './types';
 import { createTripQuery, setTransportModeFilters } from './utils';
@@ -121,10 +116,9 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
 
   const { urls, orgId } = getOrgData();
   const { isDarkMode } = useTheme();
-  useEffect(() => {
-    tripQuery.transportModeFilter === null &&
-      onTransportFilterChanged(setTransportModeFilters(transportModeFilter));
-  }, [transportModeFilter]); //eslint-disable-line react-hooks/exhaustive-deps
+
+  if (tripQuery.transportModeFilter === null)
+    onTransportFilterChanged(setTransportModeFilters(transportModeFilter));
 
   return (
     <div>

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -24,7 +24,7 @@ import {
 } from 'react';
 import style from './assistant.module.css';
 import { FromToTripQuery } from './types';
-import { createTripQuery } from './utils';
+import { createTripQuery, setTransportModeFilters } from './utils';
 import { TabLink } from '@atb/components/tab-link';
 import { logSpecificEvent } from '@atb/modules/firebase';
 import { getOrgData } from '@atb/modules/org-data';
@@ -121,20 +121,9 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
 
   const { urls, orgId } = getOrgData();
   const { isDarkMode } = useTheme();
-
-  /*
-   * Temporary solution until firebase configuration is in place.
-   */
   useEffect(() => {
-    if (tripQuery.transportModeFilter === null)
-      onTransportFilterChanged(
-        transportModeFilter
-          ?.filter(
-            (filter) =>
-              !filter.modes.some((mode) => mode.transportMode === 'air'),
-          )
-          .map((filter) => filter.id) ?? null,
-      );
+    tripQuery.transportModeFilter === null &&
+      onTransportFilterChanged(setTransportModeFilters(transportModeFilter));
   }, [transportModeFilter]); //eslint-disable-line react-hooks/exhaustive-deps
 
   return (

--- a/src/page-modules/assistant/utils.ts
+++ b/src/page-modules/assistant/utils.ts
@@ -2,6 +2,7 @@ import type { SearchMode } from '@atb/modules/search-time';
 import { searchTimeToQueryString } from '@atb/modules/search-time';
 import { GeocoderFeature } from '@atb/page-modules/departures';
 import { FromToTripQuery, TripData, TripQuery, TripQuerySchema } from './types';
+import { TravelSearchFiltersType } from '@atb-as/config-specs';
 
 export function filterOutDuplicates(
   arrayToFilter: TripData['tripPatterns'],
@@ -121,4 +122,14 @@ export function tripQueryToQueryString(input: TripQuery): string {
         encodeURIComponent(String(input[key as keyof TripQuery])),
     )
     .join('&');
+}
+
+export function setTransportModeFilters(
+  transportModes: TravelSearchFiltersType['transportModes'],
+) {
+  return (
+    transportModes
+      ?.filter((filter) => filter.selectedAsDefault)
+      .map((filter) => filter.id) ?? null
+  );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -70,10 +70,10 @@
   dependencies:
     node-fetch "^2.6.1"
 
-"@atb-as/config-specs@^3.16.0":
-  version "3.16.0"
-  resolved "https://registry.yarnpkg.com/@atb-as/config-specs/-/config-specs-3.16.0.tgz#c0693176ad894283a99eca421c9d158436e9f9bb"
-  integrity sha512-+xmB4zKpAWumMjmbwu2Mpyzm5gkejZC2+f+dc1hFQrQnyCcv+6BOIfKfqUs52ziJqzeK2l4YSUlaqqB8lkrrkQ==
+"@atb-as/config-specs@^3.23.0":
+  version "3.23.0"
+  resolved "https://registry.yarnpkg.com/@atb-as/config-specs/-/config-specs-3.23.0.tgz#f915ac43df1d7d59d7e964feb27106c4940647ed"
+  integrity sha512-p3n8E38r2mXggZE6HuTD/Nz/3KOnRnxux5mwqw2xeuClYuP6HnxaC6k7FUo1sAouHZTqA64C+C2Ld0hWMI2dlQ==
   dependencies:
     ajv "^8.12.0"
     ajv-formats "^2.1.1"


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/17912

### Background

FRAM and NFK have requested that some transport mode filters should be unchecked by default in both app and travel planner web. This request highlights a need that we need to address. As the number of organizations in the OMS grows, it becomes increasingly more difficult to find on singel transport mode configuration that will work well for all orgnaizations. Therefore, each organization should be able to configure their own desired default transportModes. 

The requests from AtB, FRAM and NFK are as following:
- [ ] **AtB:** All transport mode filters should be checked by default (7/7).
- [ ] **NFK:** All transport mode filters except flight should be check by default (6/7).
- [ ] **FRAM:** All transport mode filters except flight and train should be checked by default (5/7).
- [ ] **TROMS:** All transport mode filters should be checked by default (7/7).
- [ ] **Innlandet:** All transport mode filters except flight and train should be checked by default (5/7).

#### Illustrations
<details>
<summary>screenshots/video/figma</summary>

**NFK**
<img width="479" alt="Skjermbilde 2024-05-07 kl  08 32 06" src="https://github.com/AtB-AS/planner-web/assets/59939294/b4496ff3-bcb5-4145-9fce-d5fdfcb2aa14">

**FRAM**
![Skjermbilde 2024-05-06 kl  15 07 18](https://github.com/AtB-AS/planner-web/assets/59939294/48bd001b-815b-405d-b86d-2d73629ca589)

**AtB**
![Skjermbilde 2024-05-06 kl  15 30 19](https://github.com/AtB-AS/planner-web/assets/59939294/f97c92fe-d276-4580-b456-f30d3bf29bf5)

</details>




### Proposed solutionfinder
- [ ] Add a function to determine whether the `selectedAsDefault` property is set for each filter. 

### Acceptence criteria 
- [ ] The correct transport mode filters are checked by default.
- [ ] The user is still able to specify which transport mode filters to use during the search.   




