### PR TITLE
feat: add note informing users about having to buy external ticket

### DIFF
--- a/src/page-modules/assistant/details/index.tsx
+++ b/src/page-modules/assistant/details/index.tsx
@@ -12,6 +12,9 @@ import { getInterchangeDetails } from './trip-section/interchange-section';
 import { getLegWaitDetails } from './trip-section/wait-section';
 import { useRouter } from 'next/router';
 import { tripQueryStringToQueryParams } from './utils';
+import { MessageBox } from '@atb/components/message-box';
+import { getBookingStatus } from '@atb/modules/flexible/utils';
+import { getOrgData } from '@atb/modules/org-data';
 
 export type AssistantDetailsProps = {
   tripPattern: TripPatternWithDetails;
@@ -34,6 +37,12 @@ export function AssistantDetails({ tripPattern }: AssistantDetailsProps) {
   if (tripSearchParams && router.query.filter) {
     tripSearchParams.append('filter', router.query.filter as string);
   }
+
+  const requireTicketBooking = tripPattern.legs.some(
+    (leg) =>
+      getBookingStatus(leg.bookingArrangements, leg.aimedStartTime, 7) !==
+      'none',
+  );
 
   return (
     <div className={style.container}>
@@ -72,6 +81,12 @@ export function AssistantDetails({ tripPattern }: AssistantDetailsProps) {
         </div>
       </div>
       <div className={style.tripContainer}>
+        {requireTicketBooking && (
+          <MessageBox
+            type="info"
+            message={t(PageText.Assistant.ticketBooking.globalMessage)}
+          />
+        )}
         {tripPattern.legs.map((leg, index) => (
           <TripSection
             key={index}

--- a/src/page-modules/assistant/details/index.tsx
+++ b/src/page-modules/assistant/details/index.tsx
@@ -14,7 +14,6 @@ import { useRouter } from 'next/router';
 import { tripQueryStringToQueryParams } from './utils';
 import { MessageBox } from '@atb/components/message-box';
 import { getBookingStatus } from '@atb/modules/flexible/utils';
-import { getOrgData } from '@atb/modules/org-data';
 
 export type AssistantDetailsProps = {
   tripPattern: TripPatternWithDetails;

--- a/src/page-modules/assistant/details/index.tsx
+++ b/src/page-modules/assistant/details/index.tsx
@@ -83,7 +83,7 @@ export function AssistantDetails({ tripPattern }: AssistantDetailsProps) {
         {requireTicketBooking && (
           <MessageBox
             type="info"
-            message={t(PageText.Assistant.ticketBooking.globalMessage)}
+            message={t(PageText.Assistant.details.ticketBooking.globalMessage)}
           />
         )}
         {tripPattern.legs.map((leg, index) => (

--- a/src/translations/pages/assistant.ts
+++ b/src/translations/pages/assistant.ts
@@ -70,13 +70,6 @@ const AssistantInternal = {
       },
     },
   },
-  ticketBooking: {
-    globalMessage: _(
-      'Reisen krever billett som må kjøpes fra et annet selskap enn AtB.',
-      'This journey requires a ticket that must be purchased from provider other than AtB.',
-      'Reisa krev billett som ikkje er tilgjengeleg i denne appen, eller som må kjøpast frå eit anna selskap enn AtB.',
-    ),
-  },
   trip: {
     resultsFound: _(
       'Reiseforslag funnet',
@@ -459,6 +452,13 @@ const AssistantInternal = {
           ),
       },
     },
+    ticketBooking: {
+      globalMessage: _(
+        'Reisen krever billett som ikke er tilgjengelig i denne appen, eller som må kjøpes fra et annet selskap enn AtB.',
+        'This journey requires a ticket that is not available from this app, or must be purchased from a provider other than AtB.',
+        'Reisa krev billett som ikkje er tilgjengeleg i denne appen, eller som må kjøpast frå eit anna selskap enn AtB.',
+      ),
+    },
   },
 };
 
@@ -479,12 +479,14 @@ export const Assistant = orgSpecificTranslations(AssistantInternal, {
         ),
       },
     },
-    ticketBooking: {
-      globalMessage: _(
-        'Reisen krever billett som må kjøpes fra et annet selskap enn Reis Nordland.',
-        'This journey requires a ticket that must be purchased from provider other than Reis Nordland.',
-        'Reisa krev billett som ikkje er tilgjengeleg i denne appen, eller som må kjøpast frå eit anna selskap enn Reis Nordland.',
-      ),
+    details: {
+      ticketBooking: {
+        globalMessage: _(
+          'Reisen krever billett som ikke er tilgjengelig i denne appen, eller som må kjøpes fra et annet selskap enn Reis Nordland.',
+          'This journey requires a ticket that is not available from this app, or must be purchased from a provider other than Nordland.',
+          'Reisa krev billett som ikkje er tilgjengeleg i denne appen, eller som må kjøpast frå eit anna selskap enn Reis Nordland.',
+        ),
+      },
     },
   },
   fram: {
@@ -503,12 +505,14 @@ export const Assistant = orgSpecificTranslations(AssistantInternal, {
         ),
       },
     },
-    ticketBooking: {
-      globalMessage: _(
-        'Reisen krever billett som må kjøpes fra et annet selskap enn FRAM.',
-        'This journey requires a ticket that must be purchased from provider other than FRAM.',
-        'Reisa krev billett som ikkje er tilgjengeleg i denne appen, eller som må kjøpast frå eit anna selskap enn FRAM.',
-      ),
+    details: {
+      ticketBooking: {
+        globalMessage: _(
+          'Reisen krever billett som ikke er tilgjengelig i denne appen, eller som må kjøpes fra et annet selskap enn FRAM.',
+          'This journey requires a ticket that is not available from this app, or must be purchased from a provider other than FRAM.',
+          'Reisa krev billett som ikkje er tilgjengeleg i denne appen, eller som må kjøpast frå eit anna selskap enn FRAM.',
+        ),
+      },
     },
   },
 });

--- a/src/translations/pages/assistant.ts
+++ b/src/translations/pages/assistant.ts
@@ -70,6 +70,13 @@ const AssistantInternal = {
       },
     },
   },
+  ticketBooking: {
+    globalMessage: _(
+      'Reisen krever billett som må kjøpes fra et annet selskap enn AtB.',
+      'This journey requires a ticket that must be purchased from provider other than AtB.',
+      'Reisa krev billett som ikkje er tilgjengeleg i denne appen, eller som må kjøpast frå eit anna selskap enn AtB.',
+    ),
+  },
   trip: {
     resultsFound: _(
       'Reiseforslag funnet',
@@ -472,6 +479,13 @@ export const Assistant = orgSpecificTranslations(AssistantInternal, {
         ),
       },
     },
+    ticketBooking: {
+      globalMessage: _(
+        'Reisen krever billett som må kjøpes fra et annet selskap enn Reis Nordland.',
+        'This journey requires a ticket that must be purchased from provider other than Reis Nordland.',
+        'Reisa krev billett som ikkje er tilgjengeleg i denne appen, eller som må kjøpast frå eit anna selskap enn Reis Nordland.',
+      ),
+    },
   },
   fram: {
     search: {
@@ -488,6 +502,13 @@ export const Assistant = orgSpecificTranslations(AssistantInternal, {
           'Eksempel: 905, 902, 901',
         ),
       },
+    },
+    ticketBooking: {
+      globalMessage: _(
+        'Reisen krever billett som må kjøpes fra et annet selskap enn FRAM.',
+        'This journey requires a ticket that must be purchased from provider other than FRAM.',
+        'Reisa krev billett som ikkje er tilgjengeleg i denne appen, eller som må kjøpast frå eit anna selskap enn FRAM.',
+      ),
     },
   },
 });


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/18065

### Background
As mentioned in the conversation, the same note informing the users out the need to buy tickets from other sources than in the app, should also be shown in the planner web.

> The booking phone number and/or URL is only shown if the booking status is "bookable", see https://github.com/AtB-AS/planner-web/blob/main/src/page-modules/assistant/details/trip-section/booking-section.tsx#L57. 
> 
> This is the same as what the app does. However, the app also has a note saying "This journey requires a ticket that is not available from this app, or must be purchased from a provider other than AtB." This doesn't answer all of the questions a customer might have, but it's some more information. A better approach could be to show the booking URL / phone number at all times, but if so we should probably update the app as well.
> 
> I suggest that we add the note from the app to the planner-web and then discuss with the designers at AtB how we can improve this in both the app and planner-web. 
> 
> <details>
> <summary>Screenshot of the OMS-app</summary>
> 
> ![Image](https://github.com/AtB-AS/kundevendt/assets/43166974/280d3d2b-7522-4063-970a-5bd51aea3866)
> 
> </details>
>   

 _Originally posted by @mortennordseth in [#17560](https://github.com/AtB-AS/kundevendt/issues/17560#issuecomment-2044238052)_


#### Illustrations
<details>
<summary>screenshots/video/figma</summary>

![Image](https://github.com/AtB-AS/kundevendt/assets/59939294/b993614b-5d44-417b-9177-803a9fcd541a)

</details>

### Proposed solution
Display the same message in planner web as already shown in the app.
 
### Acceptance Criteria
- [ ] The info box should appear the same way in panner-web as in the app. 




