### PR TITLE
feat(widget): adds option to use inherited font in the widget

### DIFF
--- a/src/pages/widget/index.tsx
+++ b/src/pages/widget/index.tsx
@@ -38,6 +38,13 @@ const initializeCode = html`
     const widget = window.PlannerWeb.createWidget({
       urlBase: 'https://reiseplanlegger.example.no/',
       language: 'nn', // supports 'nb', 'nn' and 'en'
+
+      // Optional options
+      outputOverrideOptions: {
+        // Inherit font from page website.
+        // By default it uses Roboto as the hosted planner web solution.
+        inheritFont: false,
+      },
     });
 
     // After loading JS and CSS file it can be initialized
@@ -171,7 +178,10 @@ function WidgetContent({
       <h2>Demo</h2>
       <div dangerouslySetInnerHTML={{ __html: html }} />
 
-      <p>Note: Widget is without padding. Should be up to consumer to decide when integrating.</p>
+      <p>
+        Note: Widget is without padding. Should be up to consumer to decide when
+        integrating.
+      </p>
 
       <h2>Installation (latest version v{data.latest.version})</h2>
 
@@ -183,6 +193,22 @@ function WidgetContent({
 
       <h3>HTML output</h3>
       <CopyMarkupLarge content={html} />
+
+      <div>
+        <p style={{ marginTop: '2rem' }}>
+          <strong>Note</strong>: If using output override options when calling{' '}
+          <code>createWidget</code> and copy-paste the HTML code you would have
+          to add classes to the container (element with the class{' '}
+          <code>widget-module__wrapper</code>) manually.
+        </p>
+
+        <ul style={{ listStylePosition: 'inside', marginTop: '1rem' }}>
+          <li>
+            <code>.widget-inheritFont</code>: Inherit font family from the
+            website
+          </li>
+        </ul>
+      </div>
 
       <h3>Scripts (UMD / ESM)</h3>
 

--- a/src/widget/widget.module.css
+++ b/src/widget/widget.module.css
@@ -321,3 +321,10 @@
 .messageBox[hidden] {
   display: none;
 }
+/**
+  * Configurable options for widget
+*/
+.inheritFont,
+.inheritFont * {
+  font-family: inherit !important;
+}

--- a/src/widget/widget.ts
+++ b/src/widget/widget.ts
@@ -704,7 +704,7 @@ function createOutput({ URL_BASE }: SettingConstants, texts: Texts) {
   `;
 
   const output = html`
-    <div class="${style.wrapper} ${style.lightWrapper}">
+    <div class="${style.wrapper} ${style.lightWrapper} ${style.inheritFont}">
       <nav class="${style.nav}">
         <ul class="${style.tabs} js-tablist">
           <li>

--- a/src/widget/widget.ts
+++ b/src/widget/widget.ts
@@ -39,9 +39,13 @@ function createSettingsConstants(urlBase: string) {
   };
 }
 
+type OutputOverrideOptions = {
+  inheritFont?: boolean;
+};
 export type WidgetOptions = {
   urlBase: string;
   language?: Languages;
+  outputOverrideOptions?: Partial<OutputOverrideOptions>;
 };
 export type PlannerWebOutput = {
   output: string;
@@ -51,10 +55,18 @@ export type PlannerWebOutput = {
 export function createWidget({
   urlBase,
   language = 'en',
+  outputOverrideOptions = {},
 }: WidgetOptions): PlannerWebOutput {
   const texts = translations(language);
   const settings = createSettingsConstants(urlBase);
-  const output = createOutput(settings, texts);
+
+  const defaultOutputOverrideOptions: OutputOverrideOptions = {
+    inheritFont: false,
+    ...outputOverrideOptions,
+  };
+
+  const output = createOutput(settings, texts, defaultOutputOverrideOptions);
+
   return {
     output,
     init,
@@ -225,7 +237,11 @@ class MessageBox extends HTMLElement {
   }
 }
 
-function createOutput({ URL_BASE }: SettingConstants, texts: Texts) {
+function createOutput(
+  { URL_BASE }: SettingConstants,
+  texts: Texts,
+  outputOverrideOptions: OutputOverrideOptions,
+) {
   function searchItem(item: GeocoderFeature) {
     const img = venueIcon(item);
     const title = el('span', [item.name]);
@@ -704,7 +720,11 @@ function createOutput({ URL_BASE }: SettingConstants, texts: Texts) {
   `;
 
   const output = html`
-    <div class="${style.wrapper} ${style.lightWrapper} ${style.inheritFont}">
+    <div
+      class="${style.wrapper} ${style.lightWrapper} ${outputOverrideOptions.inheritFont
+        ? style.inheritFont
+        : ''}"
+    >
       <nav class="${style.nav}">
         <ul class="${style.tabs} js-tablist">
           <li>


### PR DESCRIPTION
Added options to enforce use of inherited font for all elements in the widget. Will allow for parent container to dictate the use of font family. If not specified, the default behaviour is to use Roboto which is the default font for the hosted planner web solution (and webshop).

```ts
    const widget = window.PlannerWeb.createWidget({
      urlBase: 'https://reiseplanlegger.example.no/',
      language: 'nn', // supports 'nb', 'nn' and 'en'

      // Optional options
      outputOverrideOptions: {
        // Inherit font from page website.
        // By default it uses Roboto as the hosted planner web solution.
        inheritFont: false,
      },
    });
```

Fixes https://github.com/AtB-AS/kundevendt/issues/18111