### PR TITLE
feat: extend widget with optional single column layout

### DIFF
--- a/src/pages/widget/index.tsx
+++ b/src/pages/widget/index.tsx
@@ -204,8 +204,12 @@ function WidgetContent({
 
         <ul style={{ listStylePosition: 'inside', marginTop: '1rem' }}>
           <li>
-            <code>.widget-inheritFont</code>: Inherit font family from the
-            website
+            <code>.widget-module__inheritFont</code>: Inherit font family from
+            the website
+          </li>
+          <li>
+            <code>.widget-module__singleColumnLayout</code>: Use single column
+            design of widget layout
           </li>
         </ul>
       </div>

--- a/src/pages/widget/index.tsx
+++ b/src/pages/widget/index.tsx
@@ -44,6 +44,8 @@ const initializeCode = html`
         // Inherit font from page website.
         // By default it uses Roboto as the hosted planner web solution.
         inheritFont: false,
+        // Use single column design of widget layout
+        singleColumnLayout: false,
       },
     });
 

--- a/src/widget/widget.module.css
+++ b/src/widget/widget.module.css
@@ -321,14 +321,18 @@
 .messageBox[hidden] {
   display: none;
 }
+
 /**
   * Configurable options for widget
 */
+
+/* Inherit the font from the web page using the widget. */
 .inheritFont,
 .inheritFont * {
   font-family: inherit !important;
 }
 
+/* Change the layout to a single column layout instead of the default layout. */
 .singleColumnLayout .main {
   grid-template-columns: 1fr;
 }

--- a/src/widget/widget.module.css
+++ b/src/widget/widget.module.css
@@ -328,3 +328,13 @@
 .inheritFont * {
   font-family: inherit !important;
 }
+
+.singleColumnLayout .main {
+  grid-template-columns: 1fr;
+}
+.singleColumnLayout .search_container {
+  max-width: unset;
+}
+.singleColumnLayout .selector_options {
+  width: 100%;
+}

--- a/src/widget/widget.ts
+++ b/src/widget/widget.ts
@@ -5,6 +5,7 @@ import type { SearchTime } from '@atb/modules/search-time/types';
 import Combobox from '@github/combobox-nav';
 
 import style from './widget.module.css';
+import { andIf } from '../utils/css';
 
 const DEFAULT_DEBOUNCE_TIME = 300;
 
@@ -723,11 +724,13 @@ function createOutput(
 
   const output = html`
     <div
-      class="${style.wrapper} ${style.lightWrapper} ${outputOverrideOptions.inheritFont
-        ? style.inheritFont
-        : ''} ${outputOverrideOptions.singleColumnLayout
-        ? style.singleColumnLayout
-        : ''}"
+      class="${andIf({
+        [style.wrapper]: true,
+        [style.lightWrapper]: true,
+        [style.inheritFont]: outputOverrideOptions.inheritFont ?? false,
+        [style.singleColumnLayout]:
+          outputOverrideOptions.singleColumnLayout ?? false,
+      })}"
     >
       <nav class="${style.nav}">
         <ul class="${style.tabs} js-tablist">

--- a/src/widget/widget.ts
+++ b/src/widget/widget.ts
@@ -41,6 +41,7 @@ function createSettingsConstants(urlBase: string) {
 
 type OutputOverrideOptions = {
   inheritFont?: boolean;
+  singleColumnLayout?: boolean;
 };
 export type WidgetOptions = {
   urlBase: string;
@@ -62,6 +63,7 @@ export function createWidget({
 
   const defaultOutputOverrideOptions: OutputOverrideOptions = {
     inheritFont: false,
+    singleColumnLayout: false,
     ...outputOverrideOptions,
   };
 
@@ -723,6 +725,8 @@ function createOutput(
     <div
       class="${style.wrapper} ${style.lightWrapper} ${outputOverrideOptions.inheritFont
         ? style.inheritFont
+        : ''} ${outputOverrideOptions.singleColumnLayout
+        ? style.singleColumnLayout
         : ''}"
     >
       <nav class="${style.nav}">


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/18000

### Background

Add the ability to choose a single column type design (enforce mobile view) for the widget.

This is a need sent in by Troms.

#### Illustrations
<details>
<summary>screenshots/video/figma</summary>

![Skjermbilde 2024-05-30 kl  13 08 17](https://github.com/AtB-AS/planner-web/assets/59939294/0e3e1ac7-8004-4af2-8230-4275ff57e83c)r
![Skjermbilde 2024-05-30 kl  13 08 25](https://github.com/AtB-AS/planner-web/assets/59939294/46119fc9-c2f5-4b36-99ab-6e1f9110acfc)



</details>

### Proposed solution

Include `singleColumnLayout` as an optional property to determine whether the widget should be shown in single column layout or not. By default set to false.  

### Acceptance Criteria


- [ ] By default, single column layout is set to false. 
- [ ] Should be possible to switch to single column layout when inspecting widget, by adding copy-pasting the css class `widget-module__singleColumnLayout` straight into the HTML with the element class widget-module__wrapper manually.