### PR TITLE
fix: fix server side redirect error

### DIFF
--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -16,7 +16,12 @@ import { PageText, useTranslation } from '@atb/translations';
 import { FocusScope } from '@react-aria/focus';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useRouter } from 'next/router';
-import { FormEventHandler, PropsWithChildren, useState } from 'react';
+import {
+  FormEventHandler,
+  PropsWithChildren,
+  useEffect,
+  useState,
+} from 'react';
 import style from './assistant.module.css';
 import { FromToTripQuery } from './types';
 import { createTripQuery, setTransportModeFilters } from './utils';
@@ -117,8 +122,14 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
   const { urls, orgId } = getOrgData();
   const { isDarkMode } = useTheme();
 
-  if (tripQuery.transportModeFilter === null)
-    onTransportFilterChanged(setTransportModeFilters(transportModeFilter));
+  useEffect(() => {
+    if (tripQuery.transportModeFilter === null)
+      onTransportFilterChanged(setTransportModeFilters(transportModeFilter));
+  }, [
+    onTransportFilterChanged,
+    transportModeFilter,
+    tripQuery.transportModeFilter,
+  ]);
 
   return (
     <div>

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -122,13 +122,17 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
   const { urls, orgId } = getOrgData();
   const { isDarkMode } = useTheme();
 
+  const isTripQueryTransportModeFilterNull =
+    tripQuery.transportModeFilter === null;
+
   useEffect(() => {
-    if (tripQuery.transportModeFilter === null)
+    if (isTripQueryTransportModeFilterNull) {
       onTransportFilterChanged(setTransportModeFilters(transportModeFilter));
+    }
   }, [
     onTransportFilterChanged,
     transportModeFilter,
-    tripQuery.transportModeFilter,
+    isTripQueryTransportModeFilterNull,
   ]);
 
   return (


### PR DESCRIPTION
Removing the `useEffect` caused the code to run on the server side, causing an error by `next/router` which can only be run on the client side.