### PR TITLE
refactor: parse global messages using zod

### DIFF
--- a/src/modules/global-messages/converters.ts
+++ b/src/modules/global-messages/converters.ts
@@ -17,7 +17,7 @@ export const globalMessageConverter = {
       type: data.type,
       subtle: data.subtle,
       context: data.context,
-      isDismissable: data.isDismissable ?? false,
+      isDismissable: data.isDismissable,
       startDate: firestoreTimestampToDate(data.startDate),
       endDate: firestoreTimestampToDate(data.endDate),
     };

--- a/src/modules/global-messages/converters.ts
+++ b/src/modules/global-messages/converters.ts
@@ -1,50 +1,5 @@
-import { isArray } from 'lodash';
-import { GlobalMessageContextEnum, GlobalMessageType } from './types';
-import { MessageMode } from '@atb/components/message-box';
-import { QueryDocumentSnapshot } from 'firebase/firestore';
-import { LocalizedString } from '@atb/translations/commons';
-
-export function mapToLocalizedStringArray(
-  data: any,
-): LocalizedString[] | undefined {
-  if (!data) return;
-  if (!isArray(data)) return;
-
-  return data
-    .map((ls: any) => mapToLocalizedString(ls))
-    .filter((lv): lv is LocalizedString => !!lv);
-}
-
-function mapToLocalizedString(data: any): LocalizedString | undefined {
-  if (!data) return;
-  if (data.lang != 'nob' && data.lang != 'eng' && data.lang != 'nno') return;
-
-  return {
-    lang: data.lang,
-    value: data.value,
-  };
-}
-
-function mapToContexts(data: any): GlobalMessageContextEnum[] | undefined {
-  if (!isArray(data)) return;
-
-  return data
-    .map((context: any) => mapToContext(context))
-    .filter(Boolean) as GlobalMessageContextEnum[];
-}
-
-function mapToContext(data: any): GlobalMessageContextEnum | undefined {
-  if (!Object.values(GlobalMessageContextEnum).includes(data)) return;
-  return data as GlobalMessageContextEnum;
-}
-
-function mapToMessageType(type: any) {
-  if (typeof type !== 'string') return;
-
-  const options = ['info', 'valid', 'warning', 'error'];
-  if (!options.includes(type)) return;
-  return type as MessageMode;
-}
+import { GlobalMessageType, globalMessageTypeSchema } from './types';
+import { QueryDocumentSnapshot, Timestamp } from 'firebase/firestore';
 
 export const globalMessageConverter = {
   toFirestore(_any: any) {
@@ -54,40 +9,31 @@ export const globalMessageConverter = {
     snapshot: QueryDocumentSnapshot<GlobalMessageType>,
   ): GlobalMessageType | undefined {
     const data = snapshot.data();
+    const potential = {
+      id: snapshot.id,
+      active: data.active,
+      title: data.title,
+      body: data.body,
+      type: data.type,
+      subtle: data.subtle,
+      context: data.context,
+      isDismissable: data.isDismissable ?? false,
+      startDate: firestoreTimestampToDate(data.startDate),
+      endDate: firestoreTimestampToDate(data.endDate),
+    };
 
-    if (!hasNecessaryGlobalMessageTypeFields(data)) {
-      return undefined;
+    const validated = globalMessageTypeSchema.safeParse(potential);
+
+    if (validated.success) {
+      return validated.data;
     }
 
-    const active = data.active;
-    const body = mapToLocalizedStringArray(data.body);
-    const title = mapToLocalizedStringArray(data.title);
-    const context = mapToContexts(data.context);
-    const type = mapToMessageType(data.type);
-    const subtle = data.subtle ?? false;
-    const isDismissable = data.isDismissable ?? false;
-    const startDate = data.startDate;
-    const endDate = data.endDate;
-
-    if (!body || !context || !type) return;
-
-    return {
-      id: snapshot.id,
-      type,
-      subtle,
-      active,
-      context,
-      body,
-      title,
-      isDismissable,
-      startDate,
-      endDate,
-    };
+    return undefined;
   },
 };
 
-function hasNecessaryGlobalMessageTypeFields(data: any) {
-  return (
-    'active' in data && 'body' in data && 'context' in data && 'type' in data
-  );
+function firestoreTimestampToDate(timestamp: any) {
+  if (!timestamp) return;
+  if (!(timestamp instanceof Timestamp)) return;
+  return timestamp.toDate();
 }

--- a/src/modules/global-messages/converters.ts
+++ b/src/modules/global-messages/converters.ts
@@ -33,7 +33,5 @@ export const globalMessageConverter = {
 };
 
 function firestoreTimestampToDate(timestamp: any) {
-  if (!timestamp) return;
-  if (!(timestamp instanceof Timestamp)) return;
-  return timestamp.toDate();
+  return timestamp?.toDate?.();
 }

--- a/src/modules/global-messages/types.ts
+++ b/src/modules/global-messages/types.ts
@@ -18,9 +18,9 @@ export const globalMessageTypeSchema = z.object({
   title: z.array(languageAndTextSchema).optional(),
   body: z.array(languageAndTextSchema),
   type: messageModeSchema,
-  subtle: z.boolean().optional(),
+  subtle: z.boolean().default(false),
   context: z.array(z.nativeEnum(GlobalMessageContextEnum)),
-  isDismissable: z.boolean().optional(),
+  isDismissable: z.boolean().default(false),
   startDate: z.date().optional(),
   endDate: z.date().optional(),
 });

--- a/src/modules/global-messages/types.ts
+++ b/src/modules/global-messages/types.ts
@@ -1,20 +1,28 @@
-import { MessageMode } from '@atb/components/message-box';
-import { LocalizedString } from '@atb/translations/commons';
-import { Timestamp } from 'firebase/firestore';
+import { languageAndTextSchema } from '@atb/translations/types';
+import { z } from 'zod';
+
+const messageModeSchema = z.union([
+  z.literal('info'),
+  z.literal('valid'),
+  z.literal('warning'),
+  z.literal('error'),
+]);
 
 export enum GlobalMessageContextEnum {
   plannerWebAssistant = 'planner-web-assistant',
 }
 
-export type GlobalMessageType = {
-  id: string;
-  active: boolean;
-  title?: LocalizedString[];
-  body: LocalizedString[];
-  type: MessageMode;
-  subtle?: boolean;
-  context: GlobalMessageContextEnum[];
-  isDismissable?: boolean;
-  startDate?: Timestamp;
-  endDate?: Timestamp;
-};
+export const globalMessageTypeSchema = z.object({
+  id: z.string(),
+  active: z.boolean(),
+  title: z.array(languageAndTextSchema).optional(),
+  body: z.array(languageAndTextSchema),
+  type: messageModeSchema,
+  subtle: z.boolean().optional(),
+  context: z.array(z.nativeEnum(GlobalMessageContextEnum)),
+  isDismissable: z.boolean().optional(),
+  startDate: z.date().optional(),
+  endDate: z.date().optional(),
+});
+
+export type GlobalMessageType = z.infer<typeof globalMessageTypeSchema>;


### PR DESCRIPTION
With this PR we start using zod for parsing global messages. I've also updated the `startDate` and `endDate` type to be Date instead of Firestore Timestamp. 

Part of solving https://github.com/AtB-AS/kundevendt/issues/17725