### PR TITLE
fix: let header image navigate to main page

### DIFF
--- a/src/layouts/shared/page-header.tsx
+++ b/src/layouts/shared/page-header.tsx
@@ -9,7 +9,7 @@ import { MonoIcon } from '@atb/components/icon';
 export default function PageHeader() {
   const { t } = useTranslation();
   const [isDarkMode] = useDarkMode();
-  const { fylkeskommune } = getOrgData();
+  const { fylkeskommune, urls } = getOrgData();
 
   return (
     <header className={style.pageHeader}>
@@ -17,8 +17,9 @@ export default function PageHeader() {
         <div className={style.pageHeader__inner}>
           <h1 className={style.pageHeader__logo}>
             <Link
-              href="/"
+              href={urls.homePageUrl.href}
               className={style.pageHeader__logoLink}
+              title={t(CommonText.Layout.homeLink(urls.homePageUrl.name))}
               data-testid="homeButton"
             >
               {fylkeskommune?.replaceTitleWithLogoInHeader ? (

--- a/src/translations/common/layout.ts
+++ b/src/translations/common/layout.ts
@@ -2,6 +2,9 @@ import { translation as _ } from '@atb/translations/commons';
 import { orgSpecificTranslations } from '@atb/translations/utils';
 
 const LayoutInternal = {
+  homeLink: (name: string) =>
+    _(`Tilbake til ${name}`, `Back to ${name}`, `Tilbake til ${name}`),
+
   meta: {
     defaultDescription: _(
       'Finn rutetider, holdeplasser og tilbud for buss, trikk, båt og tog i Trøndelag med reiseplanleggeren.',


### PR DESCRIPTION
After user testing it was hard to find way back even with link. This is quick test/fix to improve that but, long term issue is located at: https://github.com/AtB-AS/kundevendt/issues/18376