### PR TITLE
feat: troms configuration

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,11 +35,11 @@ jobs:
         FRAM_NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=${{ github.event_name == 'release' && 'G-KS45JBFWF4' || '' }}
         TROMS_NEXT_PUBLIC_MAPBOX_DEFAULT_LAT=69.665229
         TROMS_NEXT_PUBLIC_MAPBOX_DEFAULT_LNG=18.9070347
-        TROMS_NEXT_PUBLIC_FIREBASE_PROJECT_ID=${{ github.event_name == 'release' && '' || 'troms-staging'}}
-        TROMS_NEXT_PUBLIC_FIREBASE_PUBLIC_API_KEY=${{ github.event_name == 'release' && '' || 'AIzaSyCtJMximw0SL9N8YNH21TWDO0s_mv_9crE' }}
-        TROMS_NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=${{ github.event_name == 'release' && '' || 'troms-staging.firebaseapp.com' }}
-        TROMS_NEXT_PUBLIC_FIREBASE_APP_ID=${{ github.event_name == 'release' && '' || '1:973624729382:web:a84d8a489613a14be12be7' }}
-        TROMS_NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=''
+        TROMS_NEXT_PUBLIC_FIREBASE_PROJECT_ID=${{ github.event_name == 'release' && 'troms-prod' || 'troms-staging'}}
+        TROMS_NEXT_PUBLIC_FIREBASE_PUBLIC_API_KEY=${{ github.event_name == 'release' && 'AIzaSyAzGgJ8ne8N4CIfASHao3YpOsUvZfOAdiE' || 'AIzaSyCtJMximw0SL9N8YNH21TWDO0s_mv_9crE' }}
+        TROMS_NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=${{ github.event_name == 'release' && 'troms-prod.firebaseapp.com' || 'troms-staging.firebaseapp.com' }}
+        TROMS_NEXT_PUBLIC_FIREBASE_APP_ID=${{ github.event_name == 'release' && '1:667141878008:web:b1a8f3e21716e96e954b0d' || '1:973624729382:web:a84d8a489613a14be12be7' }}
+        TROMS_NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=${{ github.event_name == 'release' && 'G-ZDRTXVTCQD' || '' }}
         NEXT_PUBLIC_ENVIRONMENT=${{ github.event_name == 'release' && 'prod' || 'staging' }}
     secrets:
       github_pat: ${{ secrets.GH_PAT }}

--- a/orgs/troms.json
+++ b/orgs/troms.json
@@ -28,8 +28,8 @@
     "instagramLink": "https://www.instagram.com/troms_fylkestrafikk/",
     "facebookLink": "https://www.facebook.com/tromsfylkestrafikk/",
     "homePageUrl": {
-      "name": "fylkestrafikk.no",
-      "href": "https://www.fylkestrafikk.no/"
+      "name": "svipper.no",
+      "href": "https://www.svipper.no/"
     },
     "ticketsUrl": {
       "en-US": "https://fylkestrafikk.no/meny/billetter-og-priser/?sprak=3",
@@ -40,7 +40,7 @@
     "sitemapUrls": {
       "dev": "http://localhost:3000",
       "staging": "https://troms-staging.planner-web.mittatb.no/",
-      "prod": "https://reise.fylkestrafikk.no/"
+      "prod": "https://reise.svipper.no/"
     }
   },
   "journeyApiConfigurations": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@apollo/client": "^3.9.7",
     "@atb-as/config-specs": "^3.23.0",
-    "@atb-as/theme": "^8.1.0",
+    "@atb-as/theme": "^8.2.2",
     "@github/combobox-nav": "^2.3.1",
     "@isaacs/ttlcache": "^1.4.1",
     "@leile/lobo-t": "^1.0.5",
@@ -64,7 +64,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@atb-as/generate-assets": "^10.1.1",
+    "@atb-as/generate-assets": "^12.1.2",
     "@graphql-codegen/cli": "^5.0.2",
     "@graphql-codegen/near-operation-file-preset": "^3.0.0",
     "@graphql-codegen/typescript": "^4.0.6",

--- a/src/translations/common/titles.ts
+++ b/src/translations/common/titles.ts
@@ -18,9 +18,9 @@ export const Titles = orgSpecificTranslations(TitlesInternal, {
   },
   troms: {
     siteTitle: _(
-      'Troms fylkestrafikk Reisesøk',
-      'Troms fylkestrafikk Travel Search',
-      'Troms fylkestrafikk Reisesøk',
+      'Svipper Reisesøk',
+      'Svipper Travel Search',
+      'Svipper Reisesøk',
     ),
   },
 });

--- a/src/translations/modules/layout.ts
+++ b/src/translations/modules/layout.ts
@@ -114,15 +114,11 @@ export const Layout = orgSpecificTranslations(LayoutInternal, {
       footer: {
         sections: {
           contact: {
-            header: _(
-              'Kontakt Troms fylkestrafikk',
-              'Contact Troms fylkestrafikk',
-              'Kontakt Troms fylkestrafikk',
-            ),
+            header: _('Kontakt Svipper', 'Contact Svipper', 'Kontakt Svipper'),
             contactLink: _(
-              'Kontakt Troms fylkestrafikk',
-              'Contact Troms fylkestrafikk',
-              'Kontakt Troms fylkestrafikk',
+              'Kontakt Svipper',
+              'Contact Svipper',
+              'Kontakt Svipper',
             ),
           },
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -83,22 +83,30 @@
     zod "^3.21.4"
     zod-to-json-schema "^3.20.4"
 
-"@atb-as/generate-assets@^10.1.1":
-  version "10.1.1"
-  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-10.1.1.tgz#8c634026a1b9fb0fc9d535058fa9e1be162909ba"
-  integrity sha512-hYhqluNuql8l+bR47RNIVETsXCNkvyIKHSYW1+Rq/ul/+svrJqZrgJIBdtEZKgb+TRXnyoHaaKM5NAMRxUNELQ==
+"@atb-as/generate-assets@^12.1.2":
+  version "12.1.2"
+  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-12.1.2.tgz#f2542271b42ad08d87ce7a87fd075c100161465c"
+  integrity sha512-mxAbB+CnfmdUQLJ5hzNCu7xyc+rLpQ2AEP21b8+fbkeVjcfhKboG3vym9B6wYGBCdVYjEEbt+bzcSzj7iNNJCw==
   dependencies:
-    "@atb-as/theme" "^8.1.0"
+    "@atb-as/theme" "^10.2.0"
     commander "^9.4.0"
     fast-glob "^3.2.11"
     micromatch "^4.0.5"
     normalize-path "^3.0.0"
     stream-editor "^1.11.0"
 
-"@atb-as/theme@^8.1.0":
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-8.1.0.tgz#b1318b9f4044db319634f230ffa30d1832c22b0f"
-  integrity sha512-vSul0l2HQXz9g3TUXuEFZpggcB03MCTiqR62lVHtTrnTvjAx+VxEUt+xIPXbuDOry9zEWcZiNBUHzLIaNCca1w==
+"@atb-as/theme@^10.2.0":
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-10.2.0.tgz#ab8b1a6143d802b9f3816cec62d92b0e16ea5c08"
+  integrity sha512-afpB55WiXPdw/QlhQ5cikOYcMLyqDWl4W3tK1iJYlU1lBthHZXJoWkgv/8KZ38uAGgf3uNQtgRmBRmGkwspfeQ==
+  dependencies:
+    hex-to-rgba "^2.0.1"
+    ts-deepmerge "^4.0.0"
+
+"@atb-as/theme@^8.2.2":
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-8.2.2.tgz#5f344ef29a29b0c8d14ca20392dba8c819a90bb9"
+  integrity sha512-YENMFdn5Rc6xTdsPz/0udZARsWfp06yMNfwy/eBHTWo/Sf9LpDVdOB0dhPzZKurod1mWI3MjntgHBXn2wxZW4w==
   dependencies:
     hex-to-rgba "^2.0.1"
     ts-deepmerge "^4.0.0"


### PR DESCRIPTION
This PR does 3 things:

1. Add troms-prod firebase configuration
2. Refactor to use the Svipper name
3. Upgrades the assets and theme packages with the latest Svipper changes

There are some issues with the colors and missing illustrations, but after merging this it will be easier for the PO and designer to locate what's missing or need refactoring. 

Partially closes https://github.com/AtB-AS/kundevendt/issues/18397