### PR TITLE
feat: adds maximum interchange wait time to details page. Fixes #18410

### DIFF
--- a/src/page-modules/assistant/details/trip-section/index.tsx
+++ b/src/page-modules/assistant/details/trip-section/index.tsx
@@ -225,6 +225,7 @@ export default function TripSection({
         <InterchangeSection
           interchangeDetails={interchangeDetails}
           publicCode={leg.line?.publicCode}
+          maximumWaitTime={leg.interchangeTo?.maximumWaitTime}
         />
       )}
 

--- a/src/page-modules/assistant/details/trip-section/interchange-section.tsx
+++ b/src/page-modules/assistant/details/trip-section/interchange-section.tsx
@@ -7,6 +7,7 @@ import { getPlaceName } from '../utils';
 import { PageText, useTranslation } from '@atb/translations';
 
 import style from './trip-section.module.css';
+import { secondsToDuration } from '@atb/utils/date';
 
 export type InterchangeDetails = {
   publicCode: string;
@@ -16,43 +17,67 @@ export type InterchangeDetails = {
 export type InterchangeSectionProps = {
   interchangeDetails: InterchangeDetails;
   publicCode?: string | null;
+  maximumWaitTime?: number;
 };
 
-export function InterchangeSection({
-  interchangeDetails,
-  publicCode,
-}: InterchangeSectionProps) {
+export function InterchangeSection(props: InterchangeSectionProps) {
   const { t } = useTranslation();
   const unknownTransportationColor = useTransportationThemeColor({
     transportMode: 'unknown',
     transportSubModes: undefined,
   });
+
+  const message = useInterchangeTextTranslation(props);
+
   return (
     <div className={style.rowContainer}>
       <DecorationLine color={unknownTransportationColor.backgroundColor} />
       <TripRow rowLabel={<MonoIcon icon="actions/Interchange" />}>
-        <MessageBox
-          noStatusIcon
-          type="info"
-          message={
-            publicCode
-              ? t(
-                  PageText.Assistant.details.tripSection.interchange(
-                    publicCode,
-                    interchangeDetails.publicCode,
-                    interchangeDetails.fromPlace,
-                  ),
-                )
-              : t(
-                  PageText.Assistant.details.tripSection.interchangeWithUnknownFromPublicCode(
-                    interchangeDetails.publicCode,
-                    interchangeDetails.fromPlace,
-                  ),
-                )
-          }
-        />
+        <MessageBox noStatusIcon type="info" message={message} />
       </TripRow>
     </div>
+  );
+}
+
+function useInterchangeTextTranslation({
+  publicCode,
+  interchangeDetails,
+  maximumWaitTime,
+}: InterchangeSectionProps) {
+  const { t, language } = useTranslation();
+
+  // If maximum wait time is defined or over 0, append it to the message.
+  const appendWaitTime = (text: string) =>
+    maximumWaitTime
+      ? [
+          text,
+          t(
+            PageText.Assistant.details.tripSection.interchangeMaxWait(
+              secondsToDuration(maximumWaitTime, language),
+            ),
+          ),
+        ].join(' ')
+      : text;
+
+  if (publicCode) {
+    return appendWaitTime(
+      t(
+        PageText.Assistant.details.tripSection.interchange(
+          publicCode,
+          interchangeDetails.publicCode,
+          interchangeDetails.fromPlace,
+        ),
+      ),
+    );
+  }
+
+  return appendWaitTime(
+    t(
+      PageText.Assistant.details.tripSection.interchangeWithUnknownFromPublicCode(
+        interchangeDetails.publicCode,
+        interchangeDetails.fromPlace,
+      ),
+    ),
   );
 }
 

--- a/src/page-modules/assistant/details/trip-section/interchange-section.tsx
+++ b/src/page-modules/assistant/details/trip-section/interchange-section.tsx
@@ -42,13 +42,13 @@ export function InterchangeSection(props: InterchangeSectionProps) {
 function useInterchangeTextTranslation({
   publicCode,
   interchangeDetails,
-  maximumWaitTime,
+  maximumWaitTime = 0,
 }: InterchangeSectionProps) {
   const { t, language } = useTranslation();
 
   // If maximum wait time is defined or over 0, append it to the message.
   const appendWaitTime = (text: string) =>
-    maximumWaitTime
+    maximumWaitTime > 0
       ? [
           text,
           t(

--- a/src/page-modules/assistant/server/journey-planner/index.ts
+++ b/src/page-modules/assistant/server/journey-planner/index.ts
@@ -401,6 +401,7 @@ export function createJourneyApi(
           interchangeTo: leg.interchangeTo?.toServiceJourney?.id
             ? {
                 guaranteed: leg.interchangeTo.guaranteed ?? false,
+                maximumWaitTime: leg.interchangeTo.maximumWaitTime ?? 0,
                 toServiceJourney: {
                   id: leg.interchangeTo.toServiceJourney.id,
                 },

--- a/src/page-modules/assistant/server/journey-planner/journey-gql/trip-with-details.gql
+++ b/src/page-modules/assistant/server/journey-planner/journey-gql/trip-with-details.gql
@@ -97,6 +97,7 @@ query TripsWithDetails(
         }
         interchangeTo {
           guaranteed
+          maximumWaitTime
           toServiceJourney {
             id
           }

--- a/src/page-modules/assistant/server/journey-planner/journey-gql/via-trip-with-details.gql
+++ b/src/page-modules/assistant/server/journey-planner/journey-gql/via-trip-with-details.gql
@@ -86,6 +86,7 @@ query ViaTripsWithDetails(
           }
           interchangeTo {
             guaranteed
+            maximumWaitTime
             toServiceJourney {
               id
             }

--- a/src/page-modules/assistant/server/journey-planner/validators.ts
+++ b/src/page-modules/assistant/server/journey-planner/validators.ts
@@ -138,6 +138,7 @@ export const tripPatternWithDetailsSchema = z.object({
       interchangeTo: z
         .object({
           guaranteed: z.boolean(),
+          maximumWaitTime: z.number(),
           toServiceJourney: z.object({ id: z.string() }),
         })
         .nullable(),

--- a/src/translations/pages/assistant.ts
+++ b/src/translations/pages/assistant.ts
@@ -401,6 +401,12 @@ const AssistantInternal = {
           `Correspondance with ${toPublicCode} on ${location}.`,
           `Korrespondanse med ${toPublicCode} på ${location}.`,
         ),
+      interchangeMaxWait: (maxWaitTime: string) =>
+        _(
+          `Venter inntil ${maxWaitTime}.`,
+          `Waiting up to ${maxWaitTime}.`,
+          `Ventar i opp til ${maxWaitTime}.`,
+        ),
       wait: {
         label: (time: string) =>
           _(`Vent i ${time}`, `Wait for ${time}`, `Vent i ${time}`),


### PR DESCRIPTION
Fixes https://github.com/AtB-AS/kundevendt/issues/18410

I'm unsure whether or not to actually handle the null case or just treat it as 0. But for now, if the max wait time is 0 we just treat it as not defined. 🤔 Open to actually handle it explicitly though.

![Screenshot 2024-06-24 at 19 39 54](https://github.com/AtB-AS/planner-web/assets/606374/605c4ff0-5645-4136-93f0-d4cf98385e04)
