### PR TITLE
style: make the message box border 2px

### DIFF
--- a/src/components/message-box/message-box.module.css
+++ b/src/components/message-box/message-box.module.css
@@ -1,7 +1,7 @@
 .container {
   display: flex;
   padding: var(--spacings-medium);
-  border: 1px solid;
+  border: var(--border-width-medium) solid;
 }
 .borderRadius {
   border-radius: var(--border-radius-regular);


### PR DESCRIPTION
According to the design in Figma, the message box border should be 2px and not 1px.