### PR TITLE
fix: show correct day label for trip results

### DIFF
--- a/src/page-modules/assistant/trip/index.tsx
+++ b/src/page-modules/assistant/trip/index.tsx
@@ -50,13 +50,13 @@ export default function Trip({ tripQuery, fallback }: TripProps) {
         details={
           tripQuery.transportModeFilter || tripQuery.lineFilter
             ? t(
-              PageText.Assistant.trip.emptySearchResults
-                .emptySearchResultsDetailsWithFilters,
-            )
+                PageText.Assistant.trip.emptySearchResults
+                  .emptySearchResultsDetailsWithFilters,
+              )
             : t(
-              PageText.Assistant.trip.emptySearchResults
-                .emptySearchResultsDetails,
-            )
+                PageText.Assistant.trip.emptySearchResults
+                  .emptySearchResultsDetails,
+              )
         }
       />
     );
@@ -68,12 +68,22 @@ export default function Trip({ tripQuery, fallback }: TripProps) {
   ): string | undefined => {
     if (!trips) return undefined;
     if (tripIndex === 0 && patternIndex === 0) return undefined;
+
     if (patternIndex === 0) {
-      return trips[tripIndex - 1]?.tripPatterns[
-        trips[tripIndex - 1]?.tripPatterns.length - 1
-      ]?.expectedStartTime;
+      // Iterate backwards to find the first trip with a non-empty tripPatterns list
+      for (let i = tripIndex - 1; i >= 0; i--) {
+        const previousTrip = trips[i];
+        if (previousTrip.tripPatterns.length > 0) {
+          return previousTrip.tripPatterns[previousTrip.tripPatterns.length - 1]
+            ?.expectedStartTime;
+        }
+      }
+      // If no previous trip with non-empty tripPatterns is found
+      return undefined;
+    } else {
+      // Return the expectedStartTime of the previous pattern in the current trip
+      return trips[tripIndex].tripPatterns[patternIndex - 1]?.expectedStartTime;
     }
-    return trips[tripIndex].tripPatterns[patternIndex - 1]?.expectedStartTime;
   };
 
   return (

--- a/src/page-modules/assistant/trip/index.tsx
+++ b/src/page-modules/assistant/trip/index.tsx
@@ -79,7 +79,7 @@ export default function Trip({ tripQuery, fallback }: TripProps) {
         }
       }
       // If no previous trip with non-empty tripPatterns is found
-      return undefined;
+      return;
     } else {
       // Return the expectedStartTime of the previous pattern in the current trip
       return trips[tripIndex].tripPatterns[patternIndex - 1]?.expectedStartTime;


### PR DESCRIPTION
For some trips, when the previous page has an empty trip pattern list, the day label is wrong (see screenshot). This PR updates the `getPreviousDepartureTime` function to take that into account and fix this bug. 

<details>
<summary>Screenshots</summary>

**Before**

<img width="1020" alt="image" src="https://github.com/AtB-AS/planner-web/assets/43166974/10ba17fc-1d14-4668-99bb-dfd8dd9d0f63">

**After**

<img width="1041" alt="image" src="https://github.com/AtB-AS/planner-web/assets/43166974/4484fd79-44db-405f-8327-35ec5bf9f878">

</details>