### PR TITLE
fix: add condition to check whether passengers should stay seated between leg interchanges.   

### DIFF
--- a/src/page-modules/assistant/details/trip-section/index.tsx
+++ b/src/page-modules/assistant/details/trip-section/index.tsx
@@ -226,6 +226,7 @@ export default function TripSection({
           interchangeDetails={interchangeDetails}
           publicCode={leg.line?.publicCode}
           maximumWaitTime={leg.interchangeTo?.maximumWaitTime}
+          staySeated={leg.interchangeTo?.staySeated}
         />
       )}
 

--- a/src/page-modules/assistant/details/trip-section/interchange-section.tsx
+++ b/src/page-modules/assistant/details/trip-section/interchange-section.tsx
@@ -18,6 +18,7 @@ export type InterchangeSectionProps = {
   interchangeDetails: InterchangeDetails;
   publicCode?: string | null;
   maximumWaitTime?: number;
+  staySeated: boolean | undefined;
 };
 
 export function InterchangeSection(props: InterchangeSectionProps) {
@@ -43,6 +44,7 @@ function useInterchangeTextTranslation({
   publicCode,
   interchangeDetails,
   maximumWaitTime = 0,
+  staySeated,
 }: InterchangeSectionProps) {
   const { t, language } = useTranslation();
 
@@ -59,6 +61,16 @@ function useInterchangeTextTranslation({
         ].join(' ')
       : text;
 
+  if (publicCode && staySeated) {
+    return appendWaitTime(
+      t(
+        PageText.Assistant.details.tripSection.lineChangeStaySeated(
+          interchangeDetails.publicCode,
+          publicCode,
+        ),
+      ),
+    );
+  }
   if (publicCode) {
     return appendWaitTime(
       t(

--- a/src/page-modules/assistant/details/trip-section/interchange-section.tsx
+++ b/src/page-modules/assistant/details/trip-section/interchange-section.tsx
@@ -18,7 +18,7 @@ export type InterchangeSectionProps = {
   interchangeDetails: InterchangeDetails;
   publicCode?: string | null;
   maximumWaitTime?: number;
-  staySeated: boolean | undefined;
+  staySeated: boolean | undefined | null;
 };
 
 export function InterchangeSection(props: InterchangeSectionProps) {

--- a/src/page-modules/assistant/server/journey-planner/index.ts
+++ b/src/page-modules/assistant/server/journey-planner/index.ts
@@ -402,6 +402,7 @@ export function createJourneyApi(
             ? {
                 guaranteed: leg.interchangeTo.guaranteed ?? false,
                 maximumWaitTime: leg.interchangeTo.maximumWaitTime ?? 0,
+                staySeated: leg.interchangeTo.staySeated,
                 toServiceJourney: {
                   id: leg.interchangeTo.toServiceJourney.id,
                 },

--- a/src/page-modules/assistant/server/journey-planner/index.ts
+++ b/src/page-modules/assistant/server/journey-planner/index.ts
@@ -565,6 +565,11 @@ function mapResultToTrips(
                   : null,
               }
             : null,
+          interchangeTo: leg.interchangeTo?.staySeated
+            ? {
+                staySeated: leg.interchangeTo.staySeated,
+              }
+            : null,
         };
       }),
       compressedQuery: generateSingleTripQueryString(

--- a/src/page-modules/assistant/server/journey-planner/journey-gql/trip-with-details.gql
+++ b/src/page-modules/assistant/server/journey-planner/journey-gql/trip-with-details.gql
@@ -98,6 +98,7 @@ query TripsWithDetails(
         interchangeTo {
           guaranteed
           maximumWaitTime
+          staySeated
           toServiceJourney {
             id
           }

--- a/src/page-modules/assistant/server/journey-planner/journey-gql/trip.gql
+++ b/src/page-modules/assistant/server/journey-planner/journey-gql/trip.gql
@@ -149,6 +149,9 @@ fragment tripPattern on TripPattern {
       }
     }
     transportSubmode
+    interchangeTo {
+      staySeated
+    }
   }
 }
 

--- a/src/page-modules/assistant/server/journey-planner/journey-gql/via-trip-with-details.gql
+++ b/src/page-modules/assistant/server/journey-planner/journey-gql/via-trip-with-details.gql
@@ -87,6 +87,7 @@ query ViaTripsWithDetails(
           interchangeTo {
             guaranteed
             maximumWaitTime
+            staySeated
             toServiceJourney {
               id
             }

--- a/src/page-modules/assistant/server/journey-planner/validators.ts
+++ b/src/page-modules/assistant/server/journey-planner/validators.ts
@@ -145,6 +145,7 @@ export const tripPatternWithDetailsSchema = z.object({
         .object({
           guaranteed: z.boolean(),
           maximumWaitTime: z.number(),
+          staySeated: z.boolean().optional(),
           toServiceJourney: z.object({ id: z.string() }),
         })
         .nullable(),

--- a/src/page-modules/assistant/server/journey-planner/validators.ts
+++ b/src/page-modules/assistant/server/journey-planner/validators.ts
@@ -58,6 +58,12 @@ export const legSchema = z.object({
   situations: z.array(situationSchema),
   fromPlace: placeSchema,
   serviceJourney: serviceJourneySchema.nullable(),
+  interchangeTo: z
+    .object({
+      staySeated: z.boolean().nullable(),
+    })
+    .nullable()
+    .optional(),
 });
 
 export const tripPatternSchema = z.object({

--- a/src/page-modules/assistant/trip/trip-pattern/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/index.tsx
@@ -71,6 +71,18 @@ export default function TripPattern({
     [style['tripPattern--old']]: tripIsInPast,
   });
 
+  const staySeated = (idx: number) =>
+    expandedLegs[idx].interchangeTo?.staySeated === true;
+
+  const shouldHaveRemainedSeatedInPreviousLeg = (idx: number) => {
+    if (idx > 0) return staySeated(idx - 1);
+    return false;
+  };
+
+  const isNotLastLeg = (i: number) => {
+    return i < expandedLegs.length - 1 || collapsedLegs.length > 0;
+  };
+
   return (
     <motion.a
       href={`/assistant/${tripPattern.compressedQuery}?filter=${router.query.filter}`}
@@ -98,9 +110,7 @@ export default function TripPattern({
           <div className={style.legs__expandedLegs} ref={legsContentRef}>
             {expandedLegs.map((leg, i) => (
               <Fragment key={`leg-${leg.expectedStartTime}-${i}`}>
-                {i > 0 &&
-                expandedLegs[i - 1].interchangeTo?.staySeated ===
-                  true ? null : (
+                {shouldHaveRemainedSeatedInPreviousLeg(i) ? null : (
                   <div className={style.legs__leg}>
                     {leg.mode ? (
                       <TransportIconWithLabel
@@ -164,13 +174,12 @@ export default function TripPattern({
                   </div>
                 )}
 
-                {(i < expandedLegs.length - 1 || collapsedLegs.length > 0) &&
-                  expandedLegs[i].interchangeTo?.staySeated !== true && (
-                    <div className={style.legs__legLineContainer}>
-                      <div className={style.legs__legLine} />
-                      <div className={style.legs__legLine} />
-                    </div>
-                  )}
+                {isNotLastLeg(i) && !staySeated(i) && (
+                  <div className={style.legs__legLineContainer}>
+                    <div className={style.legs__legLine} />
+                    <div className={style.legs__legLine} />
+                  </div>
+                )}
               </Fragment>
             ))}
 

--- a/src/page-modules/assistant/trip/trip-pattern/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/index.tsx
@@ -98,66 +98,79 @@ export default function TripPattern({
           <div className={style.legs__expandedLegs} ref={legsContentRef}>
             {expandedLegs.map((leg, i) => (
               <Fragment key={`leg-${leg.expectedStartTime}-${i}`}>
-                <div className={style.legs__leg}>
-                  {leg.mode ? (
-                    <TransportIconWithLabel
-                      mode={{
-                        transportMode: leg.mode,
-                        transportSubModes: leg.transportSubmode
-                          ? [leg.transportSubmode]
-                          : undefined,
-                      }}
-                      label={leg.line?.publicCode ?? undefined}
-                      duration={leg.mode === 'foot' ? leg.duration : undefined}
-                      isFlexible={isLineFlexibleTransport(leg.line)}
-                    />
-                  ) : (
-                    <div className={style.legs__leg__walkIcon}>
-                      <MonoIcon icon="transportation/Walk" />
-                    </div>
-                  )}
+                {i > 0 &&
+                expandedLegs[i - 1].interchangeTo?.staySeated ===
+                  true ? null : (
+                  <div className={style.legs__leg}>
+                    {leg.mode ? (
+                      <TransportIconWithLabel
+                        mode={{
+                          transportMode: leg.mode,
+                          transportSubModes: leg.transportSubmode
+                            ? [leg.transportSubmode]
+                            : undefined,
+                        }}
+                        label={leg.line?.publicCode ?? undefined}
+                        duration={
+                          leg.mode === 'foot' ? leg.duration : undefined
+                        }
+                        isFlexible={isLineFlexibleTransport(leg.line)}
+                      />
+                    ) : (
+                      <div className={style.legs__leg__walkIcon}>
+                        <MonoIcon icon="transportation/Walk" />
+                      </div>
+                    )}
 
-                  <div
-                    className={style.timeStartContainer}
-                    data-testid={`timeStartContainer-${i}`}
-                  >
-                    {secondsBetween(leg.aimedStartTime, leg.expectedStartTime) >
-                    DEFAULT_THRESHOLD_AIMED_EXPECTED_IN_SECONDS ? (
-                      <>
-                        <Typo.span textType="body__tertiary">
-                          {formatToClock(
-                            leg.expectedStartTime,
-                            language,
-                            'floor',
-                          )}
-                        </Typo.span>
+                    <div
+                      className={style.timeStartContainer}
+                      data-testid={`timeStartContainer-${i}`}
+                    >
+                      {secondsBetween(
+                        leg.aimedStartTime,
+                        leg.expectedStartTime,
+                      ) > DEFAULT_THRESHOLD_AIMED_EXPECTED_IN_SECONDS ? (
+                        <>
+                          <Typo.span textType="body__tertiary">
+                            {formatToClock(
+                              leg.expectedStartTime,
+                              language,
+                              'floor',
+                            )}
+                          </Typo.span>
+                          <Typo.span
+                            textType="body__tertiary--strike"
+                            className={style.outdatet}
+                          >
+                            {formatToClock(
+                              leg.aimedStartTime,
+                              language,
+                              'floor',
+                            )}
+                          </Typo.span>
+                        </>
+                      ) : (
                         <Typo.span
-                          textType="body__tertiary--strike"
-                          className={style.outdatet}
+                          textType={
+                            isCancelled
+                              ? 'body__tertiary--strike'
+                              : 'body__tertiary'
+                          }
                         >
                           {formatToClock(leg.aimedStartTime, language, 'floor')}
                         </Typo.span>
-                      </>
-                    ) : (
-                      <Typo.span
-                        textType={
-                          isCancelled
-                            ? 'body__tertiary--strike'
-                            : 'body__tertiary'
-                        }
-                      >
-                        {formatToClock(leg.aimedStartTime, language, 'floor')}
-                      </Typo.span>
-                    )}
-                  </div>
-                </div>
-
-                {(i < expandedLegs.length - 1 || collapsedLegs.length > 0) && (
-                  <div className={style.legs__legLineContainer}>
-                    <div className={style.legs__legLine} />
-                    <div className={style.legs__legLine} />
+                      )}
+                    </div>
                   </div>
                 )}
+
+                {(i < expandedLegs.length - 1 || collapsedLegs.length > 0) &&
+                  expandedLegs[i].interchangeTo?.staySeated !== true && (
+                    <div className={style.legs__legLineContainer}>
+                      <div className={style.legs__legLine} />
+                      <div className={style.legs__legLine} />
+                    </div>
+                  )}
               </Fragment>
             ))}
 

--- a/src/page-modules/assistant/trip/trip-pattern/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/index.tsx
@@ -71,12 +71,9 @@ export default function TripPattern({
     [style['tripPattern--old']]: tripIsInPast,
   });
 
-  const staySeated = (idx: number) =>
-    expandedLegs[idx].interchangeTo?.staySeated === true;
-
-  const shouldHaveRemainedSeatedInPreviousLeg = (idx: number) => {
-    if (idx > 0) return staySeated(idx - 1);
-    return false;
+  const staySeated = (idx: number) => {
+    const leg = expandedLegs[idx];
+    return leg && leg.interchangeTo?.staySeated === true;
   };
 
   const isNotLastLeg = (i: number) => {
@@ -110,7 +107,7 @@ export default function TripPattern({
           <div className={style.legs__expandedLegs} ref={legsContentRef}>
             {expandedLegs.map((leg, i) => (
               <Fragment key={`leg-${leg.expectedStartTime}-${i}`}>
-                {shouldHaveRemainedSeatedInPreviousLeg(i) ? null : (
+                {staySeated(i - 1) ? null : (
                   <div className={style.legs__leg}>
                     {leg.mode ? (
                       <TransportIconWithLabel

--- a/src/translations/pages/assistant.ts
+++ b/src/translations/pages/assistant.ts
@@ -457,6 +457,12 @@ const AssistantInternal = {
             `Kva er ${publicCode}?`,
           ),
       },
+      lineChangeStaySeated: (fromPublicCode: string, toPublicCode: string) =>
+        _(
+          `Bli sittende. Linjenummeret endres fra ${fromPublicCode} til ${toPublicCode}.`,
+          `Stay seated. The line number is changing from ${fromPublicCode} to ${toPublicCode}.`,
+          `Bli sittande. Linjenummeret endrar seg frå ${fromPublicCode} til ${toPublicCode}.`,
+        ),
     },
     ticketBooking: {
       globalMessage: _(


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/18588

### Background
Currently, the way a bus line change a during a trip is displayed as there is also conducted a bus change. This can be confusing and might lead to customers to get of the bus when thei are supposed to stay seated.

Entur displays this differently, where only the waiting time is stated in the stop details so that there is no misunderstanding among customers who might jump off and wait for the next bus

#### Illustrations
<details>
<summary>screenshots/trip</summary>

Planner Web currently:
<img width="936" alt="Skjermbilde 2024-07-12 kl  11 20 30" src="https://github.com/user-attachments/assets/dfd399c4-4faa-4b6d-9223-54f0b349f790">


Entur:
![Skjermbilde 2024-07-12 kl  11 52 42](https://github.com/user-attachments/assets/d5f57a0c-b252-4d4d-a086-ce452128fdff)


After this PR:
<img width="963" alt="Skjermbilde 2024-07-12 kl  11 17 09" src="https://github.com/user-attachments/assets/e2d894f5-9519-47f9-8bb5-dd62d9ef2546">


</details>

<details>
<summary>screenshots/trip-details-view</summary>

Planner Web currently:
<img width="395" alt="Skjermbilde 2024-07-12 kl  12 02 50" src="https://github.com/user-attachments/assets/a425b022-481f-4bdb-8e02-a0a02a229fbb">


Entur:
![Skjermbilde 2024-07-12 kl  12 02 02](https://github.com/user-attachments/assets/c90af0d2-90d8-4f46-af59-5b49146b18db)



After this PR:
![Skjermbilde 2024-07-12 kl  15 38 35](https://github.com/user-attachments/assets/1868eb2b-2b28-4ba5-8e59-558a35680614)


</details>

### Proposed solution

Extend trip schema with with the property staySeated to check whether passengers should stay seated or not during interchanges between two legs.


### Acceptance Criteria

- [ ] This update should not affect how any trips are being displayed other than the one where `staySeated: true`.  

### Test input
- [ ] Some trips from Mosjøen sentrum to Søvik are lines where  `staySeated: true`.  