### PR TITLE
fix: display departures in CET instead of local time 

### DIFF
--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -289,7 +289,7 @@ export function formatToClockOrRelativeMinutes(
   const diff = secondsBetween(new Date(), parsed);
 
   if (diff / 60 >= minuteThreshold) {
-    return formatLocaleTime(parsed, language);
+    return formatLocaleTime(setTimezone(parsed), language);
   }
 
   if (diff / 60 <= 1) {


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/18697

### What is wrong, and what is expected behavior?

When in another timezone, departures from a stop place are displayed in local time instead of in CET. These departures should always be displayed in CET. 

### How to replicate:
- Change the local timezone on your computer.
- Search after a stop place in departures. 

### Illustration before fix
<details>
<Summary>screenshots/vid
<img width="1356" alt="Skjermbilde 2024-07-31 kl  05 45 42" src="https://github.com/user-attachments/assets/4d5b751e-7eae-4a99-9cf9-d39e142c1d87">
eo</Summary>

</details>

### Illustration after fix
<details>
<Summary>screenshots/video</Summary>
<img width="1354" alt="Skjermbilde 2024-07-31 kl  05 26 20" src="https://github.com/user-attachments/assets/3fe34f3d-ce49-4ac6-89ec-fefd8b170f27">

</details>

### Solution
Update formatToClockOrRelativeMinutes to take time zone of user into account. 

### Acceptance criteria
- [ ] Display departures in CET.