### PR TITLE
feat: extend notices to inform users about the need to contact the relevant authorities to carry out certain trips

### DIFF
--- a/src/page-modules/assistant/server/journey-planner/index.ts
+++ b/src/page-modules/assistant/server/journey-planner/index.ts
@@ -397,6 +397,11 @@ export function createJourneyApi(
                   : {}),
               }
             : null,
+          toEstimatedCall: leg.toEstimatedCall?.notices.length
+            ? {
+                notices: mapAndFilterNotices(leg.toEstimatedCall.notices),
+              }
+            : null,
 
           interchangeTo: leg.interchangeTo?.toServiceJourney?.id
             ? {
@@ -415,6 +420,7 @@ export function createJourneyApi(
             ...(leg.serviceJourney?.notices || []),
             ...(leg.serviceJourney?.journeyPattern?.notices || []),
             ...(leg.fromEstimatedCall?.notices || []),
+            ...(leg.toEstimatedCall?.notices || []),
           ]),
           situations: mapSituations(leg.situations),
           serviceJourneyEstimatedCalls: leg.serviceJourneyEstimatedCalls.map(

--- a/src/page-modules/assistant/server/journey-planner/journey-gql/trip-with-details.gql
+++ b/src/page-modules/assistant/server/journey-planner/journey-gql/trip-with-details.gql
@@ -95,6 +95,11 @@ query TripsWithDetails(
           }
           cancellation
         }
+        toEstimatedCall {
+          notices {
+            ...notice
+          }
+        }
         interchangeTo {
           guaranteed
           maximumWaitTime

--- a/src/page-modules/assistant/server/journey-planner/journey-gql/via-trip-with-details.gql
+++ b/src/page-modules/assistant/server/journey-planner/journey-gql/via-trip-with-details.gql
@@ -84,6 +84,11 @@ query ViaTripsWithDetails(
             }
             cancellation
           }
+          toEstimatedCall {
+            notices {
+              ...notice
+            }
+          }
           interchangeTo {
             guaranteed
             maximumWaitTime

--- a/src/page-modules/assistant/server/journey-planner/validators.ts
+++ b/src/page-modules/assistant/server/journey-planner/validators.ts
@@ -141,6 +141,11 @@ export const tripPatternWithDetailsSchema = z.object({
           cancellation: z.boolean(),
         })
         .nullable(),
+      toEstimatedCall: z
+        .object({
+          notices: z.array(noticeSchema),
+        })
+        .nullable(),
       interchangeTo: z
         .object({
           guaranteed: z.boolean(),


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/4203

### Background
It seems that the app is currently not handling notices on the EstimatedCall on which a trip ends: https://github.com/AtB-AS/mittatb-app/blob/51ea34a7b69f8aca381aac5ffc94fa36a88086ae/src/travel-details-screens/utils.ts#L44-L50

#### Illustrations
<details>
<summary>screenshots/video/figma</summary>
<img width="918" alt="Skjermbilde 2024-08-13 kl  14 58 32" src="https://github.com/user-attachments/assets/1ba50f8d-94e9-4542-962d-0da5a9d4eb03">
<img width="937" alt="Skjermbilde 2024-08-13 kl  14 58 40" src="https://github.com/user-attachments/assets/35c027ac-027d-4002-9017-f8f7a32043d7">
</details>

### Proposed solution
To solve, we should probably extend the code above to also include notices from ToEstimatedCall.

### Acceptance Criteria
- [ ] Notices from estimated call are displayed. 

### Test input
- [ ] Tromsø Prostneset hurtigbåtkai - Lauksundskaret ferjekai
- [ ] Terråk hurtigbåtkai - Skotnes hurtigbåtkai