### PR TITLE
refactor: initialize map on mobile devices when opened

### DIFF
--- a/src/components/map/map.tsx
+++ b/src/components/map/map.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useCallback } from 'react';
 import mapboxgl from 'mapbox-gl';
 import style from './map.module.css';
 import 'mapbox-gl/dist/mapbox-gl.css';
@@ -50,7 +50,7 @@ export default function Map({ layer, onSelectStopPlace, ...props }: MapProps) {
     : { position: defaultPosition, initialZoom: ZOOM_LEVEL };
   const bounds = mapLegs ? getMapBounds(mapLegs) : undefined;
 
-  const initializeMap = () => {
+  const initializeMap = useCallback(() => {
     if (!mapContainer.current || map.current) return;
     // If browsers doesn't support WebGL, don't initialize map
     if (!mapboxgl.supported()) return;
@@ -62,7 +62,7 @@ export default function Map({ layer, onSelectStopPlace, ...props }: MapProps) {
       zoom: initialZoom,
       bounds, // If bounds is specified, it overrides center and zoom constructor options.
     });
-  };
+  }, [position, initialZoom, bounds]);
 
   useEffect(() => {
     if (isMobileDevice) return;
@@ -79,6 +79,12 @@ export default function Map({ layer, onSelectStopPlace, ...props }: MapProps) {
   useMapPin(map, position, layer);
   useMapLegs(map, mapLegs);
   useMapTariffZones(map);
+
+  useEffect(() => {
+    if (!isMobileDevice) {
+      initializeMap();
+    }
+  }, [isMobileDevice, initializeMap]);
 
   return (
     <div className={style.map} aria-hidden="true">

--- a/src/components/map/use-fullscreen-map.ts
+++ b/src/components/map/use-fullscreen-map.ts
@@ -3,10 +3,12 @@ import { useCallback, useEffect, useState } from 'react';
 export const useFullscreenMap = (
   mapWrapperRef: React.MutableRefObject<HTMLDivElement | null>,
   mapRef: React.MutableRefObject<mapboxgl.Map | undefined>,
+  initializeMap: () => void,
 ) => {
   const [isFullscreen, setIsFullscreen] = useState<boolean>(false);
 
   const openFullscreen = () => {
+    initializeMap();
     if (!mapWrapperRef.current || !mapRef.current) return;
     mapWrapperRef.current.style.display = 'block';
     mapRef.current.resize();

--- a/src/layouts/shared/menu-utils.tsx
+++ b/src/layouts/shared/menu-utils.tsx
@@ -1,6 +1,7 @@
-import {and} from '@atb/utils/css';
-import {MutableRefObject, useCallback, useEffect, useState} from 'react';
+import { and } from '@atb/utils/css';
+import { MutableRefObject, useCallback, useEffect, useState } from 'react';
 import style from './page-header.module.css';
+import useMediaQuery from '@atb/utils/user-media-query';
 
 export function Hamburger({
   isOpen,
@@ -128,48 +129,4 @@ export function useTogglableBurgerMenu<
     setMenuVisible,
     tabIndex,
   };
-}
-
-function hasWindow() {
-  return typeof window !== 'undefined';
-}
-
-const useMediaQuery = (mediaQuery: string) => {
-  const [isMatched, setMatched] = useState(() => {
-    if (!hasWindow()) return false;
-    return Boolean(window.matchMedia(mediaQuery).matches);
-  });
-
-  useEffect(() => {
-    if (!hasWindow()) return;
-    const mediaQueryList = window.matchMedia(mediaQuery);
-    const documentChangeHandler = () =>
-      setMatched(Boolean(mediaQueryList.matches));
-    listenTo(mediaQueryList, documentChangeHandler);
-
-    documentChangeHandler();
-    return () => removeListener(mediaQueryList, documentChangeHandler);
-  }, [mediaQuery]);
-
-  return isMatched;
-};
-
-function listenTo(
-  matcher: MediaQueryList,
-  cb: (ev: MediaQueryListEvent) => void,
-) {
-  if ('addEventListener' in (matcher as any)) {
-    return matcher.addEventListener('change', cb);
-  }
-  return matcher.addListener(cb);
-}
-
-function removeListener(
-  matcher: MediaQueryList,
-  cb: (ev: MediaQueryListEvent) => void,
-) {
-  if ('removeEventListener' in (matcher as any)) {
-    return matcher.removeEventListener('change', cb);
-  }
-  return matcher.removeListener(cb);
 }

--- a/src/utils/user-media-query.ts
+++ b/src/utils/user-media-query.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+
+export default function useMediaQuery(mediaQuery: string) {
+  const [isMatched, setMatched] = useState(() => {
+    if (!hasWindow()) return false;
+    return Boolean(window.matchMedia(mediaQuery).matches);
+  });
+
+  useEffect(() => {
+    if (!hasWindow()) return;
+    const mediaQueryList = window.matchMedia(mediaQuery);
+    const documentChangeHandler = () =>
+      setMatched(Boolean(mediaQueryList.matches));
+    listenTo(mediaQueryList, documentChangeHandler);
+
+    documentChangeHandler();
+    return () => removeListener(mediaQueryList, documentChangeHandler);
+  }, [mediaQuery]);
+
+  return isMatched;
+}
+
+function hasWindow() {
+  return typeof window !== 'undefined';
+}
+
+function listenTo(
+  matcher: MediaQueryList,
+  cb: (ev: MediaQueryListEvent) => void,
+) {
+  if ('addEventListener' in (matcher as any)) {
+    return matcher.addEventListener('change', cb);
+  }
+  return matcher.addListener(cb);
+}
+
+function removeListener(
+  matcher: MediaQueryList,
+  cb: (ev: MediaQueryListEvent) => void,
+) {
+  if ('removeEventListener' in (matcher as any)) {
+    return matcher.removeEventListener('change', cb);
+  }
+  return matcher.removeListener(cb);
+}


### PR DESCRIPTION
While looking into the excessive Mapbox loads, I found that a significant majority of our users are accessing the site on mobile devices (over 65% for FRAM). On mobile devices, the map isn't displayed until the user clicks the "Open in Fullscreen" option. However, we're currently initializing the map as soon as the page loads, even though it's not visible. This PR optimizes the process by delaying the map's initialization until it is actually opened in fullscreen, which should help reduce our costs.

Part of https://github.com/AtB-AS/kundevendt/issues/18810