### PR TITLE
Revert "Extend notifications to include behovsanlop. (#320)"

### DIFF
--- a/src/page-modules/assistant/server/journey-planner/index.ts
+++ b/src/page-modules/assistant/server/journey-planner/index.ts
@@ -397,11 +397,6 @@ export function createJourneyApi(
                   : {}),
               }
             : null,
-          toEstimatedCall: leg.toEstimatedCall?.notices.length
-            ? {
-                notices: mapAndFilterNotices(leg.toEstimatedCall.notices),
-              }
-            : null,
 
           interchangeTo: leg.interchangeTo?.toServiceJourney?.id
             ? {
@@ -420,7 +415,6 @@ export function createJourneyApi(
             ...(leg.serviceJourney?.notices || []),
             ...(leg.serviceJourney?.journeyPattern?.notices || []),
             ...(leg.fromEstimatedCall?.notices || []),
-            ...(leg.toEstimatedCall?.notices || []),
           ]),
           situations: mapSituations(leg.situations),
           serviceJourneyEstimatedCalls: leg.serviceJourneyEstimatedCalls.map(

--- a/src/page-modules/assistant/server/journey-planner/journey-gql/trip-with-details.gql
+++ b/src/page-modules/assistant/server/journey-planner/journey-gql/trip-with-details.gql
@@ -95,11 +95,6 @@ query TripsWithDetails(
           }
           cancellation
         }
-        toEstimatedCall {
-          notices {
-            ...notice
-          }
-        }
         interchangeTo {
           guaranteed
           maximumWaitTime

--- a/src/page-modules/assistant/server/journey-planner/journey-gql/via-trip-with-details.gql
+++ b/src/page-modules/assistant/server/journey-planner/journey-gql/via-trip-with-details.gql
@@ -84,11 +84,6 @@ query ViaTripsWithDetails(
             }
             cancellation
           }
-          toEstimatedCall {
-            notices {
-              ...notice
-            }
-          }
           interchangeTo {
             guaranteed
             maximumWaitTime

--- a/src/page-modules/assistant/server/journey-planner/validators.ts
+++ b/src/page-modules/assistant/server/journey-planner/validators.ts
@@ -141,11 +141,6 @@ export const tripPatternWithDetailsSchema = z.object({
           cancellation: z.boolean(),
         })
         .nullable(),
-      toEstimatedCall: z
-        .object({
-          notices: z.array(noticeSchema),
-        })
-        .nullable(),
       interchangeTo: z
         .object({
           guaranteed: z.boolean(),


### PR DESCRIPTION
This reverts commit 94660fd36fa5a6fb73490aa5e897d78d488104b4.

Reverting this because of changes to where we should display the messages (see PR in app) and we need to do a planner-web release (https://github.com/AtB-AS/kundevendt/issues/4203) 