### PR TITLE
feat: show destination display via information

### DIFF
--- a/src/page-modules/departures/__tests__/departure-data.fixture.ts
+++ b/src/page-modules/departures/__tests__/departure-data.fixture.ts
@@ -19,7 +19,10 @@ export const departureDataFixture: DepartureData = {
       departures: [
         {
           id: 'ATB:ServiceJourney:71_230306097870252_7024',
-          name: 'Dora',
+          destinationDisplay: {
+            frontText: 'Dora',
+            via: [],
+          },
           date: '2023-10-08',
           expectedDepartureTime: '2023-10-08T20:53:15+02:00',
           aimedDepartureTime: '2023-10-08T20:50:00+02:00',
@@ -32,7 +35,10 @@ export const departureDataFixture: DepartureData = {
         },
         {
           id: 'ATB:ServiceJourney:25_230306097862768_7070',
-          name: 'Hurtigbåtterminalen',
+          destinationDisplay: {
+            frontText: 'Hurtigbåtterminalen',
+            via: [],
+          },
           date: '2023-10-08',
           expectedDepartureTime: '2023-10-08T20:53:19+02:00',
           aimedDepartureTime: '2023-10-08T20:47:00+02:00',
@@ -54,7 +60,10 @@ export const departureDataFixture: DepartureData = {
       departures: [
         {
           id: 'ATB:ServiceJourney:10_230905147222030_7096',
-          name: 'Sjetnmarka via Klæbuveien',
+          destinationDisplay: {
+            frontText: 'Sjetnemarka',
+            via: ['Klæbuveien'],
+          },
           date: '2023-10-08',
           expectedDepartureTime: '2023-10-08T20:55:28+02:00',
           aimedDepartureTime: '2023-10-08T20:54:00+02:00',
@@ -67,7 +76,10 @@ export const departureDataFixture: DepartureData = {
         },
         {
           id: 'ATB:ServiceJourney:20_230306097869036_7048',
-          name: 'Romolslia via St. Olavs hospital',
+          destinationDisplay: {
+            frontText: 'Romolslia',
+            via: ['St. Olavs hospital'],
+          },
           date: '2023-10-08',
           expectedDepartureTime: '2023-10-08T20:55:32+02:00',
           aimedDepartureTime: '2023-10-08T20:54:00+02:00',
@@ -80,7 +92,10 @@ export const departureDataFixture: DepartureData = {
         },
         {
           id: 'ATB:ServiceJourney:12_230306097866716_7048',
-          name: 'Marienborg',
+          destinationDisplay: {
+            frontText: 'Marienborg',
+            via: [],
+          },
           date: '2023-10-08',
           expectedDepartureTime: '2023-10-08T20:57:11+02:00',
           aimedDepartureTime: '2023-10-08T20:56:00+02:00',

--- a/src/page-modules/departures/__tests__/departure-details.test.tsx
+++ b/src/page-modules/departures/__tests__/departure-details.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import { DeparturesDetails } from '../details';
+import { formatDestinationDisplay } from '../utils';
 
 afterEach(function () {
   cleanup();
@@ -22,7 +23,7 @@ describe('departure details page', function () {
     );
     expect(
       output.getByText(
-        `${serviceJourneyFixture.line.publicCode} ${serviceJourneyFixture.estimatedCalls[0].destinationDisplay.frontText}`,
+        `${serviceJourneyFixture.line.publicCode} Vestlia via sentrum`,
       ),
     ).toBeInTheDocument();
   });

--- a/src/page-modules/departures/__tests__/service-journey-data.fixture.ts
+++ b/src/page-modules/departures/__tests__/service-journey-data.fixture.ts
@@ -20,8 +20,8 @@ export const serviceJourneyFixture: ServiceJourneyData = {
       cancellation: false,
       date: '2023-11-10',
       destinationDisplay: {
-        frontText: 'Vestlia via sentrum-Othilienborg',
-        via: [],
+        frontText: 'Vestlia',
+        via: ['sentrum-Othilienborg'],
       },
       expectedDepartureTime: '2023-11-10T14:59:24+01:00',
       expectedArrivalTime: '2023-11-10T14:59:24+01:00',

--- a/src/page-modules/departures/__tests__/service-journey-data.fixture.ts
+++ b/src/page-modules/departures/__tests__/service-journey-data.fixture.ts
@@ -21,6 +21,7 @@ export const serviceJourneyFixture: ServiceJourneyData = {
       date: '2023-11-10',
       destinationDisplay: {
         frontText: 'Vestlia via sentrum-Othilienborg',
+        via: [],
       },
       expectedDepartureTime: '2023-11-10T14:59:24+01:00',
       expectedArrivalTime: '2023-11-10T14:59:24+01:00',
@@ -48,7 +49,8 @@ export const serviceJourneyFixture: ServiceJourneyData = {
       cancellation: false,
       date: '2023-11-10',
       destinationDisplay: {
-        frontText: 'Vestlia via sentrum-Othilienborg',
+        frontText: 'Vestlia',
+        via: ['sentrum-Othilienborg'],
       },
       expectedDepartureTime: '2023-11-10T15:01:40+01:00',
       expectedArrivalTime: '2023-11-10T15:01:22+01:00',
@@ -76,7 +78,8 @@ export const serviceJourneyFixture: ServiceJourneyData = {
       cancellation: false,
       date: '2023-11-10',
       destinationDisplay: {
-        frontText: 'Vestlia via sentrum-Othilienborg',
+        frontText: 'Vestlia',
+        via: [],
       },
       expectedDepartureTime: '2023-11-10T15:02:50+01:00',
       expectedArrivalTime: '2023-11-10T15:02:11+01:00',
@@ -104,7 +107,8 @@ export const serviceJourneyFixture: ServiceJourneyData = {
       cancellation: false,
       date: '2023-11-10',
       destinationDisplay: {
-        frontText: 'Vestlia via sentrum-Othilienborg',
+        frontText: 'Vestlia',
+        via: [],
       },
       expectedDepartureTime: '2023-11-10T15:03:43+01:00',
       expectedArrivalTime: '2023-11-10T15:03:04+01:00',
@@ -132,7 +136,8 @@ export const serviceJourneyFixture: ServiceJourneyData = {
       cancellation: false,
       date: '2023-11-10',
       destinationDisplay: {
-        frontText: 'Vestlia via sentrum-Othilienborg',
+        frontText: 'Vestlia',
+        via: [],
       },
       expectedDepartureTime: '2023-11-10T15:04:09+01:00',
       expectedArrivalTime: '2023-11-10T15:03:54+01:00',
@@ -160,7 +165,8 @@ export const serviceJourneyFixture: ServiceJourneyData = {
       cancellation: false,
       date: '2023-11-10',
       destinationDisplay: {
-        frontText: 'Vestlia via sentrum-Othilienborg',
+        frontText: 'Vestlia',
+        via: [],
       },
       expectedDepartureTime: '2023-11-10T15:05:07+01:00',
       expectedArrivalTime: '2023-11-10T15:04:42+01:00',
@@ -188,7 +194,8 @@ export const serviceJourneyFixture: ServiceJourneyData = {
       cancellation: false,
       date: '2023-11-10',
       destinationDisplay: {
-        frontText: 'Vestlia via sentrum-Othilienborg',
+        frontText: 'Vestlia',
+        via: [],
       },
       expectedDepartureTime: '2023-11-10T15:05:56+01:00',
       expectedArrivalTime: '2023-11-10T15:05:19+01:00',
@@ -216,7 +223,8 @@ export const serviceJourneyFixture: ServiceJourneyData = {
       cancellation: false,
       date: '2023-11-10',
       destinationDisplay: {
-        frontText: 'Vestlia via sentrum-Othilienborg',
+        frontText: 'Vestlia',
+        via: ['sentrum'],
       },
       expectedDepartureTime: '2023-11-10T15:07:14+01:00',
       expectedArrivalTime: '2023-11-10T15:06:34+01:00',
@@ -244,7 +252,8 @@ export const serviceJourneyFixture: ServiceJourneyData = {
       cancellation: false,
       date: '2023-11-10',
       destinationDisplay: {
-        frontText: 'Vestlia via sentrum-Othilienborg',
+        frontText: 'Vestlia',
+        via: [],
       },
       expectedDepartureTime: '2023-11-10T15:08:22+01:00',
       expectedArrivalTime: '2023-11-10T15:07:52+01:00',
@@ -272,7 +281,8 @@ export const serviceJourneyFixture: ServiceJourneyData = {
       cancellation: false,
       date: '2023-11-10',
       destinationDisplay: {
-        frontText: 'Vestlia via sentrum-Othilienborg',
+        frontText: 'Vestlia',
+        via: [],
       },
       expectedDepartureTime: '2023-11-10T15:10:33+01:00',
       expectedArrivalTime: '2023-11-10T15:09:56+01:00',

--- a/src/page-modules/departures/details/index.tsx
+++ b/src/page-modules/departures/details/index.tsx
@@ -11,6 +11,7 @@ import { ServiceJourneyData } from '../server/journey-planner/validators';
 import style from './details.module.css';
 import { EstimatedCallRows } from './estimated-call-rows';
 import { addMetadataToEstimatedCalls } from './utils';
+import { formatDestinationDisplay } from '../utils';
 
 export type DeparturesDetailsProps = {
   fromQuayId?: string;
@@ -27,7 +28,7 @@ export function DeparturesDetails({
   const focusedCall =
     serviceJourney.estimatedCalls.find((call) => call.quay.id === fromQuayId) ||
     serviceJourney.estimatedCalls[0];
-  const title = `${serviceJourney.line.publicCode} ${focusedCall.destinationDisplay.frontText}`;
+  const title = `${serviceJourney.line.publicCode} ${formatDestinationDisplay(t, focusedCall.destinationDisplay)}`;
   const realtimeText = useRealtimeText(
     serviceJourney.estimatedCalls.map((c) => ({
       actualDepartureTime: c.actualDepartureTime ?? undefined,

--- a/src/page-modules/departures/server/journey-planner/index.ts
+++ b/src/page-modules/departures/server/journey-planner/index.ts
@@ -135,6 +135,10 @@ export function createJourneyApi(
             ) ?? [],
           departures: q.estimatedCalls.map((e) => ({
             id: e.serviceJourney.id,
+            destinationDisplay: {
+              frontText: e.destinationDisplay?.frontText,
+              via: e.destinationDisplay?.via ?? [],
+            },
             name: e.destinationDisplay?.frontText,
             date: e.date,
             expectedDepartureTime: e.expectedDepartureTime,
@@ -284,7 +288,10 @@ export function createJourneyApi(
         },
         departures: result.data.quay?.estimatedCalls?.map((e) => ({
           id: e.serviceJourney.id,
-          name: e.destinationDisplay?.frontText,
+          destinationDisplay: {
+            frontText: e.destinationDisplay?.frontText,
+            via: e.destinationDisplay?.via ?? [],
+          },
           publicCode: e.serviceJourney.line.publicCode,
           date: e.date,
           aimedDepartureTime: e.aimedDepartureTime,
@@ -376,6 +383,7 @@ export function createJourneyApi(
             date: estimatedCall.date,
             destinationDisplay: {
               frontText: estimatedCall.destinationDisplay?.frontText,
+              via: estimatedCall.destinationDisplay?.via ?? [],
             },
             expectedDepartureTime: estimatedCall.expectedDepartureTime,
             expectedArrivalTime: estimatedCall.expectedArrivalTime,

--- a/src/page-modules/departures/server/journey-planner/journey-gql/departures.gql
+++ b/src/page-modules/departures/server/journey-planner/journey-gql/departures.gql
@@ -31,6 +31,7 @@ query stopPlaceQuayDepartures(
         }
         destinationDisplay {
           frontText
+          via
         }
         serviceJourney {
           id

--- a/src/page-modules/departures/server/journey-planner/journey-gql/estimated-calls.gql
+++ b/src/page-modules/departures/server/journey-planner/journey-gql/estimated-calls.gql
@@ -23,6 +23,7 @@ query quayEstimatedCalls(
       }
       destinationDisplay {
         frontText
+        via
       }
       serviceJourney {
         id

--- a/src/page-modules/departures/server/journey-planner/journey-gql/service-journey-with-estimated-calls.gql
+++ b/src/page-modules/departures/server/journey-planner/journey-gql/service-journey-with-estimated-calls.gql
@@ -25,6 +25,7 @@ query serviceJourneyWithEstimatedCalls($id: String!, $date: Date) {
       date
       destinationDisplay {
         frontText
+        via
       }
       expectedDepartureTime
       expectedArrivalTime

--- a/src/page-modules/departures/server/journey-planner/validators.ts
+++ b/src/page-modules/departures/server/journey-planner/validators.ts
@@ -22,7 +22,10 @@ export const stopPlaceSchema = z.object({
 
 export const departureSchema = z.object({
   id: z.string(),
-  name: z.string(),
+  destinationDisplay: z.object({
+    frontText: z.string(),
+    via: z.array(z.string()),
+  }),
   publicCode: z.string().nullable(),
   date: z.string(),
   aimedDepartureTime: z.string(),
@@ -79,7 +82,10 @@ export const serviceJourneySchema = z.object({
       aimedDepartureTime: z.string(),
       cancellation: z.boolean(),
       date: z.string(),
-      destinationDisplay: z.object({ frontText: z.string() }),
+      destinationDisplay: z.object({
+        frontText: z.string(),
+        via: z.array(z.string()),
+      }),
       expectedDepartureTime: z.string(),
       expectedArrivalTime: z.string(),
       forAlighting: z.boolean(),

--- a/src/page-modules/departures/stop-place/index.tsx
+++ b/src/page-modules/departures/stop-place/index.tsx
@@ -26,6 +26,7 @@ import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { nextDepartures } from '../client';
 import style from './stop-place.module.css';
+import { formatDestinationDisplay } from '../utils';
 
 export type StopPlaceProps = {
   departures: DepartureData;
@@ -204,6 +205,8 @@ export function EstimatedCallItem({
   quayId,
   departure,
 }: EstimatedCallItemProps) {
+  const { t } = useTranslation();
+  const lineName = formatDestinationDisplay(t, departure.destinationDisplay);
   return (
     <li>
       <Link
@@ -240,7 +243,7 @@ export function EstimatedCallItem({
               departure.cancelled ? 'body__primary--strike' : 'body__primary'
             }
           >
-            {departure.name}
+            {lineName}
           </Typo.p>
         </div>
 

--- a/src/page-modules/departures/utils.ts
+++ b/src/page-modules/departures/utils.ts
@@ -1,6 +1,9 @@
 import { FromDepartureQuery } from './types';
 import { searchTimeToQueryString } from '@atb/modules/search-time';
+import { TranslateFunction } from '@atb/translations';
 import { ParsedUrlQueryInput } from 'querystring';
+import { Departure } from './server/journey-planner';
+import dictionary from '@atb/translations/dictionary';
 
 export function createFromQuery(tripQuery: FromDepartureQuery): {
   pathname: string;
@@ -34,4 +37,26 @@ export function createFromQuery(tripQuery: FromDepartureQuery): {
     pathname: '/departures',
     query: searchTimeQuery,
   };
+}
+
+export function formatDestinationDisplay(
+  t: TranslateFunction,
+  destinationDisplay: Departure['destinationDisplay'],
+): string | undefined {
+  const frontText = destinationDisplay.frontText;
+  const via = destinationDisplay.via;
+
+  if (via.length < 1) {
+    return frontText;
+  }
+
+  let viaNames = via[0];
+  if (via.length > 1) {
+    viaNames =
+      via.slice(0, -1).join(', ') +
+      ` ${t(dictionary.listConcatWord)} ` +
+      via[via.length - 1];
+  }
+
+  return frontText + ` ${t(dictionary.via)} ` + viaNames;
 }

--- a/src/translations/dictionary.ts
+++ b/src/translations/dictionary.ts
@@ -56,6 +56,8 @@ const dictionary = {
   missingRealTimePrefix: _('ca. ', 'ca. ', `ca. `),
   readMore: _('Les mer', 'Read more', `Les meir`),
   close: _('Lukk', 'Close', 'Lukk'),
+  listConcatWord: _('og', 'and', 'og'),
+  via: _('via', 'via', 'via'),
 };
 
 export default orgSpecificTranslations(dictionary, {


### PR DESCRIPTION
We're currently not using the via information found in the destination display object and are therefore giving different information than in the app. This updates the line names for the departure and departure details pages. 

<details>
<summary>Screenshots</summary>

<img width="773" alt="image" src="https://github.com/user-attachments/assets/640d39e6-ef7d-4b9e-abcb-b27477e24f09">

<img width="705" alt="image" src="https://github.com/user-attachments/assets/96c4b945-c4a7-41a6-8b6b-9630fbf92fbd">


</details>
