### PR TITLE
feat: icons for the contact page navigator

### DIFF
--- a/src/page-modules/contact/layouts/contact-page-layout.tsx
+++ b/src/page-modules/contact/layouts/contact-page-layout.tsx
@@ -6,36 +6,44 @@ import { usePathname } from 'next/navigation';
 import Link from 'next/link';
 import { andIf } from '@atb/utils/css';
 import { Typo } from '@atb/components/typography';
+import { MonoIcon, MonoIcons } from '@atb/components/icon';
 
 export type ContactPage = {
   title: TranslatedString;
   href: string;
+  icon: MonoIcons;
 };
 
 export const contactPages: ContactPage[] = [
   {
     title: PageText.Contact.ticketControl.title,
     href: '/contact/billettkontroll-og-gebyr',
+    icon: 'ticketing/TicketInvalid',
   },
   {
     title: PageText.Contact.travelGuarantee.title,
     href: '/contact/reisegaranti',
+    icon: 'transportation-entur/Taxi',
   },
   {
     title: PageText.Contact.modeOfTransport.title,
     href: '/contact/transportmiddel-og-stoppested',
+    icon: 'transportation/Bus',
   },
   {
     title: PageText.Contact.ticketsApp.title,
     href: '/contact/billette-og-app',
+    icon: 'devices/Phone',
   },
   {
     title: PageText.Contact.lostAndFound.title,
     href: '/contact/hittegods',
+    icon: 'actions/Support',
   },
   {
     title: PageText.Contact.groupTravel.title,
     href: '/contact/gruppereise',
+    icon: 'ticketing/TicketMultiple',
   },
 ];
 
@@ -65,7 +73,7 @@ function ContactPageLayout({ children }: ContactPageLayoutProps) {
                   [style.contact_page_navigator__activePage]: isActive,
                 })}
               >
-                {/*Add icon*/}
+                <MonoIcon size="large" icon={contactPage.icon} />
                 <Typo.p
                   textType={isActive ? 'body__primary--bold' : 'body__primary'}
                 >

--- a/src/page-modules/contact/layouts/layout.module.css
+++ b/src/page-modules/contact/layouts/layout.module.css
@@ -12,14 +12,23 @@
 .contact_page_navigator__container {
   display: flex;
   justify-content: center;
-  width: 100%;
-  gap: var(--spacings-large);
+  flex-wrap: wrap;
+  gap: var(--spacings-medium);
 }
 
 .contact_page_navigator__link {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacings-small);
+  width: 12rem;
+  height: 120px;
+
   composes: interactive-interactive_2;
   text-align: center;
   text-decoration: none;
+
   padding: var(--spacings-medium);
   border-radius: var(--border-radius-regular);
 }
@@ -30,6 +39,6 @@
 }
 
 .contact_page_navigator__activePage {
-  border: var(--border-radius-small) solid
-    var(--static-background-background_0-text);
+  border: var(--border-width-medium) solid
+    var(--interactive-interactive_2-outline-background);
 }

--- a/src/page-modules/contact/layouts/layout.module.css
+++ b/src/page-modules/contact/layouts/layout.module.css
@@ -20,16 +20,15 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
   gap: var(--spacings-small);
   width: 12rem;
-  height: 120px;
+  height: 7.5rem;
 
   composes: interactive-interactive_2;
   text-align: center;
   text-decoration: none;
 
-  padding: var(--spacings-medium);
+  padding: var(--spacings-large);
   border-radius: var(--border-radius-regular);
 }
 


### PR DESCRIPTION
I've added icons to the contact page navigator. Also updated the "active-border" to use the design-system.  

<img width="1055" alt="image" src="https://github.com/user-attachments/assets/1bebc142-c37e-42d6-9532-773123cb2ff1">

<img width="1074" alt="image" src="https://github.com/user-attachments/assets/76db1625-e858-4f76-b62e-2f15060e8bac">

<img width="393" alt="image" src="https://github.com/user-attachments/assets/c1f3291b-9b1f-4b8f-8059-b5686cae4c6e">
