### PR TITLE
feat: add form selector component

### DIFF
--- a/src/page-modules/contact/components/form-selector/form-selector.tsx
+++ b/src/page-modules/contact/components/form-selector/form-selector.tsx
@@ -1,0 +1,33 @@
+import { TranslatedString } from '@atb/translations';
+import { SectionCard } from '../section-card';
+import { RadioInput } from '../input/radio';
+
+export type FormSelectorOption = {
+  label: string;
+  checked: boolean;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+};
+
+type FormSelectorProps = {
+  title: TranslatedString;
+  options: FormSelectorOption[];
+};
+
+const FormSelector = ({ title, options }: FormSelectorProps) => {
+  return (
+    <SectionCard title={title}>
+      <ul>
+        {options.map((option, idx) => (
+          <RadioInput
+            key={idx}
+            label={option.label}
+            checked={option.checked}
+            onChange={(event) => option.onChange(event)}
+          />
+        ))}
+      </ul>
+    </SectionCard>
+  );
+};
+
+export default FormSelector;

--- a/src/page-modules/contact/components/form-selector/index.ts
+++ b/src/page-modules/contact/components/form-selector/index.ts
@@ -1,0 +1,1 @@
+export { default as FormSelector } from './form-selector';

--- a/src/page-modules/contact/layouts/ticket-control-page-layout.tsx
+++ b/src/page-modules/contact/layouts/ticket-control-page-layout.tsx
@@ -2,8 +2,6 @@ import { PropsWithChildren } from 'react';
 import { SectionCard } from '../components/section-card';
 import { useRouter } from 'next/router';
 import { PageText, useTranslation } from '@atb/translations';
-import { Checkbox } from '../components/input/checkbox';
-import { Input } from '../components/input';
 import { RadioInput } from '../components/input/radio';
 
 export type TicketControlPageLayoutProps = PropsWithChildren<{

--- a/src/page-modules/contact/machineEvents.ts
+++ b/src/page-modules/contact/machineEvents.ts
@@ -13,7 +13,8 @@ export const machineEvents = {} as
         | 'isAppTicketStorageMode'
         | 'agreesFirstAgreement'
         | 'agreesSecondAgreement'
-        | 'hasInternationalBankAccount';
+        | 'hasInternationalBankAccount'
+        | 'isIntialAgreementChecked';
     }
   | {
       type: 'UPDATE_FIELD';

--- a/src/page-modules/contact/travel-guarantee/index.tsx
+++ b/src/page-modules/contact/travel-guarantee/index.tsx
@@ -1,4 +1,4 @@
-import FormSelector from './form-selector';
+import TravelGuaranteeFormSelector from './travel-guarantee-form-selector';
 import { SectionCard } from '../components/section-card';
 import { ComponentText, PageText, useTranslation } from '@atb/translations';
 import { useMachine } from '@xstate/react';
@@ -34,7 +34,7 @@ export const RefundForm = () => {
 
   return (
     <form onSubmit={onSubmit}>
-      <FormSelector state={state} send={send} />
+      <TravelGuaranteeFormSelector state={state} send={send} />
       {(state.hasTag('taxi') || state.hasTag('car')) && (
         <SectionCard
           title={

--- a/src/page-modules/contact/travel-guarantee/travel-guarantee-form-selector.tsx
+++ b/src/page-modules/contact/travel-guarantee/travel-guarantee-form-selector.tsx
@@ -1,18 +1,51 @@
 import { PageText, TranslatedString, useTranslation } from '@atb/translations';
 import { SectionCard } from '../components/section-card';
-import { Input } from '../components/input';
 import style from '../contact.module.css';
-import { RadioInput } from '../components/input/radio';
 import { Typo } from '@atb/components/typography';
 import { Checkbox } from '../components/input/checkbox';
+import { FormSelector } from '../components/form-selector';
+import { machineEvents } from '../machineEvents';
+import { ContextProps } from './travelGuaranteeFormMachine';
+import { FormSelectorOption } from '../components/form-selector/form-selector';
 
-type FormSelectorProps = {
-  state: any;
-  send: any;
+type TravelGuaranteeFormSelectorProps = {
+  state: {
+    hasTag(arg0: string): boolean | undefined;
+    context: ContextProps;
+  };
+  send: (event: typeof machineEvents) => void; // Function to send events to the state machine
 };
 
-export const FormSelector = ({ state, send }: FormSelectorProps) => {
+export const TravelGuaranteeFormSelector = ({
+  state,
+  send,
+}: TravelGuaranteeFormSelectorProps) => {
   const { t } = useTranslation();
+
+  const options = [
+    {
+      label: t(
+        PageText.Contact.travelGuarantee.subPageTitles.refundTaxi.description,
+      ),
+      checked: state.hasTag('taxi'),
+      onChange: () => send({ type: 'TAXI' }),
+    },
+    {
+      label: t(
+        PageText.Contact.travelGuarantee.subPageTitles.refundCar.description,
+      ),
+      checked: state.hasTag('car'),
+      onChange: () => send({ type: 'CAR' }),
+    },
+    {
+      label: t(
+        PageText.Contact.travelGuarantee.subPageTitles
+          .refundOtherPublicTransport.description,
+      ),
+      checked: state.hasTag('other'),
+      onChange: () => send({ type: 'OTHER' }),
+    },
+  ] as FormSelectorOption[];
 
   return (
     <div>
@@ -73,44 +106,22 @@ export const FormSelector = ({ state, send }: FormSelectorProps) => {
               PageText.Contact.ticketControl.feeComplaint.firstAgreement
                 .checkbox,
             )}
-            checked={state.context.isChecked}
-            onChange={() => send({ type: 'TOGGLE' })}
+            checked={state.context.isIntialAgreementChecked}
+            onChange={() =>
+              send({ type: 'TOGGLE', field: 'isIntialAgreementChecked' })
+            }
           />
         </SectionCard>
       )}
 
       {state.context.isIntialAgreementChecked && (
-        <SectionCard title={PageText.Contact.travelGuarantee.title}>
-          <ul>
-            <RadioInput
-              label={t(
-                PageText.Contact.travelGuarantee.subPageTitles.refundTaxi
-                  .description,
-              )}
-              checked={state.hasTag('taxi')}
-              onChange={() => send({ type: 'TAXI' })}
-            />
-            <RadioInput
-              label={t(
-                PageText.Contact.travelGuarantee.subPageTitles.refundCar
-                  .description,
-              )}
-              checked={state.hasTag('car')}
-              onChange={() => send({ type: 'CAR' })}
-            />
-            <RadioInput
-              label={t(
-                PageText.Contact.travelGuarantee.subPageTitles
-                  .refundOtherPublicTransport.description,
-              )}
-              checked={state.hasTag('other')}
-              onChange={() => send({ type: 'OTHER' })}
-            />
-          </ul>
-        </SectionCard>
+        <FormSelector
+          title={PageText.Contact.travelGuarantee.title}
+          options={options}
+        />
       )}
     </div>
   );
 };
 
-export default FormSelector;
+export default TravelGuaranteeFormSelector;

--- a/src/page-modules/contact/travel-guarantee/travelGuaranteeFormMachine.ts
+++ b/src/page-modules/contact/travel-guarantee/travelGuaranteeFormMachine.ts
@@ -29,7 +29,7 @@ type APIParams = {
   SWIFT: string;
 };
 
-type ContextProps = {
+export type ContextProps = {
   isIntialAgreementChecked: boolean;
   hasInternationalBankAccount: boolean;
   travelGuaranteeStateWhenSubmitted: 'car' | 'taxi' | 'other' | undefined;
@@ -76,6 +76,16 @@ export const fetchMachine = setup({
         return {
           ...context,
           [field]: value,
+        };
+      }
+      return context;
+    }),
+
+    toggleField: assign(({ context, event }: any) => {
+      if (event.type === 'TOGGLE') {
+        const { field } = event;
+        return {
+          [field]: !context[field],
         };
       }
       return context;


### PR DESCRIPTION
Added a form selector component to avoid repetition of code. Usable for all pages using states to navigate between forms. 