### PR TITLE
feat: error and success pages for contact page

### DIFF
--- a/src/page-modules/contact/error-content/error-content.module.css
+++ b/src/page-modules/contact/error-content/error-content.module.css
@@ -1,0 +1,11 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacings-large);
+
+  height: 100%;
+  max-width: var(--maxPageWidth);
+
+  margin: 0 auto;
+  padding: var(--spacings-xLarge);
+}

--- a/src/page-modules/contact/error-content/error-content.tsx
+++ b/src/page-modules/contact/error-content/error-content.tsx
@@ -1,0 +1,23 @@
+import { ButtonLink } from '@atb/components/button';
+import { MonoIcon } from '@atb/components/icon';
+import { Typo } from '@atb/components/typography';
+import { PageText, useTranslation } from '@atb/translations';
+import style from './error-content.module.css';
+
+export function ErrorContent() {
+  const { t } = useTranslation();
+  return (
+    <section className={style.container}>
+      <ButtonLink
+        mode="transparent"
+        href="/contact"
+        title={t(PageText.Contact.error.backButton)}
+        icon={{ left: <MonoIcon icon="navigation/ArrowLeft" /> }}
+      />
+      <Typo.h2 textType="heading--big">
+        {t(PageText.Contact.error.title)}
+      </Typo.h2>
+      <Typo.p textType="body__primary">{t(PageText.Contact.error.info)}</Typo.p>
+    </section>
+  );
+}

--- a/src/page-modules/contact/success-content/success-content.module.css
+++ b/src/page-modules/contact/success-content/success-content.module.css
@@ -1,0 +1,11 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacings-large);
+
+  height: 100%;
+  max-width: var(--maxPageWidth);
+
+  margin: 0 auto;
+  padding: var(--spacings-xLarge);
+}

--- a/src/page-modules/contact/success-content/success-content.tsx
+++ b/src/page-modules/contact/success-content/success-content.tsx
@@ -1,0 +1,25 @@
+import { ButtonLink } from '@atb/components/button';
+import { MonoIcon } from '@atb/components/icon';
+import { Typo } from '@atb/components/typography';
+import { PageText, useTranslation } from '@atb/translations';
+import style from './success-content.module.css';
+
+export function SuccessContent() {
+  const { t } = useTranslation();
+  return (
+    <section className={style.container}>
+      <ButtonLink
+        mode="transparent"
+        href="/"
+        title={t(PageText.Contact.success.backButton)}
+        icon={{ left: <MonoIcon icon="navigation/ArrowLeft" /> }}
+      />
+      <Typo.h2 textType="heading--big">
+        {t(PageText.Contact.success.title)}
+      </Typo.h2>
+      <Typo.p textType="body__primary">
+        {t(PageText.Contact.success.info)}
+      </Typo.p>
+    </section>
+  );
+}

--- a/src/pages/contact/error.tsx
+++ b/src/pages/contact/error.tsx
@@ -1,0 +1,19 @@
+import DefaultLayout from '@atb/layouts/default';
+import { withGlobalData, WithGlobalData } from '@atb/layouts/global-data';
+import { ErrorContent } from '@atb/page-modules/contact/error-content/error-content';
+
+import { NextPage } from 'next';
+
+export type ContactErrorPageProps = WithGlobalData<{}>;
+
+const ContactErrorPage: NextPage<ContactErrorPageProps> = (props) => {
+  return (
+    <DefaultLayout {...props}>
+      <ErrorContent />
+    </DefaultLayout>
+  );
+};
+
+export default ContactErrorPage;
+
+export const getServerSideProps = withGlobalData();

--- a/src/pages/contact/success.tsx
+++ b/src/pages/contact/success.tsx
@@ -1,0 +1,19 @@
+import DefaultLayout from '@atb/layouts/default';
+import { withGlobalData, WithGlobalData } from '@atb/layouts/global-data';
+import { SuccessContent } from '@atb/page-modules/contact/success-content/success-content';
+
+import { NextPage } from 'next';
+
+export type ContactSuccessPageProps = WithGlobalData<{}>;
+
+const ContactSuccessPage: NextPage<ContactSuccessPageProps> = (props) => {
+  return (
+    <DefaultLayout {...props}>
+      <SuccessContent />
+    </DefaultLayout>
+  );
+};
+
+export default ContactSuccessPage;
+
+export const getServerSideProps = withGlobalData();

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -974,4 +974,38 @@ export const Contact = {
       },
     },
   },
+  success: {
+    backButton: _(
+      'Tilbake til forsiden',
+      'Back to frontpage',
+      'Tilbake til forsida',
+    ),
+    title: _(
+      'Takk for din henvendelse',
+      'Thank you for your inquiry',
+      'Takk for din førespurnad',
+    ),
+    info: _(
+      'Vi har mottatt din henvendelse og vil behandle den så raskt som mulig.',
+      'We have received your inquiry and will process it as soon as possible.',
+      'Vi har motteke din førespurnad og vil behandle den så raskt som mogleg.',
+    ),
+  },
+  error: {
+    backButton: _(
+      'Tilbake til skjemaside',
+      'Back to form page',
+      'Tilbake til skjemaside',
+    ),
+    title: _(
+      'Ojda! Noe gikk galt med innsending av skjema',
+      'Oops! Something went wrong with submitting the form',
+      'Oi då! Noko gjekk gale med innsending av skjema',
+    ),
+    info: _(
+      'Her gikk vi på en blemme og det skjedde en feil. Kan du prøve igjen?',
+      'An error occured. Could you try again for us?',
+      'Her gjekk vi på ei blemme og det skjedde ein feil. Kan du prøve igjen?',
+    ),
+  },
 };

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -976,9 +976,9 @@ export const Contact = {
   },
   success: {
     backButton: _(
-      'Tilbake til forsiden',
-      'Back to frontpage',
-      'Tilbake til forsida',
+      'Tilbake til hovedsiden',
+      'Back to the main page',
+      'Tilbake til hovedsida',
     ),
     title: _(
       'Takk for din henvendelse',
@@ -993,9 +993,9 @@ export const Contact = {
   },
   error: {
     backButton: _(
-      'Tilbake til skjemaside',
-      'Back to form page',
-      'Tilbake til skjemaside',
+      'Tilbake til skjemasiden',
+      'Back to the contact page',
+      'Tilbake til skjemasiden',
     ),
     title: _(
       'Ojda! Noe gikk galt med innsending av skjema',


### PR DESCRIPTION
Added a generic error and success page that users can be redirected to on error/success when submitting a form. 