### PR TITLE
chore: comment out link to contact page

### DIFF
--- a/src/layouts/shared/page-header.tsx
+++ b/src/layouts/shared/page-header.tsx
@@ -55,6 +55,7 @@ export default function PageHeader() {
             </Link>
           </h1>
         </div>
+        {/*
         {hasContactFormUrl && (
           <nav>
             <Link
@@ -70,6 +71,7 @@ export default function PageHeader() {
             </Link>
           </nav>
         )}
+      */}
       </div>
     </header>
   );


### PR DESCRIPTION
 Comment out link to contact page. Navigating to the contact page stil works when typing `/contact` directly into the search bar. 