### PR TITLE
feat: drag and drop files

### DIFF
--- a/src/page-modules/contact/components/input/file.tsx
+++ b/src/page-modules/contact/components/input/file.tsx
@@ -31,6 +31,10 @@ export function FileInput({ onChange, label, name }: FileInputProps) {
     }
   };
 
+  const handleDragOver = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+  };
+
   const handleDrop = (event: DragEvent<HTMLDivElement>) => {
     event.preventDefault();
 
@@ -44,7 +48,7 @@ export function FileInput({ onChange, label, name }: FileInputProps) {
   };
 
   return (
-    <div onDrop={handleDrop}>
+    <div onDragOver={handleDragOver} onDrop={handleDrop}>
       <input
         id={id}
         type="file"


### PR DESCRIPTION
This prevents the browser from opening the file when dropped above the file-input. 