### PR TITLE
fix: file attachment capture attribute

### DIFF
--- a/src/page-modules/contact/components/input/file.tsx
+++ b/src/page-modules/contact/components/input/file.tsx
@@ -76,7 +76,6 @@ export function FileInput({ onChange, label, name }: FileInputProps) {
         className={style.input__file}
         multiple
         accept="image/*,.pdf,.doc,docx,.txt"
-        capture="environment"
       />
 
       <label htmlFor={id} className={style.label__file}>


### PR DESCRIPTION
It's currently only possible to upload files taken with the camera on mobile devices. Removing `capture` lets the user decide whether to take an image or upload an existing one. 