### PR TITLE
fix: handling reseting transport mode and line. 

### DIFF
--- a/src/page-modules/contact/commoneEvents.ts
+++ b/src/page-modules/contact/commoneEvents.ts
@@ -1,3 +1,6 @@
+import { TransportModeType } from '@atb-as/config-specs';
+import { Line } from '.';
+
 export const commonEvents = {} as
   | { type: 'VALIDATE' }
   | {
@@ -12,7 +15,6 @@ export const commonEvents = {} as
         | 'firstName'
         | 'feedback'
         | 'IBAN'
-        | 'line'
         | 'lastName'
         | 'phoneNumber'
         | 'postalCode'
@@ -25,5 +27,10 @@ export const commonEvents = {} as
   | {
       type: 'ON_TRANSPORTMODE_CHANGE';
       inputName: 'transportMode';
-      value: any;
+      value: TransportModeType;
+    }
+  | {
+      type: 'ON_LINE_CHANGE';
+      inputName: 'line';
+      value: Line;
     };

--- a/src/page-modules/contact/commoneEvents.ts
+++ b/src/page-modules/contact/commoneEvents.ts
@@ -26,7 +26,6 @@ export const commonEvents = {} as
     }
   | {
       type: 'ON_TRANSPORTMODE_CHANGE';
-      inputName: 'transportMode';
       value: TransportModeType;
     }
   | {

--- a/src/page-modules/contact/commoneEvents.ts
+++ b/src/page-modules/contact/commoneEvents.ts
@@ -18,8 +18,12 @@ export const commonEvents = {} as
         | 'postalCode'
         | 'SWIFT'
         | 'toStop'
-        | 'transportMode'
         | 'fromStop'
         | 'plannedDepartureTime';
+      value: any;
+    }
+  | {
+      type: 'ON_TRANSPORTMODE_CHANGE';
+      inputName: 'transportMode';
       value: any;
     };

--- a/src/page-modules/contact/commoneEvents.ts
+++ b/src/page-modules/contact/commoneEvents.ts
@@ -30,6 +30,5 @@ export const commonEvents = {} as
     }
   | {
       type: 'ON_LINE_CHANGE';
-      inputName: 'line';
       value: Line;
     };

--- a/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
@@ -68,7 +68,7 @@ export const DelayForm = ({ state, send }: DelayFormProps) => {
           onChange={(value: Line | undefined) => {
             if (!value) return;
             send({
-              type: 'ON_INPUT_CHANGE',
+              type: 'ON_LINE_CHANGE',
               inputName: 'line',
               value: value,
             });

--- a/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
@@ -68,7 +68,6 @@ export const DelayForm = ({ state, send }: DelayFormProps) => {
             if (!value) return;
             send({
               type: 'ON_LINE_CHANGE',
-              inputName: 'line',
               value: value,
             });
           }}

--- a/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
@@ -43,7 +43,7 @@ export const DelayForm = ({ state, send }: DelayFormProps) => {
           value={state.context.transportMode}
           onChange={(value) =>
             send({
-              type: 'ON_INPUT_CHANGE',
+              type: 'ON_TRANSPORTMODE_CHANGE',
               inputName: 'transportMode',
               value: value as TransportModeType,
             })

--- a/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
@@ -44,7 +44,6 @@ export const DelayForm = ({ state, send }: DelayFormProps) => {
           onChange={(value) =>
             send({
               type: 'ON_TRANSPORTMODE_CHANGE',
-              inputName: 'transportMode',
               value: value as TransportModeType,
             })
           }

--- a/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
@@ -67,7 +67,6 @@ export const DriverForm = ({ state, send }: DriverFormProps) => {
           onChange={(value) =>
             send({
               type: 'ON_TRANSPORTMODE_CHANGE',
-              inputName: 'transportMode',
               value: value as TransportModeType,
             })
           }

--- a/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
@@ -91,7 +91,7 @@ export const DriverForm = ({ state, send }: DriverFormProps) => {
           onChange={(value: Line | undefined) => {
             if (!value) return;
             send({
-              type: 'ON_INPUT_CHANGE',
+              type: 'ON_LINE_CHANGE',
               inputName: 'line',
               value: value,
             });

--- a/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
@@ -66,7 +66,7 @@ export const DriverForm = ({ state, send }: DriverFormProps) => {
           value={state.context.transportMode}
           onChange={(value) =>
             send({
-              type: 'ON_INPUT_CHANGE',
+              type: 'ON_TRANSPORTMODE_CHANGE',
               inputName: 'transportMode',
               value: value as TransportModeType,
             })

--- a/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
@@ -91,7 +91,6 @@ export const DriverForm = ({ state, send }: DriverFormProps) => {
             if (!value) return;
             send({
               type: 'ON_LINE_CHANGE',
-              inputName: 'line',
               value: value,
             });
           }}

--- a/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
@@ -90,7 +90,6 @@ export const InjuryForm = ({ state, send }: InjuryFormProps) => {
             if (!value) return;
             send({
               type: 'ON_LINE_CHANGE',
-              inputName: 'line',
               value: value,
             });
           }}

--- a/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
@@ -66,7 +66,6 @@ export const InjuryForm = ({ state, send }: InjuryFormProps) => {
           onChange={(value) =>
             send({
               type: 'ON_TRANSPORTMODE_CHANGE',
-              inputName: 'transportMode',
               value: value as TransportModeType,
             })
           }

--- a/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
@@ -90,7 +90,7 @@ export const InjuryForm = ({ state, send }: InjuryFormProps) => {
           onChange={(value: Line | undefined) => {
             if (!value) return;
             send({
-              type: 'ON_INPUT_CHANGE',
+              type: 'ON_LINE_CHANGE',
               inputName: 'line',
               value: value,
             });

--- a/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
@@ -65,7 +65,7 @@ export const InjuryForm = ({ state, send }: InjuryFormProps) => {
           value={state.context.transportMode}
           onChange={(value) =>
             send({
-              type: 'ON_INPUT_CHANGE',
+              type: 'ON_TRANSPORTMODE_CHANGE',
               inputName: 'transportMode',
               value: value as TransportModeType,
             })

--- a/src/page-modules/contact/means-of-transport/forms/serviceOfferingForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/serviceOfferingForm.tsx
@@ -71,7 +71,6 @@ export const ServiceOfferingForm = ({
           onChange={(value) =>
             send({
               type: 'ON_TRANSPORTMODE_CHANGE',
-              inputName: 'transportMode',
               value: value as TransportModeType,
             })
           }

--- a/src/page-modules/contact/means-of-transport/forms/serviceOfferingForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/serviceOfferingForm.tsx
@@ -70,7 +70,7 @@ export const ServiceOfferingForm = ({
           value={state.context.transportMode}
           onChange={(value) =>
             send({
-              type: 'ON_INPUT_CHANGE',
+              type: 'ON_TRANSPORTMODE_CHANGE',
               inputName: 'transportMode',
               value: value as TransportModeType,
             })

--- a/src/page-modules/contact/means-of-transport/forms/serviceOfferingForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/serviceOfferingForm.tsx
@@ -95,7 +95,7 @@ export const ServiceOfferingForm = ({
           onChange={(value: Line | undefined) => {
             if (!value) return;
             send({
-              type: 'ON_INPUT_CHANGE',
+              type: 'ON_LINE_CHANGE',
               inputName: 'line',
               value: value,
             });

--- a/src/page-modules/contact/means-of-transport/forms/serviceOfferingForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/serviceOfferingForm.tsx
@@ -95,7 +95,6 @@ export const ServiceOfferingForm = ({
             if (!value) return;
             send({
               type: 'ON_LINE_CHANGE',
-              inputName: 'line',
               value: value,
             });
           }}

--- a/src/page-modules/contact/means-of-transport/forms/stopForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/stopForm.tsx
@@ -40,7 +40,6 @@ export const StopForm = ({ state, send }: StopFormProps) => {
           onChange={(value) =>
             send({
               type: 'ON_TRANSPORTMODE_CHANGE',
-              inputName: 'transportMode',
               value: value as TransportModeType,
             })
           }

--- a/src/page-modules/contact/means-of-transport/forms/stopForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/stopForm.tsx
@@ -39,7 +39,7 @@ export const StopForm = ({ state, send }: StopFormProps) => {
           value={state.context.transportMode}
           onChange={(value) =>
             send({
-              type: 'ON_INPUT_CHANGE',
+              type: 'ON_TRANSPORTMODE_CHANGE',
               inputName: 'transportMode',
               value: value as TransportModeType,
             })

--- a/src/page-modules/contact/means-of-transport/forms/stopForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/stopForm.tsx
@@ -64,7 +64,6 @@ export const StopForm = ({ state, send }: StopFormProps) => {
             if (!value) return;
             send({
               type: 'ON_LINE_CHANGE',
-              inputName: 'line',
               value: value,
             });
           }}

--- a/src/page-modules/contact/means-of-transport/forms/stopForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/stopForm.tsx
@@ -64,7 +64,7 @@ export const StopForm = ({ state, send }: StopFormProps) => {
           onChange={(value: Line | undefined) => {
             if (!value) return;
             send({
-              type: 'ON_INPUT_CHANGE',
+              type: 'ON_LINE_CHANGE',
               inputName: 'line',
               value: value,
             });

--- a/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
@@ -72,7 +72,6 @@ export const TransportationForm = ({
             if (!value) return;
             send({
               type: 'ON_LINE_CHANGE',
-              inputName: 'line',
               value: value,
             });
           }}

--- a/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
@@ -48,7 +48,6 @@ export const TransportationForm = ({
           onChange={(value) =>
             send({
               type: 'ON_TRANSPORTMODE_CHANGE',
-              inputName: 'transportMode',
               value: value as TransportModeType,
             })
           }

--- a/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
@@ -72,7 +72,7 @@ export const TransportationForm = ({
           onChange={(value: Line | undefined) => {
             if (!value) return;
             send({
-              type: 'ON_INPUT_CHANGE',
+              type: 'ON_LINE_CHANGE',
               inputName: 'line',
               value: value,
             });

--- a/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
@@ -47,7 +47,7 @@ export const TransportationForm = ({
           value={state.context.transportMode}
           onChange={(value) =>
             send({
-              type: 'ON_INPUT_CHANGE',
+              type: 'ON_TRANSPORTMODE_CHANGE',
               inputName: 'transportMode',
               value: value as TransportModeType,
             })

--- a/src/page-modules/contact/means-of-transport/means-of-transport-form-machine.ts
+++ b/src/page-modules/contact/means-of-transport/means-of-transport-form-machine.ts
@@ -6,6 +6,8 @@ import {
   convertFilesToBase64,
   getCurrentDateString,
   getCurrentTimeString,
+  setLineAndResetStops,
+  setTransportModeAndResetLineAndStops,
 } from '../utils';
 import { Area, meansOfTransportFormEvents } from './events';
 
@@ -77,6 +79,12 @@ export const meansOfTransportFormMachine = setup({
         } else {
           context.errorMessages[inputName] = [];
         }
+
+        if (inputName === 'transportMode')
+          return setTransportModeAndResetLineAndStops(context, value);
+
+        if (inputName === 'line') return setLineAndResetStops(context, value);
+
         return {
           ...context,
           [inputName]: value,

--- a/src/page-modules/contact/means-of-transport/means-of-transport-form-machine.ts
+++ b/src/page-modules/contact/means-of-transport/means-of-transport-form-machine.ts
@@ -87,12 +87,10 @@ export const meansOfTransportFormMachine = setup({
       }
       return context;
     }),
+
     onTransportModeChange: assign(({ context, event }) => {
-      if (event.type === 'ON_TRANSPORTMODE_CHANGE') {
-        const { inputName, value } = event;
-        if (inputName === 'transportMode')
-          return setTransportModeAndResetLineAndStops(context, value);
-      }
+      if (event.type === 'ON_TRANSPORTMODE_CHANGE')
+        return setTransportModeAndResetLineAndStops(context, event.value);
       return context;
     }),
 

--- a/src/page-modules/contact/means-of-transport/means-of-transport-form-machine.ts
+++ b/src/page-modules/contact/means-of-transport/means-of-transport-form-machine.ts
@@ -80,11 +80,23 @@ export const meansOfTransportFormMachine = setup({
           context.errorMessages[inputName] = [];
         }
 
+        if (inputName === 'line') return setLineAndResetStops(context, value);
+
+        return {
+          ...context,
+          [inputName]: value,
+        };
+      }
+      return context;
+    }),
+    onTransportModeChange: assign(({ context, event }) => {
+      if (event.type === 'ON_TRANSPORTMODE_CHANGE') {
+        const { inputName, value } = event;
+
         if (inputName === 'transportMode')
           return setTransportModeAndResetLineAndStops(context, value);
 
-        if (inputName === 'line') return setLineAndResetStops(context, value);
-
+        context.errorMessages[inputName] = [];
         return {
           ...context,
           [inputName]: value,
@@ -174,6 +186,9 @@ export const meansOfTransportFormMachine = setup({
       on: {
         ON_INPUT_CHANGE: {
           actions: 'onInputChange',
+        },
+        ON_TRANSPORTMODE_CHANGE: {
+          actions: 'onTransportModeChange',
         },
 
         VALIDATE: {

--- a/src/page-modules/contact/means-of-transport/means-of-transport-form-machine.ts
+++ b/src/page-modules/contact/means-of-transport/means-of-transport-form-machine.ts
@@ -92,15 +92,8 @@ export const meansOfTransportFormMachine = setup({
     onTransportModeChange: assign(({ context, event }) => {
       if (event.type === 'ON_TRANSPORTMODE_CHANGE') {
         const { inputName, value } = event;
-
         if (inputName === 'transportMode')
           return setTransportModeAndResetLineAndStops(context, value);
-
-        context.errorMessages[inputName] = [];
-        return {
-          ...context,
-          [inputName]: value,
-        };
       }
       return context;
     }),

--- a/src/page-modules/contact/means-of-transport/means-of-transport-form-machine.ts
+++ b/src/page-modules/contact/means-of-transport/means-of-transport-form-machine.ts
@@ -80,8 +80,6 @@ export const meansOfTransportFormMachine = setup({
           context.errorMessages[inputName] = [];
         }
 
-        if (inputName === 'line') return setLineAndResetStops(context, value);
-
         return {
           ...context,
           [inputName]: value,
@@ -97,6 +95,15 @@ export const meansOfTransportFormMachine = setup({
       }
       return context;
     }),
+
+    onLineChange: assign(({ context, event }) => {
+      if (event.type === 'ON_LINE_CHANGE') {
+        const { inputName, value } = event;
+        if (inputName === 'line') return setLineAndResetStops(context, value);
+      }
+      return context;
+    }),
+
     navigateToErrorPage: () => {
       window.location.href = '/contact/error';
     },
@@ -182,6 +189,9 @@ export const meansOfTransportFormMachine = setup({
         },
         ON_TRANSPORTMODE_CHANGE: {
           actions: 'onTransportModeChange',
+        },
+        ON_LINE_CHANGE: {
+          actions: 'onLineChange',
         },
 
         VALIDATE: {

--- a/src/page-modules/contact/means-of-transport/means-of-transport-form-machine.ts
+++ b/src/page-modules/contact/means-of-transport/means-of-transport-form-machine.ts
@@ -95,10 +95,8 @@ export const meansOfTransportFormMachine = setup({
     }),
 
     onLineChange: assign(({ context, event }) => {
-      if (event.type === 'ON_LINE_CHANGE') {
-        const { inputName, value } = event;
-        if (inputName === 'line') return setLineAndResetStops(context, value);
-      }
+      if (event.type === 'ON_LINE_CHANGE')
+        return setLineAndResetStops(context, event.value);
       return context;
     }),
 

--- a/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
@@ -20,10 +20,6 @@ export const FeedbackForm = ({ state, send }: FeedbackFormProps) => {
   const { t } = useTranslation();
   const { getLinesByMode, getQuaysByLine } = useLines();
 
-  useEffect(() => {
-    console.log('state.context.line: ', state.context.line);
-  }, [state]);
-
   return (
     <div>
       <SectionCard title={t(PageText.Contact.ticketControl.feedback.title)}>

--- a/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
@@ -56,7 +56,6 @@ export const FeedbackForm = ({ state, send }: FeedbackFormProps) => {
             if (!value) return;
             send({
               type: 'ON_LINE_CHANGE',
-              inputName: 'line',
               value: value,
             });
           }}

--- a/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
@@ -10,7 +10,6 @@ import { Typo } from '@atb/components/typography';
 import { FileInput } from '../../components/input/file';
 import { ticketControlFormEvents } from '../events';
 import { ContextProps } from '../ticket-control-form-machine';
-import { useEffect } from 'react';
 
 type FeedbackFormProps = {
   state: { context: ContextProps };

--- a/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
@@ -33,7 +33,6 @@ export const FeedbackForm = ({ state, send }: FeedbackFormProps) => {
           onChange={(value) =>
             send({
               type: 'ON_TRANSPORTMODE_CHANGE',
-              inputName: 'transportMode',
               value: value as TransportModeType,
             })
           }

--- a/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
@@ -56,7 +56,7 @@ export const FeedbackForm = ({ state, send }: FeedbackFormProps) => {
           onChange={(value: Line | undefined) => {
             if (!value) return;
             send({
-              type: 'ON_INPUT_CHANGE',
+              type: 'ON_LINE_CHANGE',
               inputName: 'line',
               value: value,
             });

--- a/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
@@ -32,7 +32,7 @@ export const FeedbackForm = ({ state, send }: FeedbackFormProps) => {
           value={state.context.transportMode}
           onChange={(value) =>
             send({
-              type: 'ON_INPUT_CHANGE',
+              type: 'ON_TRANSPORTMODE_CHANGE',
               inputName: 'transportMode',
               value: value as TransportModeType,
             })

--- a/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
@@ -10,6 +10,7 @@ import { Typo } from '@atb/components/typography';
 import { FileInput } from '../../components/input/file';
 import { ticketControlFormEvents } from '../events';
 import { ContextProps } from '../ticket-control-form-machine';
+import { useEffect } from 'react';
 
 type FeedbackFormProps = {
   state: { context: ContextProps };
@@ -19,6 +20,10 @@ type FeedbackFormProps = {
 export const FeedbackForm = ({ state, send }: FeedbackFormProps) => {
   const { t } = useTranslation();
   const { getLinesByMode, getQuaysByLine } = useLines();
+
+  useEffect(() => {
+    console.log('state.context.line: ', state.context.line);
+  }, [state]);
 
   return (
     <div>

--- a/src/page-modules/contact/ticket-control/ticket-control-form-machine.ts
+++ b/src/page-modules/contact/ticket-control/ticket-control-form-machine.ts
@@ -234,10 +234,8 @@ export const ticketControlFormMachine = setup({
     }),
 
     onLineChange: assign(({ context, event }) => {
-      if (event.type === 'ON_LINE_CHANGE') {
-        const { inputName, value } = event;
-        if (inputName === 'line') return setLineAndResetStops(context, value);
-      }
+      if (event.type === 'ON_LINE_CHANGE')
+        return setLineAndResetStops(context, event.value);
       return context;
     }),
   },

--- a/src/page-modules/contact/ticket-control/ticket-control-form-machine.ts
+++ b/src/page-modules/contact/ticket-control/ticket-control-form-machine.ts
@@ -90,7 +90,7 @@ export type ContextProps = {
 };
 
 // Function to reset the agreement fields and error messages
-const setFormtypeAndInitialContext = (
+const setFormTypeAndInitialContext = (
   context: ContextProps,
   formType: FormType,
 ) => {

--- a/src/page-modules/contact/ticket-control/ticket-control-form-machine.ts
+++ b/src/page-modules/contact/ticket-control/ticket-control-form-machine.ts
@@ -219,8 +219,6 @@ export const ticketControlFormMachine = setup({
         if (inputName === 'agreesFirstAgreement' && !value)
           return disagreeAgreements(context);
 
-        if (inputName === 'line') return setLineAndResetStops(context, value);
-
         context.errorMessages[inputName] = [];
         return {
           ...context,
@@ -234,6 +232,14 @@ export const ticketControlFormMachine = setup({
         const { inputName, value } = event;
         if (inputName === 'transportMode')
           return setTransportModeAndResetLineAndStops(context, value);
+      }
+      return context;
+    }),
+
+    onLineChange: assign(({ context, event }) => {
+      if (event.type === 'ON_LINE_CHANGE') {
+        const { inputName, value } = event;
+        if (inputName === 'line') return setLineAndResetStops(context, value);
       }
       return context;
     }),
@@ -333,6 +339,9 @@ export const ticketControlFormMachine = setup({
         },
         ON_TRANSPORTMODE_CHANGE: {
           actions: 'onTransportModeChange',
+        },
+        ON_LINE_CHANGE: {
+          actions: 'onLineChange',
         },
 
         VALIDATE: {

--- a/src/page-modules/contact/ticket-control/ticket-control-form-machine.ts
+++ b/src/page-modules/contact/ticket-control/ticket-control-form-machine.ts
@@ -213,16 +213,28 @@ export const ticketControlFormMachine = setup({
         const { inputName, value } = event;
 
         if (inputName === 'formType')
-          return setFormtypeAndInitialContext(context, value as FormType);
+          return setFormTypeAndInitialContext(context, value as FormType);
 
         // Set both agreements to false if agreesFirstAgreement is set to false.
         if (inputName === 'agreesFirstAgreement' && !value)
           return disagreeAgreements(context);
 
+        if (inputName === 'line') return setLineAndResetStops(context, value);
+
+        context.errorMessages[inputName] = [];
+        return {
+          ...context,
+          [inputName]: value,
+        };
+      }
+      return context;
+    }),
+    onTransportModeChange: assign(({ context, event }) => {
+      if (event.type === 'ON_TRANSPORTMODE_CHANGE') {
+        const { inputName, value } = event;
+
         if (inputName === 'transportMode')
           return setTransportModeAndResetLineAndStops(context, value);
-
-        if (inputName === 'line') return setLineAndResetStops(context, value);
 
         context.errorMessages[inputName] = [];
         return {
@@ -325,6 +337,9 @@ export const ticketControlFormMachine = setup({
       on: {
         ON_INPUT_CHANGE: {
           actions: 'onInputChange',
+        },
+        ON_TRANSPORTMODE_CHANGE: {
+          actions: 'onTransportModeChange',
         },
 
         VALIDATE: {

--- a/src/page-modules/contact/ticket-control/ticket-control-form-machine.ts
+++ b/src/page-modules/contact/ticket-control/ticket-control-form-machine.ts
@@ -232,15 +232,8 @@ export const ticketControlFormMachine = setup({
     onTransportModeChange: assign(({ context, event }) => {
       if (event.type === 'ON_TRANSPORTMODE_CHANGE') {
         const { inputName, value } = event;
-
         if (inputName === 'transportMode')
           return setTransportModeAndResetLineAndStops(context, value);
-
-        context.errorMessages[inputName] = [];
-        return {
-          ...context,
-          [inputName]: value,
-        };
       }
       return context;
     }),

--- a/src/page-modules/contact/ticket-control/ticket-control-form-machine.ts
+++ b/src/page-modules/contact/ticket-control/ticket-control-form-machine.ts
@@ -228,11 +228,8 @@ export const ticketControlFormMachine = setup({
       return context;
     }),
     onTransportModeChange: assign(({ context, event }) => {
-      if (event.type === 'ON_TRANSPORTMODE_CHANGE') {
-        const { inputName, value } = event;
-        if (inputName === 'transportMode')
-          return setTransportModeAndResetLineAndStops(context, value);
-      }
+      if (event.type === 'ON_TRANSPORTMODE_CHANGE')
+        return setTransportModeAndResetLineAndStops(context, event.value);
       return context;
     }),
 

--- a/src/page-modules/contact/travel-guarantee/index.tsx
+++ b/src/page-modules/contact/travel-guarantee/index.tsx
@@ -71,7 +71,7 @@ export const RefundForm = () => {
             onChange={(value: Line | undefined) => {
               if (!value) return;
               send({
-                type: 'ON_INPUT_CHANGE',
+                type: 'ON_LINE_CHANGE',
                 inputName: 'line',
                 value: value,
               });

--- a/src/page-modules/contact/travel-guarantee/index.tsx
+++ b/src/page-modules/contact/travel-guarantee/index.tsx
@@ -47,7 +47,6 @@ export const RefundForm = () => {
             onChange={(value) =>
               send({
                 type: 'ON_TRANSPORTMODE_CHANGE',
-                inputName: 'transportMode',
                 value: value as TransportModeType,
               })
             }

--- a/src/page-modules/contact/travel-guarantee/index.tsx
+++ b/src/page-modules/contact/travel-guarantee/index.tsx
@@ -46,7 +46,7 @@ export const RefundForm = () => {
             value={state.context.transportMode}
             onChange={(value) =>
               send({
-                type: 'ON_INPUT_CHANGE',
+                type: 'ON_TRANSPORTMODE_CHANGE',
                 inputName: 'transportMode',
                 value: value as TransportModeType,
               })

--- a/src/page-modules/contact/travel-guarantee/index.tsx
+++ b/src/page-modules/contact/travel-guarantee/index.tsx
@@ -71,7 +71,6 @@ export const RefundForm = () => {
               if (!value) return;
               send({
                 type: 'ON_LINE_CHANGE',
-                inputName: 'line',
                 value: value,
               });
             }}

--- a/src/page-modules/contact/travel-guarantee/travelGuaranteeFormMachine.ts
+++ b/src/page-modules/contact/travel-guarantee/travelGuaranteeFormMachine.ts
@@ -81,8 +81,6 @@ export const fetchMachine = setup({
       if (event.type === 'ON_INPUT_CHANGE') {
         let { inputName, value } = event;
 
-        if (inputName === 'line') return setLineAndResetStops(context, value);
-
         context.errorMessages[inputName] = [];
         return {
           ...context,
@@ -97,6 +95,14 @@ export const fetchMachine = setup({
         const { inputName, value } = event;
         if (inputName === 'transportMode')
           return setTransportModeAndResetLineAndStops(context, value);
+      }
+      return context;
+    }),
+
+    onLineChange: assign(({ context, event }) => {
+      if (event.type === 'ON_LINE_CHANGE') {
+        const { inputName, value } = event;
+        if (inputName === 'line') return setLineAndResetStops(context, value);
       }
       return context;
     }),
@@ -209,6 +215,9 @@ export const fetchMachine = setup({
         },
         ON_TRANSPORTMODE_CHANGE: {
           actions: 'onTransportModeChange',
+        },
+        ON_LINE_CHANGE: {
+          actions: 'onLineChange',
         },
         VALIDATE: {
           guard: 'validateInputs',

--- a/src/page-modules/contact/travel-guarantee/travelGuaranteeFormMachine.ts
+++ b/src/page-modules/contact/travel-guarantee/travelGuaranteeFormMachine.ts
@@ -81,9 +81,6 @@ export const fetchMachine = setup({
       if (event.type === 'ON_INPUT_CHANGE') {
         let { inputName, value } = event;
 
-        if (inputName === 'transportMode')
-          return setTransportModeAndResetLineAndStops(context, value);
-
         if (inputName === 'line') return setLineAndResetStops(context, value);
 
         context.errorMessages[inputName] = [];
@@ -91,6 +88,15 @@ export const fetchMachine = setup({
           ...context,
           [inputName]: value,
         };
+      }
+      return context;
+    }),
+
+    onTransportModeChange: assign(({ context, event }) => {
+      if (event.type === 'ON_TRANSPORTMODE_CHANGE') {
+        const { inputName, value } = event;
+        if (inputName === 'transportMode')
+          return setTransportModeAndResetLineAndStops(context, value);
       }
       return context;
     }),
@@ -198,9 +204,11 @@ export const fetchMachine = setup({
         OTHER: {
           target: 'editing.other',
         },
-
         ON_INPUT_CHANGE: {
           actions: 'onInputChange',
+        },
+        ON_TRANSPORTMODE_CHANGE: {
+          actions: 'onTransportModeChange',
         },
         VALIDATE: {
           guard: 'validateInputs',

--- a/src/page-modules/contact/travel-guarantee/travelGuaranteeFormMachine.ts
+++ b/src/page-modules/contact/travel-guarantee/travelGuaranteeFormMachine.ts
@@ -6,7 +6,12 @@ import {
   InputErrorMessages,
   travelGuaranteeInputValidator,
 } from '../validation';
-import { getCurrentDateString, getCurrentTimeString } from '../utils';
+import {
+  getCurrentDateString,
+  getCurrentTimeString,
+  setLineAndResetStops,
+  setTransportModeAndResetLineAndStops,
+} from '../utils';
 import { TravelGuaranteeFormEvents } from './events';
 
 type APIParams = {
@@ -75,6 +80,12 @@ export const fetchMachine = setup({
     onInputChange: assign(({ context, event }) => {
       if (event.type === 'ON_INPUT_CHANGE') {
         let { inputName, value } = event;
+
+        if (inputName === 'transportMode')
+          return setTransportModeAndResetLineAndStops(context, value);
+
+        if (inputName === 'line') return setLineAndResetStops(context, value);
+
         context.errorMessages[inputName] = [];
         return {
           ...context,

--- a/src/page-modules/contact/travel-guarantee/travelGuaranteeFormMachine.ts
+++ b/src/page-modules/contact/travel-guarantee/travelGuaranteeFormMachine.ts
@@ -97,10 +97,8 @@ export const fetchMachine = setup({
     }),
 
     onLineChange: assign(({ context, event }) => {
-      if (event.type === 'ON_LINE_CHANGE') {
-        const { inputName, value } = event;
-        if (inputName === 'line') return setLineAndResetStops(context, value);
-      }
+      if (event.type === 'ON_LINE_CHANGE')
+        return setLineAndResetStops(context, event.value);
       return context;
     }),
 

--- a/src/page-modules/contact/travel-guarantee/travelGuaranteeFormMachine.ts
+++ b/src/page-modules/contact/travel-guarantee/travelGuaranteeFormMachine.ts
@@ -91,11 +91,8 @@ export const fetchMachine = setup({
     }),
 
     onTransportModeChange: assign(({ context, event }) => {
-      if (event.type === 'ON_TRANSPORTMODE_CHANGE') {
-        const { inputName, value } = event;
-        if (inputName === 'transportMode')
-          return setTransportModeAndResetLineAndStops(context, value);
-      }
+      if (event.type === 'ON_TRANSPORTMODE_CHANGE')
+        return setTransportModeAndResetLineAndStops(context, event.value);
       return context;
     }),
 

--- a/src/page-modules/contact/utils.ts
+++ b/src/page-modules/contact/utils.ts
@@ -1,3 +1,6 @@
+import { TransportModeType } from '@atb-as/config-specs';
+import { Line } from '.';
+
 export const shouldShowContactPage = (): boolean => {
   return process.env.NEXT_PUBLIC_CONTACT_API_URL ? true : false;
 };
@@ -36,3 +39,25 @@ export const getCurrentDateString = (): string =>
 
 export const getCurrentTimeString = (): string =>
   `${String(new Date().getHours()).padStart(2, '0')}:${String(new Date().getMinutes()).padStart(2, '0')}`;
+
+export const setTransportModeAndResetLineAndStops = (
+  context: any,
+  transporMode: TransportModeType,
+) => {
+  return {
+    ...context,
+    transportMode: transporMode,
+    line: undefined,
+    fromStop: undefined,
+    toStop: undefined,
+  };
+};
+
+export const setLineAndResetStops = (context: any, line: Line) => {
+  return {
+    ...context,
+    line: line,
+    fromStop: undefined,
+    toStop: undefined,
+  };
+};

--- a/src/page-modules/contact/utils.ts
+++ b/src/page-modules/contact/utils.ts
@@ -50,6 +50,13 @@ export const setTransportModeAndResetLineAndStops = (
     line: undefined,
     fromStop: undefined,
     toStop: undefined,
+    errorMessages: {
+      ...context.errorMessages,
+      transportMode: [],
+      line: [],
+      fromStop: [],
+      toStop: [],
+    },
   };
 };
 

--- a/src/page-modules/contact/utils.ts
+++ b/src/page-modules/contact/utils.ts
@@ -66,5 +66,11 @@ export const setLineAndResetStops = (context: any, line: Line) => {
     line: line,
     fromStop: undefined,
     toStop: undefined,
+    errorMessages: {
+      ...context.errorMessages,
+      line: [],
+      fromStop: [],
+      toStop: [],
+    },
   };
 };


### PR DESCRIPTION
This PR adds `setTransportModeAndResetLineAndStops` `setLineAndResetStops`, two functions used to  correctly handle `line`, `fromStop` and `toStop` whenever `transportMode` and/or `line` is set.