### PR TITLE
fix: consistent width of input fields in Chrome, FireFox and Safari.  

### DIFF
--- a/src/page-modules/contact/components/input/input.module.css
+++ b/src/page-modules/contact/components/input/input.module.css
@@ -26,6 +26,7 @@
 
   border: var(--border-width-medium) solid var(--text-colors-primary);
   border-radius: var(--border-radius-small);
+  width: 100%;
 }
 
 .input:focus {


### PR DESCRIPTION
### What is wrong, and what is expected behavior?
When in Safari, after submitting, the width of input fields is adjusted when using tab to navigate between them.    

### How to replicate:
Submit button. Then, navigate between the input fields using tab. 

### Illustration
<details>
<Summary>Before fix</Summary>

https://github.com/user-attachments/assets/5035cba5-c8c8-437e-a9c5-772073a4eb54


</details>

<details>
<Summary>After fix</Summary>


https://github.com/user-attachments/assets/ef4c79e8-5492-4510-b3f2-35181c75f359


</details>

### Acceptance criteria
- [x] Width of input does not change when using tab to navigate between input fields after submit in Safari, Chrome or Firefox.






