### PR TITLE
chore: add conditional validation of bankAccountNumber, IBAN and SWIFT 

### DIFF
--- a/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
@@ -379,7 +379,7 @@ const FormContent = ({ state, send }: FormProps) => {
           <div>
             <Input
               label={PageText.Contact.input.bankAccountNumber.IBAN}
-              type="number"
+              type="string"
               name="IBAN"
               value={state.context.IBAN || ''}
               onChange={(e) =>
@@ -393,7 +393,7 @@ const FormContent = ({ state, send }: FormProps) => {
 
             <Input
               label={PageText.Contact.input.bankAccountNumber.SWIFT}
-              type="number"
+              type="string"
               name="SWIFT"
               value={state.context.SWIFT || ''}
               onChange={(e) =>

--- a/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
@@ -345,7 +345,7 @@ const FormContent = ({ state, send }: FormProps) => {
         />
 
         <Checkbox
-          label={t(PageText.Contact.input.bankAccountNumber.checkbox)}
+          label={t(PageText.Contact.input.bankInformation.checkbox)}
           checked={state.context.hasInternationalBankAccount}
           onChange={() =>
             send({
@@ -358,7 +358,9 @@ const FormContent = ({ state, send }: FormProps) => {
 
         {!state.context.hasInternationalBankAccount && (
           <Input
-            label={PageText.Contact.input.bankAccountNumber.notForeignLabel}
+            label={
+              PageText.Contact.input.bankInformation.bankAccountNumber.label
+            }
             type="number"
             name="bankAccountNumber"
             value={state.context.bankAccountNumber || ''}
@@ -378,10 +380,11 @@ const FormContent = ({ state, send }: FormProps) => {
         {state.context.hasInternationalBankAccount && (
           <div>
             <Input
-              label={PageText.Contact.input.bankAccountNumber.IBAN}
+              label={PageText.Contact.input.bankInformation.IBAN.label}
               type="string"
               name="IBAN"
               value={state.context.IBAN || ''}
+              errorMessage={state.context?.errorMessages['IBAN']?.[0]}
               onChange={(e) =>
                 send({
                   type: 'ON_INPUT_CHANGE',
@@ -392,10 +395,11 @@ const FormContent = ({ state, send }: FormProps) => {
             />
 
             <Input
-              label={PageText.Contact.input.bankAccountNumber.SWIFT}
+              label={PageText.Contact.input.bankInformation.SWIFT.label}
               type="string"
               name="SWIFT"
               value={state.context.SWIFT || ''}
+              errorMessage={state.context?.errorMessages['SWIFT']?.[0]}
               onChange={(e) =>
                 send({
                   type: 'ON_INPUT_CHANGE',
@@ -404,13 +408,6 @@ const FormContent = ({ state, send }: FormProps) => {
                 })
               }
             />
-            {state.context?.errorMessages['bankAccountNumber']?.[0] && (
-              <ErrorMessage
-                message={t(
-                  state.context?.errorMessages['bankAccountNumber']?.[0],
-                )}
-              />
-            )}
           </div>
         )}
       </SectionCard>

--- a/src/page-modules/contact/ticket-control/ticket-control-form-machine.ts
+++ b/src/page-modules/contact/ticket-control/ticket-control-form-machine.ts
@@ -130,6 +130,7 @@ const setInputToValidate = (context: ContextProps) => {
     address,
     postalCode,
     city,
+    hasInternationalBankAccount,
     bankAccountNumber,
     IBAN,
     SWIFT,
@@ -156,9 +157,9 @@ const setInputToValidate = (context: ContextProps) => {
         postalCode,
         city,
         phoneNumber,
-        bankAccountNumber,
-        IBAN,
-        SWIFT,
+        ...(hasInternationalBankAccount
+          ? { IBAN, SWIFT }
+          : { bankAccountNumber }),
       };
 
     case FormType.Feedback:

--- a/src/page-modules/contact/travel-guarantee/forms/refundCarForm.tsx
+++ b/src/page-modules/contact/travel-guarantee/forms/refundCarForm.tsx
@@ -367,7 +367,7 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
         />
 
         <Checkbox
-          label={t(PageText.Contact.input.bankAccountNumber.checkbox)}
+          label={t(PageText.Contact.input.bankInformation.checkbox)}
           checked={state.context.hasInternationalBankAccount}
           onChange={() =>
             send({
@@ -380,7 +380,9 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
 
         {!state.context.hasInternationalBankAccount && (
           <Input
-            label={PageText.Contact.input.bankAccountNumber.notForeignLabel}
+            label={
+              PageText.Contact.input.bankInformation.bankAccountNumber.label
+            }
             type="number"
             name="bankAccountNumber"
             value={state.context.bankAccountNumber || ''}
@@ -400,10 +402,11 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
         {state.context.hasInternationalBankAccount && (
           <div>
             <Input
-              label={PageText.Contact.input.bankAccountNumber.IBAN}
+              label={PageText.Contact.input.bankInformation.IBAN.label}
               type="string"
               name="IBAN"
               value={state.context.IBAN || ''}
+              errorMessage={state.context?.errorMessages['IBAN']?.[0]}
               onChange={(e) =>
                 send({
                   type: 'ON_INPUT_CHANGE',
@@ -414,10 +417,11 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
             />
 
             <Input
-              label={PageText.Contact.input.bankAccountNumber.SWIFT}
+              label={PageText.Contact.input.bankInformation.SWIFT.label}
               type="string"
               name="SWIFT"
               value={state.context.SWIFT || ''}
+              errorMessage={state.context?.errorMessages['SWIFT']?.[0]}
               onChange={(e) =>
                 send({
                   type: 'ON_INPUT_CHANGE',
@@ -426,13 +430,6 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
                 })
               }
             />
-            {state.context?.errorMessages['bankAccountNumber']?.[0] && (
-              <ErrorMessage
-                message={t(
-                  state.context?.errorMessages['bankAccountNumber']?.[0],
-                )}
-              />
-            )}
           </div>
         )}
       </SectionCard>

--- a/src/page-modules/contact/travel-guarantee/forms/refundCarForm.tsx
+++ b/src/page-modules/contact/travel-guarantee/forms/refundCarForm.tsx
@@ -401,7 +401,7 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
           <div>
             <Input
               label={PageText.Contact.input.bankAccountNumber.IBAN}
-              type="number"
+              type="string"
               name="IBAN"
               value={state.context.IBAN || ''}
               onChange={(e) =>
@@ -415,7 +415,7 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
 
             <Input
               label={PageText.Contact.input.bankAccountNumber.SWIFT}
-              type="number"
+              type="string"
               name="SWIFT"
               value={state.context.SWIFT || ''}
               onChange={(e) =>

--- a/src/page-modules/contact/travel-guarantee/forms/refundTaxiForm.tsx
+++ b/src/page-modules/contact/travel-guarantee/forms/refundTaxiForm.tsx
@@ -318,7 +318,7 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
         />
 
         <Checkbox
-          label={t(PageText.Contact.input.bankAccountNumber.checkbox)}
+          label={t(PageText.Contact.input.bankInformation.checkbox)}
           checked={state.context.hasInternationalBankAccount}
           onChange={() =>
             send({
@@ -331,7 +331,9 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
 
         {!state.context.hasInternationalBankAccount && (
           <Input
-            label={PageText.Contact.input.bankAccountNumber.notForeignLabel}
+            label={
+              PageText.Contact.input.bankInformation.bankAccountNumber.label
+            }
             type="number"
             name="bankAccountNumber"
             value={state.context.bankAccountNumber || ''}
@@ -351,10 +353,11 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
         {state.context.hasInternationalBankAccount && (
           <div>
             <Input
-              label={PageText.Contact.input.bankAccountNumber.IBAN}
+              label={PageText.Contact.input.bankInformation.IBAN.label}
               type="string"
               name="IBAN"
               value={state.context.IBAN || ''}
+              errorMessage={state.context?.errorMessages['IBAN']?.[0]}
               onChange={(e) =>
                 send({
                   type: 'ON_INPUT_CHANGE',
@@ -365,10 +368,11 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
             />
 
             <Input
-              label={PageText.Contact.input.bankAccountNumber.SWIFT}
+              label={PageText.Contact.input.bankInformation.SWIFT.label}
               type="string"
               name="SWIFT"
               value={state.context.SWIFT || ''}
+              errorMessage={state.context?.errorMessages['SWIFT']?.[0]}
               onChange={(e) =>
                 send({
                   type: 'ON_INPUT_CHANGE',
@@ -377,13 +381,6 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
                 })
               }
             />
-            {state.context?.errorMessages['bankAccountNumber']?.[0] && (
-              <ErrorMessage
-                message={t(
-                  state.context?.errorMessages['bankAccountNumber']?.[0],
-                )}
-              />
-            )}
           </div>
         )}
       </SectionCard>

--- a/src/page-modules/contact/travel-guarantee/forms/refundTaxiForm.tsx
+++ b/src/page-modules/contact/travel-guarantee/forms/refundTaxiForm.tsx
@@ -352,7 +352,7 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
           <div>
             <Input
               label={PageText.Contact.input.bankAccountNumber.IBAN}
-              type="number"
+              type="string"
               name="IBAN"
               value={state.context.IBAN || ''}
               onChange={(e) =>
@@ -366,7 +366,7 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
 
             <Input
               label={PageText.Contact.input.bankAccountNumber.SWIFT}
-              type="number"
+              type="string"
               name="SWIFT"
               value={state.context.SWIFT || ''}
               onChange={(e) =>

--- a/src/page-modules/contact/travel-guarantee/travelGuaranteeFormMachine.ts
+++ b/src/page-modules/contact/travel-guarantee/travelGuaranteeFormMachine.ts
@@ -93,6 +93,7 @@ const setInputToValidate = (context: ContextProps) => {
     address,
     postalCode,
     city,
+    hasInternationalBankAccount,
     bankAccountNumber,
     IBAN,
     SWIFT,
@@ -123,9 +124,7 @@ const setInputToValidate = (context: ContextProps) => {
     postalCode,
     city,
     phoneNumber,
-    bankAccountNumber,
-    IBAN,
-    SWIFT,
+    ...(hasInternationalBankAccount ? { IBAN, SWIFT } : { bankAccountNumber }),
   };
 
   switch (formType) {

--- a/src/page-modules/contact/validation/commonInputValidator.ts
+++ b/src/page-modules/contact/validation/commonInputValidator.ts
@@ -42,10 +42,22 @@ export const commonInputValidator = (context: any) => {
     },
     {
       inputName: 'bankAccountNumber',
-      validCondition:
-        context.bankAccountNumber || context.IBAN || context.SWIFT,
+      validCondition: context.bankAccountNumber,
       errorMessage:
-        PageText.Contact.input.bankAccountNumber.errorMessages.empty,
+        PageText.Contact.input.bankInformation.bankAccountNumber.errorMessages
+          .empty,
+    },
+    {
+      inputName: 'IBAN',
+      validCondition: context.IBAN,
+      errorMessage:
+        PageText.Contact.input.bankInformation.IBAN.errorMessages.empty,
+    },
+    {
+      inputName: 'SWIFT',
+      validCondition: context.SWIFT,
+      errorMessage:
+        PageText.Contact.input.bankInformation.SWIFT.errorMessages.empty,
     },
     {
       inputName: 'area',

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -552,7 +552,7 @@ export const Contact = {
         errorMessages: {
           empty: _(
             'Vennligst fyll ut ditt bankkontonummer',
-            'Please provide your bank account',
+            'Please provide your bank account number',
             'Vennligst fyll ut ditt bankkontonummer',
           ),
         },

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -546,27 +546,42 @@ export const Contact = {
       },
     },
 
-    bankAccountNumber: {
-      notForeignLabel: _(
-        'Bankkontonummer',
-        'Bank account number',
-        'Bankkontonummer',
-      ),
+    bankInformation: {
+      bankAccountNumber: {
+        label: _('Bankkontonummer', 'Bank account number', 'Bankkontonummer'),
+        errorMessages: {
+          empty: _(
+            'Vennligst fyll ut ditt bankkontonummer',
+            'Please provide your bank account',
+            'Vennligst fyll ut ditt bankkontonummer',
+          ),
+        },
+      },
+      IBAN: {
+        label: _('IBAN', 'IBAN', 'IBAN'),
+        errorMessages: {
+          empty: _(
+            'Vennligst fyll ut ditt IBAN-nummer',
+            'Please provide your bank IBAN number',
+            'Vennligst fyll ut ditt IBAN-nummer',
+          ),
+        },
+      },
+      SWIFT: {
+        label: _('SWIFT ', 'SWIFT ', 'SWIFT '),
+        errorMessages: {
+          empty: _(
+            'Vennligst fyll ut ditt SWIFT-nummer',
+            'Please provide your SWIFT number',
+            'Vennligst fyll ut ditt SWIFT-nummer',
+          ),
+        },
+      },
       checkbox: _(
         'Jeg har et utenlandsk bankkontonummer',
         'I have a foreign bank account',
         'Eg har eit utanlandsk bankkontonummer',
       ),
-      IBAN: _('IBAN', 'IBAN', 'IBAN'),
-      SWIFT: _('SWIFT ', 'SWIFT ', 'SWIFT '),
-
-      errorMessages: {
-        empty: _(
-          'Vennligst fyll ut ditt bankkontonummer',
-          'Please provide your bank account',
-          'Vennligst fyll ut ditt bankkontonummer',
-        ),
-      },
     },
 
     transportMode: {


### PR DESCRIPTION
This PR includes the following:

- [x] Set both IBAN and SWIFT input fields to `type: 'string'`. These numbers contains both numbers and characters. 
- [x]  Add conditional validation of bankAccountNumber, IBAN and SWIFT 