### PR TITLE
feat: lost property contact page

### DIFF
--- a/src/page-modules/contact/layouts/contact-page-layout.tsx
+++ b/src/page-modules/contact/layouts/contact-page-layout.tsx
@@ -36,11 +36,13 @@ export const contactPages: ContactPage[] = [
     href: '/contact/tickets-app',
     icon: 'devices/Phone',
   },
+  */
   {
-    title: PageText.Contact.lostAndFound.title,
-    href: '/contact/lost-and-found',
+    title: PageText.Contact.lostProperty.title,
+    href: '/contact/lost-property',
     icon: 'actions/Support',
   },
+  /*
   {
     title: PageText.Contact.groupTravel.title,
     href: '/contact/group-travel',

--- a/src/page-modules/contact/lost-property/index.tsx
+++ b/src/page-modules/contact/lost-property/index.tsx
@@ -1,0 +1,25 @@
+import { Typo } from '@atb/components/typography';
+import { SectionCard } from '../components/section-card';
+import { PageText, useTranslation } from '@atb/translations';
+
+export default function LostPropertyContent() {
+  const { t } = useTranslation();
+  return (
+    <div>
+      <SectionCard title={t(PageText.Contact.lostProperty.title)}>
+        <Typo.p textType="body__primary">
+          <span>
+            {t(PageText.Contact.lostProperty.description.info)},&nbsp;
+            <a
+              href={t(PageText.Contact.lostProperty.description.url)}
+              target="_blank"
+              rel="noreferrer"
+            >
+              {t(PageText.Contact.lostProperty.description.externalLink)}
+            </a>
+          </span>
+        </Typo.p>
+      </SectionCard>
+    </div>
+  );
+}

--- a/src/pages/contact/lost-property.tsx
+++ b/src/pages/contact/lost-property.tsx
@@ -1,0 +1,24 @@
+import DefaultLayout from '@atb/layouts/default';
+import { withGlobalData, WithGlobalData } from '@atb/layouts/global-data';
+import {
+  ContactPageLayout,
+  ContactPageLayoutProps,
+} from '@atb/page-modules/contact';
+import LostPropertyContent from '@atb/page-modules/contact/lost-property';
+import { NextPage } from 'next';
+
+export type LostPropertyPageProps = WithGlobalData<ContactPageLayoutProps>;
+
+const LostPropertyPage: NextPage<LostPropertyPageProps> = (props) => {
+  return (
+    <DefaultLayout {...props}>
+      <ContactPageLayout {...props}>
+        <LostPropertyContent />
+      </ContactPageLayout>
+    </DefaultLayout>
+  );
+};
+
+export default LostPropertyPage;
+
+export const getServerSideProps = withGlobalData();

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -427,12 +427,29 @@ export const Contact = {
       },
     },
   },
+  lostProperty: {
+    title: _('Hittegods', 'Lost property', 'Hittegods'),
+    description: {
+      info: _(
+        'Har du glemt igjen noe i en av bussene, hurtigbåtene eller fergene',
+        'If you have forgotten something on one of the buses, express boats, or ferries',
+        'Har du gløymt igjen noko i ein av bussane, hurtigbåtane eller ferjene',
+      ),
+      externalLink: _(
+        'finner du informasjon om hvem du kan kontakte her.',
+        'you can find information on who to contact here.',
+        'finn du informasjon om kven du kan ta kontakt med her.',
+      ),
+      url: _(
+        'https://frammr.no/hjelp-og-kontakt/hittegods/',
+        'https://frammr.no/hjelp-og-kontakt/hittegods/?sprak=3',
+        'https://frammr.no/hjelp-og-kontakt/hittegods/',
+      ),
+    },
+  },
 
   ticketsApp: {
     title: _('Billetter og app', 'Tickets and app', 'Billettar og app'),
-  },
-  lostAndFound: {
-    title: _('Hittegods', 'Lost and found', 'Hittegods'),
   },
   groupTravel: {
     title: _('Gruppereise', 'Group travel', 'Gruppereise'),


### PR DESCRIPTION
Added the lost property contact page: 

<img width="1381" alt="image" src="https://github.com/user-attachments/assets/73726faf-d748-461e-beea-0955d2baa0ef">
