### PR TITLE
feat: group travel contact page

### DIFF
--- a/src/page-modules/contact/group-travel/group-travel-state-machine.ts
+++ b/src/page-modules/contact/group-travel/group-travel-state-machine.ts
@@ -18,7 +18,8 @@ export type GroupTravelContextType = {
 
     groupSize: string;
     groupInfo: string;
-    responsiblePerson: string;
+    firstName: string;
+    lastName: string;
     phoneNumber: string;
     email: string;
   };
@@ -30,7 +31,8 @@ export type GroupTravelContextType = {
     toStop: boolean;
     groupSize: boolean;
     groupInfo: boolean;
-    responsiblePerson: boolean;
+    firstName: boolean;
+    lastName: boolean;
     phoneNumber: boolean;
     email: boolean;
   };
@@ -44,7 +46,8 @@ const defaultErrors: GroupTravelContextType['errors'] = {
   toStop: false,
   groupSize: false,
   groupInfo: false,
-  responsiblePerson: false,
+  firstName: false,
+  lastName: false,
   phoneNumber: false,
   email: false,
 };

--- a/src/page-modules/contact/group-travel/group-travel-state-machine.ts
+++ b/src/page-modules/contact/group-travel/group-travel-state-machine.ts
@@ -114,12 +114,12 @@ export const groupTravelStateMachine = setup({
           method: 'POST',
           body: JSON.stringify({
             ...input,
-            line: input.line.id,
-            fromStop: input.fromStop.id,
-            toStop: input.toStop.id,
-            returnLine: input.returnLine?.id,
-            returnFromStop: input.returnFromStop?.id,
-            returnToStop: input.returnToStop?.id,
+            line: input.line.name,
+            fromStop: input.fromStop.name,
+            toStop: input.toStop.name,
+            returnLine: input.returnLine?.name,
+            returnFromStop: input.returnFromStop?.name,
+            returnToStop: input.returnToStop?.name,
           }),
         })
           .then((response) => {

--- a/src/page-modules/contact/group-travel/group-travel-state-machine.ts
+++ b/src/page-modules/contact/group-travel/group-travel-state-machine.ts
@@ -1,0 +1,223 @@
+import { assign, fromPromise, setup } from 'xstate';
+import { Line } from '../server/journey-planner/validators';
+import { getCurrentDateString, getCurrentTimeString } from '../utils';
+
+export type GroupTravelContextType = {
+  travelType: 'bus' | 'boat' | null;
+  formData: {
+    dateOfTravel: string;
+    line: Line;
+    fromStop: Line['quays'][0];
+    departureTime: string;
+    toStop: Line['quays'][0];
+
+    returnLine?: Line;
+    returnFromStop?: Line['quays'][0];
+    returnDepartureTime?: string;
+    returnToStop?: Line['quays'][0];
+
+    groupSize: string;
+    groupInfo: string;
+    responsiblePerson: string;
+    phoneNumber: string;
+    email: string;
+  };
+  errors: {
+    dateOfTravel: boolean;
+    line: boolean;
+    fromStop: boolean;
+    departureTime: boolean;
+    toStop: boolean;
+    groupSize: boolean;
+    groupInfo: boolean;
+    responsiblePerson: boolean;
+    phoneNumber: boolean;
+    email: boolean;
+  };
+};
+
+const defaultErrors: GroupTravelContextType['errors'] = {
+  dateOfTravel: false,
+  line: false,
+  fromStop: false,
+  departureTime: false,
+  toStop: false,
+  groupSize: false,
+  groupInfo: false,
+  responsiblePerson: false,
+  phoneNumber: false,
+  email: false,
+};
+
+type GroupTravelEvents =
+  | { type: 'SELECT_TRAVEL_TYPE'; travelType: 'bus' | 'boat' | null }
+  | { type: 'UPDATE_FORM_DATA'; formData: GroupTravelContextType['formData'] }
+  | { type: 'SUBMIT' };
+
+export const groupTravelStateMachine = setup({
+  types: {
+    context: {} as GroupTravelContextType,
+    events: {} as GroupTravelEvents,
+  },
+  guards: {
+    isFormValid: ({ context }) => {
+      const errors: GroupTravelContextType['errors'] = defaultErrors;
+
+      Object.keys(context.errors).forEach((key) => {
+        errors[key as keyof GroupTravelContextType['errors']] =
+          !context.formData[key as keyof GroupTravelContextType['formData']];
+      });
+
+      const hasErrors = Object.values(errors).some((isError) => isError);
+
+      if (hasErrors) {
+        return false;
+      }
+      return true;
+    },
+  },
+  actions: {
+    navigateToErrorPage: () => {
+      window.location.href = '/contact/error';
+    },
+    navigateToSuccessPage: () => {
+      window.location.href = '/contact/success';
+    },
+    selectTravelType: assign(({ context, event }) => {
+      if (event.type !== 'SELECT_TRAVEL_TYPE') return context;
+      return {
+        travelType: event.travelType,
+      };
+    }),
+    updateFormData: assign(({ context, event }) => {
+      if (event.type !== 'UPDATE_FORM_DATA') return context;
+      return {
+        formData: {
+          ...context.formData,
+          ...event.formData,
+        },
+      };
+    }),
+    setValidationErrors: assign(({ context }) => {
+      const updatedErrors: GroupTravelContextType['errors'] = defaultErrors;
+
+      Object.keys(context.errors).forEach((key) => {
+        updatedErrors[key as keyof GroupTravelContextType['errors']] =
+          !context.formData[key as keyof GroupTravelContextType['formData']];
+      });
+
+      return { errors: { ...updatedErrors } };
+    }),
+    clearValidationErrors: assign({ errors: defaultErrors }),
+  },
+  actors: {
+    submitForm: fromPromise(
+      async ({ input }: { input: GroupTravelContextType['formData'] }) => {
+        await fetch('/api/contact/group-travel', {
+          method: 'POST',
+          body: JSON.stringify({
+            ...input,
+            line: input.line.id,
+            fromStop: input.fromStop.id,
+            toStop: input.toStop.id,
+            returnLine: input.returnLine?.id,
+            returnFromStop: input.returnFromStop?.id,
+            returnToStop: input.returnToStop?.id,
+          }),
+        })
+          .then((response) => {
+            if (!response.ok) throw new Error('Failed to submit form');
+            return response.ok;
+          })
+          .catch((error) => {
+            throw new Error('Failed to submit form');
+          });
+      },
+    ),
+  },
+}).createMachine({
+  id: 'ticketControlForm',
+  initial: 'selectTravelType',
+  context: {
+    travelType: null,
+    formData: {
+      dateOfTravel: getCurrentDateString(),
+      departureTime: getCurrentTimeString(),
+    },
+    errors: defaultErrors,
+  } as GroupTravelContextType,
+  on: {
+    SELECT_TRAVEL_TYPE: {
+      target: '#travelTypeHandler',
+      actions: 'selectTravelType',
+    },
+  },
+  states: {
+    selectTravelType: {},
+    travelTypeHandler: {
+      id: 'travelTypeHandler',
+      always: [
+        {
+          guard: ({ context }) => context.travelType === 'boat',
+          target: 'boatInfo',
+        },
+        {
+          guard: ({ context }) => context.travelType === 'bus',
+          target: 'busForm',
+        },
+        {
+          guard: ({ context }) => context.travelType === null,
+          target: 'selectTravelType',
+        },
+      ],
+    },
+    boatInfo: {},
+    busForm: {
+      initial: 'editing',
+      states: {
+        editing: {
+          on: {
+            UPDATE_FORM_DATA: {
+              actions: 'updateFormData',
+            },
+            SUBMIT: {
+              target: 'validating',
+            },
+          },
+        },
+        validating: {
+          always: [
+            {
+              guard: 'isFormValid',
+              target: 'submitting',
+            },
+            {
+              target: 'editing',
+              actions: 'setValidationErrors',
+            },
+          ],
+        },
+        submitting: {
+          invoke: {
+            src: 'submitForm',
+            input: ({ context }) => context.formData,
+            onDone: {
+              target: 'success',
+            },
+            onError: {
+              target: 'error',
+            },
+          },
+        },
+        success: {
+          entry: 'navigateToSuccessPage',
+          type: 'final',
+        },
+        error: {
+          entry: 'navigateToErrorPage',
+          type: 'final',
+        },
+      },
+    },
+  },
+});

--- a/src/page-modules/contact/group-travel/group-travel-state-machine.ts
+++ b/src/page-modules/contact/group-travel/group-travel-state-machine.ts
@@ -54,6 +54,17 @@ type GroupTravelEvents =
   | { type: 'UPDATE_FORM_DATA'; formData: GroupTravelContextType['formData'] }
   | { type: 'SUBMIT' };
 
+const getFormDataErrors = (formData: GroupTravelContextType['formData']) => {
+  const errors: GroupTravelContextType['errors'] = defaultErrors;
+
+  Object.keys(errors).forEach((key) => {
+    errors[key as keyof GroupTravelContextType['errors']] =
+      !formData[key as keyof GroupTravelContextType['formData']];
+  });
+
+  return errors;
+};
+
 export const groupTravelStateMachine = setup({
   types: {
     context: {} as GroupTravelContextType,
@@ -61,19 +72,8 @@ export const groupTravelStateMachine = setup({
   },
   guards: {
     isFormValid: ({ context }) => {
-      const errors: GroupTravelContextType['errors'] = defaultErrors;
-
-      Object.keys(context.errors).forEach((key) => {
-        errors[key as keyof GroupTravelContextType['errors']] =
-          !context.formData[key as keyof GroupTravelContextType['formData']];
-      });
-
-      const hasErrors = Object.values(errors).some((isError) => isError);
-
-      if (hasErrors) {
-        return false;
-      }
-      return true;
+      const errors = getFormDataErrors(context.formData);
+      return !Object.values(errors).some((isError) => isError);
     },
   },
   actions: {
@@ -99,14 +99,8 @@ export const groupTravelStateMachine = setup({
       };
     }),
     setValidationErrors: assign(({ context }) => {
-      const updatedErrors: GroupTravelContextType['errors'] = defaultErrors;
-
-      Object.keys(context.errors).forEach((key) => {
-        updatedErrors[key as keyof GroupTravelContextType['errors']] =
-          !context.formData[key as keyof GroupTravelContextType['formData']];
-      });
-
-      return { errors: { ...updatedErrors } };
+      const errors = getFormDataErrors(context.formData);
+      return { errors: { ...errors } };
     }),
     clearValidationErrors: assign({ errors: defaultErrors }),
   },

--- a/src/page-modules/contact/group-travel/group-travel.module.css
+++ b/src/page-modules/contact/group-travel/group-travel.module.css
@@ -1,0 +1,3 @@
+.list {
+  list-style-type: none;
+}

--- a/src/page-modules/contact/group-travel/index.tsx
+++ b/src/page-modules/contact/group-travel/index.tsx
@@ -329,18 +329,32 @@ export default function GroupTravelContent() {
             <Input
               label={
                 PageText.Contact.groupTravel.travelTypeBus.form.groupInformation
-                  .responsiblePerson.title
+                  .firstName.title
               }
               type="text"
-              name="responsiblePerson"
-              value={formData.responsiblePerson}
-              onChange={(e) =>
-                handleInputChange('responsiblePerson', e.target.value)
-              }
+              name="firstName"
+              value={formData.firstName}
+              onChange={(e) => handleInputChange('firstName', e.target.value)}
               errorMessage={
-                errors.responsiblePerson
+                errors.firstName
                   ? PageText.Contact.groupTravel.travelTypeBus.form
-                      .groupInformation.responsiblePerson.error
+                      .groupInformation.firstName.error
+                  : undefined
+              }
+            />
+            <Input
+              label={
+                PageText.Contact.groupTravel.travelTypeBus.form.groupInformation
+                  .lastName.title
+              }
+              type="text"
+              name="lastName"
+              value={formData.lastName}
+              onChange={(e) => handleInputChange('lastName', e.target.value)}
+              errorMessage={
+                errors.lastName
+                  ? PageText.Contact.groupTravel.travelTypeBus.form
+                      .groupInformation.lastName.error
                   : undefined
               }
             />

--- a/src/page-modules/contact/group-travel/index.tsx
+++ b/src/page-modules/contact/group-travel/index.tsx
@@ -1,0 +1,421 @@
+import { useMachine } from '@xstate/react';
+import { groupTravelStateMachine } from './group-travel-state-machine';
+import { SectionCard } from '../components/section-card';
+import { PageText, useTranslation } from '@atb/translations';
+import style from './group-travel.module.css';
+import { RadioInput } from '../components/input/radio';
+import { Typo } from '@atb/components/typography';
+import { useLines } from '../lines/use-lines';
+import Select from '../components/input/select';
+import { Line } from '../server/journey-planner/validators';
+import { Input } from '../components/input';
+import { Textarea } from '../components/input/textarea';
+import { Button } from '@atb/components/button';
+
+export default function GroupTravelContent() {
+  const { t } = useTranslation();
+  const [state, send] = useMachine(groupTravelStateMachine);
+  const { getLinesByMode, getQuaysByLine } = useLines();
+  const { formData, travelType, errors } = state.context;
+
+  const handleInputChange = (field: string, value: any) => {
+    send({
+      type: 'UPDATE_FORM_DATA',
+      formData: {
+        ...formData,
+        [field]: value,
+      },
+    });
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    send({ type: 'SUBMIT' });
+  };
+
+  return (
+    <div>
+      <SectionCard title={t(PageText.Contact.groupTravel.title)}>
+        <ul className={style.list}>
+          <li>
+            <RadioInput
+              label={t(PageText.Contact.groupTravel.travelTypeBus.radioLabel)}
+              value={'bus'}
+              checked={travelType === 'bus'}
+              onChange={(e) =>
+                send({ type: 'SELECT_TRAVEL_TYPE', travelType: 'bus' })
+              }
+            />
+          </li>
+          <li>
+            <RadioInput
+              label={t(PageText.Contact.groupTravel.travelTypeBoat.radioLabel)}
+              value={'boat'}
+              checked={travelType === 'boat'}
+              onChange={(e) =>
+                send({ type: 'SELECT_TRAVEL_TYPE', travelType: 'boat' })
+              }
+            />
+          </li>
+        </ul>
+      </SectionCard>
+
+      {travelType === 'bus' && (
+        <form onSubmit={handleSubmit}>
+          <SectionCard
+            title={t(PageText.Contact.groupTravel.travelTypeBus.radioLabel)}
+          >
+            {PageText.Contact.groupTravel.travelTypeBus.paragraphs.map(
+              (paragraph, i) => (
+                <Typo.p key={`bus-info-${i}`} textType="body__primary">
+                  {t(paragraph)}
+                </Typo.p>
+              ),
+            )}
+
+            <Typo.p textType="heading__component">
+              {t(PageText.Contact.groupTravel.travelTypeBus.kindergarden.title)}
+            </Typo.p>
+
+            {PageText.Contact.groupTravel.travelTypeBus.kindergarden.paragraphs.map(
+              (paragraph, i) => (
+                <Typo.p
+                  key={`bus-kindergarden-info-${i}`}
+                  textType="body__primary"
+                >
+                  {t(paragraph)}
+                </Typo.p>
+              ),
+            )}
+
+            <Typo.p textType="heading__component">
+              {t(PageText.Contact.groupTravel.travelTypeBus.form.title)}
+            </Typo.p>
+
+            <Typo.p textType="body__primary">
+              {t(PageText.Contact.groupTravel.travelTypeBus.form.info)}
+            </Typo.p>
+          </SectionCard>
+
+          <SectionCard
+            title={t(
+              PageText.Contact.groupTravel.travelTypeBus.form.travelInformation
+                .title,
+            )}
+          >
+            <Input
+              label={
+                PageText.Contact.groupTravel.travelTypeBus.form
+                  .travelInformation.dateOfTravel.title
+              }
+              type="date"
+              name="date"
+              value={formData.dateOfTravel}
+              onChange={(e) =>
+                handleInputChange('dateOfTravel', e.target.value)
+              }
+              errorMessage={
+                errors.dateOfTravel
+                  ? PageText.Contact.input.date.errorMessages.empty
+                  : undefined
+              }
+            />
+
+            <Select
+              label={t(
+                PageText.Contact.groupTravel.travelTypeBus.form
+                  .travelInformation.line.title,
+              )}
+              value={formData.line}
+              onChange={(value: Line | undefined) => {
+                if (!value) return;
+                handleInputChange('line', value);
+              }}
+              options={getLinesByMode('bus')}
+              valueToId={(line: Line) => line.id}
+              valueToText={(line: Line) => line.name}
+              placeholder={t(PageText.Contact.input.line.optionLabel)}
+              error={
+                errors.line
+                  ? t(PageText.Contact.input.line.errorMessages.empty)
+                  : undefined
+              }
+            />
+
+            <Select
+              label={t(
+                PageText.Contact.groupTravel.travelTypeBus.form
+                  .travelInformation.fromStop.title,
+              )}
+              value={formData.fromStop}
+              disabled={!formData.line}
+              onChange={(value) => {
+                if (!value) return;
+                handleInputChange('fromStop', value);
+              }}
+              options={
+                formData.line?.id ? getQuaysByLine(formData.line.id) : []
+              }
+              placeholder={t(PageText.Contact.input.fromStop.optionLabel)}
+              valueToId={(quay: Line['quays'][0]) => quay.id}
+              valueToText={(quay: Line['quays'][0]) => quay.name}
+              error={
+                errors.fromStop
+                  ? t(PageText.Contact.input.fromStop.errorMessages.empty)
+                  : undefined
+              }
+            />
+            <Input
+              label={
+                PageText.Contact.groupTravel.travelTypeBus.form
+                  .travelInformation.departureTime.title
+              }
+              type="time"
+              name="time"
+              value={formData.departureTime}
+              onChange={(e) =>
+                handleInputChange('departureTime', e.target.value)
+              }
+              errorMessage={
+                errors.departureTime
+                  ? PageText.Contact.input.plannedDepartureTime.errorMessages
+                      .empty
+                  : undefined
+              }
+            />
+
+            <Select
+              label={t(
+                PageText.Contact.groupTravel.travelTypeBus.form
+                  .travelInformation.toStop.title,
+              )}
+              value={formData.toStop}
+              disabled={!formData.line}
+              onChange={(value) => {
+                if (!value) return;
+                handleInputChange('toStop', value);
+              }}
+              placeholder={t(PageText.Contact.input.toStop.optionLabel)}
+              options={
+                formData.line?.id ? getQuaysByLine(formData.line.id) : []
+              }
+              valueToId={(quay: Line['quays'][0]) => quay.id}
+              valueToText={(quay: Line['quays'][0]) => quay.name}
+              error={
+                errors.toStop
+                  ? t(PageText.Contact.input.toStop.errorMessages.empty)
+                  : undefined
+              }
+            />
+          </SectionCard>
+
+          <SectionCard
+            title={t(
+              PageText.Contact.groupTravel.travelTypeBus.form.travelReturn
+                .title,
+            )}
+          >
+            <Select
+              label={t(
+                PageText.Contact.groupTravel.travelTypeBus.form.travelReturn
+                  .line.title,
+              )}
+              value={formData.returnLine}
+              onChange={(value: Line | undefined) => {
+                if (!value) return;
+                handleInputChange('returnLine', value);
+              }}
+              options={getLinesByMode('bus')}
+              valueToId={(line: Line) => line.id}
+              valueToText={(line: Line) => line.name}
+              placeholder={t(PageText.Contact.input.line.optionLabel)}
+            />
+
+            <Select
+              label={t(
+                PageText.Contact.groupTravel.travelTypeBus.form.travelReturn
+                  .fromStop.title,
+              )}
+              value={formData.returnFromStop}
+              disabled={!formData.returnLine}
+              onChange={(value) => {
+                if (!value) return;
+                handleInputChange('returnFromStop', value);
+              }}
+              options={
+                formData.line?.id
+                  ? getQuaysByLine(formData.returnLine?.id || '')
+                  : []
+              }
+              placeholder={t(PageText.Contact.input.fromStop.optionLabel)}
+              valueToId={(quay: Line['quays'][0]) => quay.id}
+              valueToText={(quay: Line['quays'][0]) => quay.name}
+            />
+            <Input
+              label={
+                PageText.Contact.groupTravel.travelTypeBus.form.travelReturn
+                  .departureTime.title
+              }
+              type="time"
+              name="time"
+              value={formData.returnDepartureTime}
+              onChange={(e) =>
+                handleInputChange('returnDepartureTime', e.target.value)
+              }
+            />
+
+            <Select
+              label={t(
+                PageText.Contact.groupTravel.travelTypeBus.form.travelReturn
+                  .toStop.title,
+              )}
+              value={formData.returnToStop}
+              disabled={!formData.returnLine}
+              onChange={(value) => {
+                if (!value) return;
+                handleInputChange('returnToStop', value);
+              }}
+              placeholder={t(PageText.Contact.input.toStop.optionLabel)}
+              options={
+                formData.line?.id
+                  ? getQuaysByLine(formData.returnLine?.id || '')
+                  : []
+              }
+              valueToId={(quay: Line['quays'][0]) => quay.id}
+              valueToText={(quay: Line['quays'][0]) => quay.name}
+            />
+          </SectionCard>
+
+          <SectionCard
+            title={t(
+              PageText.Contact.groupTravel.travelTypeBus.form.groupInformation
+                .title,
+            )}
+          >
+            <Input
+              label={
+                PageText.Contact.groupTravel.travelTypeBus.form.groupInformation
+                  .groupSize.title
+              }
+              type="number"
+              name="groupSize"
+              value={formData.groupSize}
+              onChange={(e) => handleInputChange('groupSize', e.target.value)}
+              errorMessage={
+                errors.groupSize
+                  ? PageText.Contact.groupTravel.travelTypeBus.form
+                      .groupInformation.groupSize.error
+                  : undefined
+              }
+            />
+            <Typo.p textType="body__primary">
+              {t(
+                PageText.Contact.groupTravel.travelTypeBus.form.groupInformation
+                  .groupInfo.title,
+              )}
+            </Typo.p>
+            <Textarea
+              value={formData.groupInfo}
+              onChange={(e) => handleInputChange('groupInfo', e.target.value)}
+              error={
+                errors.groupInfo
+                  ? t(
+                      PageText.Contact.groupTravel.travelTypeBus.form
+                        .groupInformation.groupInfo.error,
+                    )
+                  : undefined
+              }
+            />
+            <Input
+              label={
+                PageText.Contact.groupTravel.travelTypeBus.form.groupInformation
+                  .responsiblePerson.title
+              }
+              type="text"
+              name="responsiblePerson"
+              value={formData.responsiblePerson}
+              onChange={(e) =>
+                handleInputChange('responsiblePerson', e.target.value)
+              }
+              errorMessage={
+                errors.responsiblePerson
+                  ? PageText.Contact.groupTravel.travelTypeBus.form
+                      .groupInformation.responsiblePerson.error
+                  : undefined
+              }
+            />
+            <Input
+              label={
+                PageText.Contact.groupTravel.travelTypeBus.form.groupInformation
+                  .responsiblePersonPhone.title
+              }
+              type="tel"
+              name="responsiblePersonPhone"
+              value={formData.phoneNumber}
+              onChange={(e) => handleInputChange('phoneNumber', e.target.value)}
+              errorMessage={
+                errors.phoneNumber
+                  ? PageText.Contact.groupTravel.travelTypeBus.form
+                      .groupInformation.responsiblePersonPhone.error
+                  : undefined
+              }
+            />
+            <Input
+              label={
+                PageText.Contact.groupTravel.travelTypeBus.form.groupInformation
+                  .responsiblePersonEmail.title
+              }
+              type="email"
+              name="responsiblePersonEmail"
+              value={formData.email}
+              onChange={(e) => handleInputChange('email', e.target.value)}
+              errorMessage={
+                errors.email
+                  ? PageText.Contact.groupTravel.travelTypeBus.form
+                      .groupInformation.responsiblePersonEmail.error
+                  : undefined
+              }
+            />
+            <Button
+              title={t(PageText.Contact.submit)}
+              mode={'interactive_0--bordered'}
+              buttonProps={{ type: 'submit' }}
+            />
+          </SectionCard>
+        </form>
+      )}
+
+      {travelType === 'boat' && (
+        <SectionCard
+          title={t(PageText.Contact.groupTravel.travelTypeBoat.radioLabel)}
+        >
+          <Typo.p textType="body__primary">
+            <span>
+              {t(
+                PageText.Contact.groupTravel.travelTypeBoat.contactInformation
+                  .info,
+              )}
+              &nbsp;
+              <a
+                href={t(
+                  PageText.Contact.groupTravel.travelTypeBoat.contactInformation
+                    .url,
+                )}
+                target="_blank"
+                rel="noreferrer"
+              >
+                {t(
+                  PageText.Contact.groupTravel.travelTypeBoat.contactInformation
+                    .externalLink,
+                )}
+              </a>
+            </span>
+          </Typo.p>
+          <Typo.p textType="body__primary">
+            {t(PageText.Contact.groupTravel.travelTypeBoat.discountInformation)}
+          </Typo.p>
+        </SectionCard>
+      )}
+    </div>
+  );
+}

--- a/src/page-modules/contact/group-travel/index.tsx
+++ b/src/page-modules/contact/group-travel/index.tsx
@@ -380,6 +380,9 @@ export default function GroupTravelContent() {
               title={t(PageText.Contact.submit)}
               mode={'interactive_0--bordered'}
               buttonProps={{ type: 'submit' }}
+              state={
+                state.matches({ busForm: 'submitting' }) ? 'loading' : undefined
+              }
             />
           </SectionCard>
         </form>

--- a/src/page-modules/contact/server/contact/index.ts
+++ b/src/page-modules/contact/server/contact/index.ts
@@ -5,6 +5,7 @@ export type ContactApi = {
   submitTicketControlForm(formData: any): Promise<ContactApiReturnType>;
   submitTravelGuaranteeForm(formData: any): Promise<ContactApiReturnType>;
   submitMeansOfTransportForm(formData: any): Promise<ContactApiReturnType>;
+  submitGroupTravelForm(formData: any): Promise<ContactApiReturnType>;
 };
 
 export function createContactApi(
@@ -31,6 +32,15 @@ export function createContactApi(
 
     async submitMeansOfTransportForm(formData) {
       const response = await request('/means-of-transport', {
+        method: 'POST',
+        body: formData,
+      });
+      const data: ContactApiReturnType = await response.json();
+      return data;
+    },
+
+    async submitGroupTravelForm(formData) {
+      const response = await request('/group-travel', {
         method: 'POST',
         body: formData,
       });

--- a/src/pages/api/contact/group-travel.ts
+++ b/src/pages/api/contact/group-travel.ts
@@ -1,0 +1,12 @@
+import { tryResult } from '@atb/modules/api-server';
+import { handlerWithContactFormClient } from '@atb/page-modules/contact/server';
+import { ContactApiReturnType } from '@atb/page-modules/contact/server/types';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default handlerWithContactFormClient<ContactApiReturnType>({
+  async POST(req: NextApiRequest, res: NextApiResponse, { client, ok }) {
+    return tryResult(req, res, async () => {
+      return ok(await client.submitGroupTravelForm(req.body));
+    });
+  },
+});

--- a/src/pages/contact/group-travel.tsx
+++ b/src/pages/contact/group-travel.tsx
@@ -1,0 +1,24 @@
+import DefaultLayout from '@atb/layouts/default';
+import { withGlobalData, WithGlobalData } from '@atb/layouts/global-data';
+import { NextPage } from 'next';
+import {
+  ContactPageLayout,
+  ContactPageLayoutProps,
+} from '@atb/page-modules/contact';
+import GroupTravelContent from '@atb/page-modules/contact/group-travel';
+
+export type GroupTravelPageProps = WithGlobalData<ContactPageLayoutProps>;
+
+const GroupTravelPage: NextPage<GroupTravelPageProps> = (props) => {
+  return (
+    <DefaultLayout {...props}>
+      <ContactPageLayout {...props}>
+        <GroupTravelContent />
+      </ContactPageLayout>
+    </DefaultLayout>
+  );
+};
+
+export default GroupTravelPage;
+
+export const getServerSideProps = withGlobalData();

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -436,6 +436,296 @@ export const Contact = {
   },
   groupTravel: {
     title: _('Gruppereise', 'Group travel', 'Gruppereise'),
+    travelTypeBus: {
+      radioLabel: _(
+        'Gruppereise med buss',
+        'Group travel by bus',
+        'Gruppereise med buss',
+      ),
+      paragraphs: [
+        _(
+          'Det er ikke mulig å reservere seter om bord på buss, men ved å melde fra om større grupper vil det blir enklere å planlegge avgangene slik at ingen blir stående igjen.',
+          "It's not possible to reserve seats on the bus, but by notifying us about larger groups, it will be easier to plan the departures so that no one is left behind.",
+          'Det er ikkje mogleg å reservere seter om bord på bussar, men ved å melde frå om større grupper vil det bli enklare å planlegge avgangane slik at ingen blir ståande att.',
+        ),
+        _(
+          'Det er ingen grupperabatt på bussene til FRAM.',
+          'There is no group discount on the FRAM buses.',
+          'Det er ingen grupperabatt på bussane til FRAM.',
+        ),
+        _(
+          'Fristen for å melde inn er klokken 12.00 dagen før. Om du skal reise på en mandag, er fristen kl. 12.00 fredagen før.',
+          'The deadline for notification is 12.00 the day before. If you are traveling on a Monday, the deadline is 12.00 on the Friday before.',
+          'Fristen for å melde inn er klokka 12.00 dagen før. Om du skal reise på ein måndag, er fristen kl. 12.00 fredagen før.',
+        ),
+        _(
+          'Vi anbefaler grupper å ha med barnesete til alle som normalt bruker dette. Det er setebelte i alle bussene bortsett fra bybussene.',
+          'We recommend groups to bring a child seat for everyone who normally uses this. There are seat belts on all buses except for the city buses.',
+          'Vi anbefaler grupper å ha med barnesete til alle som normalt bruker dette. Det er setebelte i alle bussane bortsett frå bybussane.',
+        ),
+      ],
+      kindergarden: {
+        title: _(
+          'Barnehage på buss',
+          'Kindergarten on bus',
+          'Barnehage på buss',
+        ),
+        paragraphs: [
+          _(
+            'Barn på tur med barnehage kan reise gratis med buss mellom klokka 09.00 og 13.00 alle hverdager. Voksne må kjøpe vanlig billett for bussen.',
+            'Children on a trip with a kindergarten can travel for free by bus between 09.00 and 13.00 every weekday. The adults must purchase a regular bus ticket.',
+            'Barn på tur med barnehage kan reise gratis med buss mellom klokka 09.00 og 13.00 alle kvardagar. Dei vaksne må kjøpe vanleg billett for bussen.',
+          ),
+          _(
+            'Barnehagar skal sende inn skjema for gruppereise.',
+            'Kindergartens must submit a group travel form.',
+            'Barnehagar skal sende inn skjema for gruppereise.',
+          ),
+        ],
+      },
+      form: {
+        title: _('Gruppereiseskjema', 'Group travel form', 'Gruppereiseskjema'),
+        info: _(
+          'Vi ber om de personopplysningene vi trenger for å behandle saken din. Du skal derfor ikke legge inn personopplysninger i fritekstfeltene. Personopplysninger er alle opplysninger som kan knyttes til en fysisk person, eller bidra til å identifisere en fysisk person.',
+          'We ask for the personal information we need to process your case. Therefore, you should not enter personal information in the free text fields. Personal information is all information that can be linked to a physical person, or contribute to identifying a physical person.',
+          'Vi ber om dei personopplysningane vi treng for å behandle saka di. Du skal derfor ikkje legge inn personopplysningar i fritekstfelta. Personopplysningar er alle opplysningar som kan knytast til ein fysisk person, eller bidra til å identifisere ein fysisk person.',
+        ),
+        travelInformation: {
+          title: _(
+            'Reiseinformasjon',
+            'Travel information',
+            'Reiseinformasjon',
+          ),
+          dateOfTravel: {
+            title: _(
+              'Dato de skal reise',
+              'Date of travel',
+              'Dato de skal reise',
+            ),
+          },
+          line: {
+            title: _('Linje (påkrevd)', 'Line (required)', 'Linje (påkrevd)'),
+            info: _(
+              'Velg linjen på bussen de vil reise med.',
+              'Select the bus line you would like to travel with.',
+              'Velg linjen på bussen de vil reise med.',
+            ),
+          },
+          fromStop: {
+            title: _(
+              'Fra holdeplass (påkrevd)',
+              'From stop (required)',
+              'Frå holdeplass (påkrevd)',
+            ),
+            info: _(
+              'Velg holdeplassen de vil reise fra.',
+              'Select the stop you would like to travel from.',
+              'Velg haldeplassen de vil reise frå.',
+            ),
+          },
+          departureTime: {
+            title: _(
+              'Avgangstid (påkrevd)',
+              'Departure time (påkrevd)',
+              'Avgangstid (påkrevd)',
+            ),
+            info: _(
+              'Skriv inn avgangstiden fra holdeplassen de vil reise fra.',
+              'Write the departure time from the stop you would like to travel from.',
+              'Skriv inn avgangstida frå haldeplassen de vil reise frå.',
+            ),
+          },
+          toStop: {
+            title: _(
+              'Til holdeplass (påkrevd)',
+              'To stop (required)',
+              'Til holdeplass (påkrevd)',
+            ),
+            info: _(
+              'Velg holdeplassen de vil reise til.',
+              'Select the stop you would like to travel to.',
+              'Velg haldeplassen de vil reise til.',
+            ),
+          },
+        },
+        travelReturn: {
+          title: _(
+            'Retur (hvis aktuelt)',
+            'Return (if applicable)',
+            'Retur (viss aktuelt)',
+          ),
+          line: {
+            title: _(
+              'Linje (for returen)',
+              'Line (for the return)',
+              'Linje (for returen)',
+            ),
+            info: _(
+              'Velg linjen på bussen de vil reise med på returen.',
+              'Select the bus line you would like to travel with on the return.',
+              'Velg linjen på bussen de vil reise med på returen.',
+            ),
+          },
+          fromStop: {
+            title: _(
+              'Fra holdeplass (for returen)',
+              'From stop (for the return)',
+              'Frå holdeplass (for returen)',
+            ),
+            info: _(
+              'Velg holdeplassen de vil reise fra på returen.',
+              'Select the stop you would like to travel from on the return.',
+              'Velg haldeplassen de vil reise frå på returen.',
+            ),
+          },
+          departureTime: {
+            title: _(
+              'Avgangstid (for returen)',
+              'Departure time (for the return)',
+              'Avgangstid (for returen)',
+            ),
+            info: _(
+              'Skriv inn avgangstiden fra holdeplassen de vil reise fra på returen.',
+              'Write the departure time from the stop you would like to travel from on the return.',
+              'Skriv inn avgangstida frå haldeplassen de vil reise frå med på returen.',
+            ),
+          },
+          toStop: {
+            title: _(
+              'Til holdeplass (for returen)',
+              'To stop (for the return)',
+              'Til holdeplass (for returen)',
+            ),
+            info: _(
+              'Velg holdeplassen de vil reise til på returen.',
+              'Select the stop you would like to travel to on the return.',
+              'Velg haldeplassen de vil reise til på returen.',
+            ),
+          },
+        },
+        groupInformation: {
+          title: _(
+            'Informasjon om gruppen',
+            'Information about the group',
+            'Informasjon om gruppa',
+          ),
+          groupSize: {
+            title: _(
+              'Antall reisende (påkrevd)',
+              'Number of travelers (required)',
+              'Talet reisande (påkrevd)',
+            ),
+            info: _(
+              'Skriv inn antall som skal reise',
+              'Write number of travellers',
+              'Skriv inn talet reisande som skal reise. ',
+            ),
+            error: _(
+              'Antall reisende må være et tall',
+              'Number of travelers must be a number',
+              'Talet reisande må vere eit tal',
+            ),
+          },
+          groupInfo: {
+            title: _(
+              'Gruppe (påkrevd)',
+              'Group (required)',
+              'Gruppe (påkrevd)',
+            ),
+            info: _(
+              'Skriv inn navnet på bedriften, skolen, barnehagen, organisasjonen og lignende. Ikke skriv personopplysninger.',
+              'Write the name of the company, school, kindergarten, organization, and the like. Do not write personal information.',
+              'Skriv inn namnet på bedrifta, skolen, barnehagen, organisasjonen og liknande. Ikkje skriv personopplysningar. ',
+            ),
+            error: _(
+              'Info om gruppe kan ikke være tom',
+              'Group info cannot be empty',
+              'Info om gruppe kan ikkje vere tom',
+            ),
+          },
+          responsiblePerson: {
+            title: _(
+              'Navn på ansvarlig person (påkrevd)',
+              'Name of responsible person (required)',
+              'Namn på ansvarleg person (påkrevd)',
+            ),
+            info: _(
+              'Skriv inn navnet på personen som er ansvarlig for gruppen',
+              'Write the name of the person responsilbe for the group',
+              'Skriv inn namnet på personen som er ansvarleg for gruppa. ',
+            ),
+            error: _(
+              'Navn på ansvarlig person kan ikke være tom',
+              'Name of responsible person cannot be empty',
+              'Namn på ansvarleg person kan ikkje vere tom',
+            ),
+          },
+          responsiblePersonPhone: {
+            title: _(
+              'Mobilnummer til ansvarlig person (påkrevd)',
+              'Phone number of responsible person (required)',
+              'Mobilnummer til ansvarleg person (påkrevd)',
+            ),
+            info: _(
+              'Skriv inn mobilnummeret til personen som er ansvarlig for gruppen',
+              'Write the phone number of the person responsible for the group',
+              'Skriv inn mobilnummeret til personen som er ansvarleg for reisefølget. ',
+            ),
+            error: _(
+              'Mobilnummer til ansvarlig person kan ikke være tom',
+              'Phone number of responsible person cannot be empty',
+              'Mobilnummer til ansvarleg person kan ikkje vere tom',
+            ),
+          },
+          responsiblePersonEmail: {
+            title: _(
+              'E-post til ansvarlig person (påkrevd)',
+              'Email to responsible person (required)',
+              'E-post til ansvarleg person (påkrevd)',
+            ),
+            info: _(
+              'Skriv inn e-postadressen til personen som er ansvarlig for gruppen',
+              'Write the email address of the person responsible for the group',
+              'Skriv inn e-postadressa til personen som er ansvarlege for reisefølget. ',
+            ),
+            error: _(
+              'E-post til ansvarlig person kan ikke være tom',
+              'Email to responsible person cannot be empty',
+              'E-post til ansvarleg person kan ikkje vere tom',
+            ),
+          },
+        },
+      },
+    },
+    travelTypeBoat: {
+      radioLabel: _(
+        'Gruppereise med hurtigbåt',
+        'Group travel by express boat',
+        'Gruppereise med hurtigbåt',
+      ),
+      contactInformation: {
+        info: _(
+          'For gruppereiser med hurtigbåt melder du fra direkte til hurtigbåtene.',
+          'For group travel by express boat, you report directly to the express boats.',
+          'For gruppereiser med hurtigbåt melder du frå direkte til hurtigbåten.',
+        ),
+        externalLink: _(
+          'Kontaktinformasjon finner du på rutetabellene for hurtigbåt.',
+          'You can find the contact information on the express boat timetables.',
+          'Du finn kontaktinformasjon på rutetabellane for hurtigbåt.',
+        ),
+        url: _(
+          'https://frammr.no/reise/rutetabellar-og-linjekart/hurtigbat/',
+          'https://frammr.no/reise/rutetabellar-og-linjekart/hurtigbat/?sprak=11',
+          'https://frammr.no/reise/rutetabellar-og-linjekart/hurtigbat/',
+        ),
+      },
+      discountInformation: _(
+        'Grupper på 10 eller flere som kjøpe samlet billett får 30 prosent rabatt på enkeltbillett. Rabatten for gruppe gjelder bare voksne og barn, ikke for andre rabatterte billetter som for eksempel honnør.',
+        'Groups of 10 or more who buy a collective ticket receive a 30 percent discount on a single ticket. The group discount applies only to adults and children, not to other discounted tickets such as senior.',
+        'Grupper på 10 eller fleire som kjøper samla billett får 30 prosent rabatt på enkeltbillett. Rabatten for gruppe gjeld berre vaksne og barn, ikkje for andre rabatterte billettar som for eksempel honnør.',
+      ),
+    },
   },
   aboutYouInfo: {
     title: _(

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -643,21 +643,38 @@ export const Contact = {
               'Info om gruppe kan ikkje vere tom',
             ),
           },
-          responsiblePerson: {
+          firstName: {
             title: _(
-              'Navn på ansvarlig person (påkrevd)',
-              'Name of responsible person (required)',
-              'Namn på ansvarleg person (påkrevd)',
+              'Fornavnet til ansvarlig person (påkrevd)',
+              'First name of responsible person (required)',
+              'Fornamnet til ansvarleg person (påkrevd)',
             ),
             info: _(
-              'Skriv inn navnet på personen som er ansvarlig for gruppen',
-              'Write the name of the person responsilbe for the group',
-              'Skriv inn namnet på personen som er ansvarleg for gruppa. ',
+              'Skriv inn fornavnet til personen som er ansvarlig for gruppen',
+              'Write the first name of the person responsible for the group',
+              'Skriv inn fornamnet til personen som er ansvarleg for gruppa. ',
             ),
             error: _(
-              'Navn på ansvarlig person kan ikke være tom',
-              'Name of responsible person cannot be empty',
-              'Namn på ansvarleg person kan ikkje vere tom',
+              'Fornavnet til ansvarlig person kan ikke være tom',
+              'First name of responsible person cannot be empty',
+              'Fornamnet på ansvarleg person kan ikkje vere tom',
+            ),
+          },
+          lastName: {
+            title: _(
+              'Etternavnet til ansvarlig person (påkrevd)',
+              'Last name of responsible person (required)',
+              'Etternamnet til ansvarleg person (påkrevd)',
+            ),
+            info: _(
+              'Skriv inn etternavnet til personen som er ansvarlig for gruppen',
+              'Write the last name of the person responsible for the group',
+              'Skriv inn etternamnet til personen som er ansvarleg for gruppa. ',
+            ),
+            error: _(
+              'Etternavnet til ansvarlig person kan ikke være tom',
+              'Last name of responsible person cannot be empty',
+              'Etternamnet på ansvarleg person kan ikkje vere tom',
             ),
           },
           responsiblePersonPhone: {


### PR DESCRIPTION
Added a new form for the group travel contact page. 

A few things worth looking into:
- Simplified input change handling by updating the entire form
- Splitting context into multiple objects (such as `formData` and `errors`) 
- Local error handling to not be dependent on other forms
- Use `assign` for actions to get updated context data (ref. `const [forceRerender, setForceRerender] = useState(false);` in other state machines) 

<details>
<summary>Screenshots</summary>

<img width="1066" alt="image" src="https://github.com/user-attachments/assets/0f098c6f-cab9-4844-8ca0-bb59d088b726">

<img width="1059" alt="image" src="https://github.com/user-attachments/assets/45425217-301f-4f83-a2a2-522689001227">

<img width="1085" alt="image" src="https://github.com/user-attachments/assets/17dee38f-f959-4116-8cf0-dac7e4fbdc59">

<img width="1048" alt="image" src="https://github.com/user-attachments/assets/f28d8504-4852-47b1-8caf-df7be19e0624">

<img width="1045" alt="image" src="https://github.com/user-attachments/assets/d4af4784-41e1-4077-80cb-cfab0f29ecf8">


</details>