### PR TITLE
fix: hide travel guarantee forms when agreement is unchecked

### DIFF
--- a/src/page-modules/contact/travel-guarantee/travelGuaranteeFormMachine.ts
+++ b/src/page-modules/contact/travel-guarantee/travelGuaranteeFormMachine.ts
@@ -82,6 +82,17 @@ const setFormTypeAndInitialContext = (
     errorMessages: {},
   };
 };
+const setInitialAgreementAndFormType = (
+  context: ContextProps,
+  isChecked: boolean,
+) => {
+  return {
+    ...context,
+    isIntialAgreementChecked: isChecked,
+    formType: undefined,
+    errorMessages: {},
+  };
+};
 
 const setInputToValidate = (context: ContextProps) => {
   const {
@@ -169,6 +180,9 @@ export const fetchMachine = setup({
 
         if (inputName === 'formType')
           return setFormTypeAndInitialContext(context, value as FormType);
+
+        if (inputName === 'isIntialAgreementChecked')
+          return setInitialAgreementAndFormType(context, value);
 
         context.errorMessages[inputName] = [];
         return {


### PR DESCRIPTION
Add condition to hide button and forms isInitialAgreementChecked is toggled from true to false.

### Before fix:

https://github.com/user-attachments/assets/2ed6c998-6d69-4899-881d-13299db05774



### After fix:

https://github.com/user-attachments/assets/aeeda69d-e341-432a-8f18-42e3bcaa4ef6

