### PR TITLE
refactor:  minor update in the organization of translation objects

### DIFF
--- a/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
@@ -127,11 +127,15 @@ const FormContent = ({ state, send }: FormProps) => {
         />
 
         <Typo.h3 textType="heading__component">
-          {t(PageText.Contact.input.ticketStorage.question)}
+          {t(
+            PageText.Contact.ticketControl.feeComplaint.ticketStorage.question,
+          )}
         </Typo.h3>
 
         <RadioInput
-          label={t(PageText.Contact.input.ticketStorage.app.title)}
+          label={t(
+            PageText.Contact.ticketControl.feeComplaint.ticketStorage.app.title,
+          )}
           name="isAppTicketStorageMode"
           checked={state.context.isAppTicketStorageMode}
           onChange={() =>
@@ -143,7 +147,7 @@ const FormContent = ({ state, send }: FormProps) => {
           }
         />
         <RadioInput
-          label={t(PageText.Contact.input.ticketStorage.travelCardNumber.label)}
+          label={t(PageText.Contact.input.travelCardNumber.label)}
           name="isAppTicketStorageMode"
           checked={!state.context.isAppTicketStorageMode}
           onChange={() =>
@@ -158,9 +162,7 @@ const FormContent = ({ state, send }: FormProps) => {
         {state.context.isAppTicketStorageMode && (
           <div>
             <Input
-              label={
-                PageText.Contact.input.ticketStorage.app.appPhoneNumber.label
-              }
+              label={PageText.Contact.input.appPhoneNumber.label}
               type="tel"
               name="appPhoneNumber"
               value={state.context.appPhoneNumber || ''}
@@ -175,9 +177,7 @@ const FormContent = ({ state, send }: FormProps) => {
             />
 
             <Input
-              label={
-                PageText.Contact.input.ticketStorage.app.customerNumber.label
-              }
+              label={PageText.Contact.input.customerNumber.label}
               type="number"
               name="customerNumber"
               value={state.context.customerNumber || ''}
@@ -194,7 +194,7 @@ const FormContent = ({ state, send }: FormProps) => {
         )}
         {!state.context.isAppTicketStorageMode && (
           <Input
-            label={PageText.Contact.input.ticketStorage.travelCardNumber.label}
+            label={PageText.Contact.input.travelCardNumber.label}
             type="number"
             name="travelCardNumber"
             value={state.context.travelCardNumber || ''}

--- a/src/page-modules/contact/validation/commonInputValidator.ts
+++ b/src/page-modules/contact/validation/commonInputValidator.ts
@@ -120,25 +120,19 @@ export const commonInputValidator = (context: any) => {
     {
       inputName: 'appPhoneNumber',
       validCondition: context.appPhoneNumber || context.travelCardNumber,
-      errorMessage:
-        PageText.Contact.input.ticketStorage.app.appPhoneNumber.errorMessages
-          .empty,
+      errorMessage: PageText.Contact.input.appPhoneNumber.errorMessages.empty,
     },
     {
       inputName: 'customerNumber',
       validCondition: context.customerNumber || context.travelCardNumber,
-      errorMessage:
-        PageText.Contact.input.ticketStorage.app.customerNumber.errorMessages
-          .empty,
+      errorMessage: PageText.Contact.input.customerNumber.errorMessages.empty,
     },
     {
       inputName: 'travelCardNumber',
       validCondition:
         context.travelCardNumber ||
         (context.appPhoneNumber && context.customerNumber),
-      errorMessage:
-        PageText.Contact.input.ticketStorage.travelCardNumber.errorMessages
-          .empty,
+      errorMessage: PageText.Contact.input.travelCardNumber.errorMessages.empty,
     },
     {
       inputName: 'feedback',

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -37,6 +37,18 @@ export const Contact = {
         'Dersom du har fått gebyr på feil grunnlag, kan du sende oss ei skriftleg klage.',
       ),
 
+      ticketStorage: {
+        question: _(
+          'Hvor pleier du å ha billetten din?',
+          'Where do you usually keep your ticket?',
+          'Kor pleier du å ha billetten din?',
+        ),
+
+        app: {
+          title: _('App', 'App', 'App'),
+        },
+      },
+
       firstAgreement: {
         title: _(
           'Har du fått gebyr etter billettkontroll?',
@@ -1122,53 +1134,6 @@ export const Contact = {
       },
     },
 
-    ticketStorage: {
-      question: _(
-        'Hvor pleier du å ha billetten din?',
-        'Where do you usually keep your ticket?',
-        'Kor pleier du å ha billetten din?',
-      ),
-
-      app: {
-        title: _('App', 'App', 'App'),
-        appPhoneNumber: {
-          label: _(
-            'Registrert mobilnummer',
-            'Registered mobile number',
-            'Registrert mobilnummer',
-          ),
-          errorMessages: {
-            empty: _(
-              'Legg til registrert mobilnummer',
-              'Legg til registered mobile number',
-              'Legg til registrert mobilnummer',
-            ),
-          },
-        },
-
-        customerNumber: {
-          label: _('Kundenummer', 'Customer number', 'Kundenummer'),
-          errorMessages: {
-            empty: _(
-              'Fyll inn kundenummer',
-              'Enter customer number',
-              'Fyll inn kundenummer',
-            ),
-          },
-        },
-      },
-
-      travelCardNumber: {
-        label: _('Reisekort', 'Travelcard', 'Reisekort'),
-        errorMessages: {
-          empty: _(
-            'Legg til reisekort',
-            'Enter travelcard number',
-            'Legg til reisekort',
-          ),
-        },
-      },
-    },
     feedback: {
       title: _(
         'Hva ønsker du å fortelle oss?',
@@ -1272,6 +1237,42 @@ export const Contact = {
       ] as Area[],
       errorMessages: {
         empty: _('Område mangler', 'Area is missing', 'Område mangler'),
+      },
+    },
+    appPhoneNumber: {
+      label: _(
+        'Registrert mobilnummer',
+        'Registered mobile number',
+        'Registrert mobilnummer',
+      ),
+      errorMessages: {
+        empty: _(
+          'Legg til registrert mobilnummer',
+          'Legg til registered mobile number',
+          'Legg til registrert mobilnummer',
+        ),
+      },
+    },
+
+    customerNumber: {
+      label: _('Kundenummer', 'Customer number', 'Kundenummer'),
+      errorMessages: {
+        empty: _(
+          'Fyll inn kundenummer',
+          'Enter customer number',
+          'Fyll inn kundenummer',
+        ),
+      },
+    },
+
+    travelCardNumber: {
+      label: _('Reisekort', 'Travelcard', 'Reisekort'),
+      errorMessages: {
+        empty: _(
+          'Legg til reisekort',
+          'Enter travelcard number',
+          'Legg til reisekort',
+        ),
       },
     },
   },


### PR DESCRIPTION
Move `appPhoneNumber`, `customerNumber` and `travelCardNumber` into `input` in `contacts.ts`, as these inputs are used in other contexts in addition to ticketControl.feeComplaint.