### PR TITLE
feat: display public code for lines in contact form

### DIFF
--- a/src/page-modules/contact/group-travel/index.tsx
+++ b/src/page-modules/contact/group-travel/index.tsx
@@ -11,6 +11,7 @@ import { Line } from '../server/journey-planner/validators';
 import { Input } from '../components/input';
 import { Textarea } from '../components/input/textarea';
 import { Button } from '@atb/components/button';
+import { formatLineName } from '../utils';
 
 export default function GroupTravelContent() {
   const { t } = useTranslation();
@@ -133,7 +134,7 @@ export default function GroupTravelContent() {
               }}
               options={getLinesByMode('bus')}
               valueToId={(line: Line) => line.id}
-              valueToText={(line: Line) => line.name}
+              valueToText={(line: Line) => formatLineName(line)}
               placeholder={t(PageText.Contact.input.line.optionLabel)}
               error={
                 errors.line
@@ -227,7 +228,7 @@ export default function GroupTravelContent() {
               }}
               options={getLinesByMode('bus')}
               valueToId={(line: Line) => line.id}
-              valueToText={(line: Line) => line.name}
+              valueToText={(line: Line) => formatLineName(line)}
               placeholder={t(PageText.Contact.input.line.optionLabel)}
             />
 

--- a/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
@@ -11,6 +11,7 @@ import { FileInput } from '../../components/input/file';
 import { Textarea } from '../../components/input/textarea';
 import { ContextProps } from '../means-of-transport-form-machine';
 import { meansOfTransportFormEvents } from '../events';
+import { formatLineName } from '../../utils';
 
 type DelayFormProps = {
   state: { context: ContextProps };
@@ -75,7 +76,7 @@ export const DelayForm = ({ state, send }: DelayFormProps) => {
             state.context.transportMode as TransportModeType,
           )}
           valueToId={(line: Line) => line.id}
-          valueToText={(line: Line) => line.name}
+          valueToText={(line: Line) => formatLineName(line)}
           placeholder={t(PageText.Contact.input.line.optionLabel)}
           error={
             state.context?.errorMessages['line']?.[0]

--- a/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
@@ -11,6 +11,7 @@ import { Line } from '../..';
 import { FileInput } from '../../components/input/file';
 import { Textarea } from '../../components/input/textarea';
 import { meansOfTransportFormEvents } from '../events';
+import { formatLineName } from '../../utils';
 
 type DriverFormProps = {
   state: { context: ContextProps };
@@ -97,7 +98,7 @@ export const DriverForm = ({ state, send }: DriverFormProps) => {
             state.context.transportMode as TransportModeType,
           )}
           valueToId={(line: Line) => line.id}
-          valueToText={(line: Line) => line.name}
+          valueToText={(line: Line) => formatLineName(line)}
           placeholder={t(PageText.Contact.input.line.optionLabel)}
           error={
             state.context?.errorMessages['line']?.[0]

--- a/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
@@ -11,6 +11,7 @@ import { Line } from '../..';
 import { FileInput } from '../../components/input/file';
 import { Textarea } from '../../components/input/textarea';
 import { meansOfTransportFormEvents } from '../events';
+import { formatLineName } from '../../utils';
 
 type InjuryFormProps = {
   state: { context: ContextProps };
@@ -96,7 +97,7 @@ export const InjuryForm = ({ state, send }: InjuryFormProps) => {
             state.context.transportMode as TransportModeType,
           )}
           valueToId={(line: Line) => line.id}
-          valueToText={(line: Line) => line.name}
+          valueToText={(line: Line) => formatLineName(line)}
           placeholder={t(PageText.Contact.input.line.optionLabel)}
           error={
             state.context?.errorMessages['line']?.[0]

--- a/src/page-modules/contact/means-of-transport/forms/serviceOfferingForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/serviceOfferingForm.tsx
@@ -11,6 +11,7 @@ import { Line } from '../..';
 import { FileInput } from '../../components/input/file';
 import { Textarea } from '../../components/input/textarea';
 import { meansOfTransportFormEvents } from '../events';
+import { formatLineName } from '../../utils';
 
 type ServiceOfferingFormProps = {
   state: { context: ContextProps };
@@ -102,7 +103,7 @@ export const ServiceOfferingForm = ({
             state.context.transportMode as TransportModeType,
           )}
           valueToId={(line: Line) => line.id}
-          valueToText={(line: Line) => line.name}
+          valueToText={(line: Line) => formatLineName(line)}
           placeholder={t(PageText.Contact.input.line.optionLabel)}
           error={
             state.context?.errorMessages['line']?.[0]

--- a/src/page-modules/contact/means-of-transport/forms/stopForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/stopForm.tsx
@@ -11,6 +11,7 @@ import { Line } from '../..';
 import { FileInput } from '../../components/input/file';
 import { Textarea } from '../../components/input/textarea';
 import { meansOfTransportFormEvents } from '../events';
+import { formatLineName } from '../../utils';
 
 type StopFormProps = {
   state: { context: ContextProps };
@@ -71,7 +72,7 @@ export const StopForm = ({ state, send }: StopFormProps) => {
             state.context.transportMode as TransportModeType,
           )}
           valueToId={(line: Line) => line.id}
-          valueToText={(line: Line) => line.name}
+          valueToText={(line: Line) => formatLineName(line)}
           placeholder={t(PageText.Contact.input.line.optionLabel)}
           error={
             state.context?.errorMessages['line']?.[0]

--- a/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
@@ -12,6 +12,7 @@ import { FileInput } from '../../components/input/file';
 import { Textarea } from '../../components/input/textarea';
 import { meansOfTransportFormEvents } from '../events';
 import { Checkbox } from '../../components/input/checkbox';
+import { formatLineName } from '../../utils';
 
 type TransportationFormProps = {
   state: { context: ContextProps };
@@ -79,7 +80,7 @@ export const TransportationForm = ({
             state.context.transportMode as TransportModeType,
           )}
           valueToId={(line: Line) => line.id}
-          valueToText={(line: Line) => line.name}
+          valueToText={(line: Line) => formatLineName(line)}
           placeholder={t(PageText.Contact.input.line.optionLabel)}
           error={
             state.context?.errorMessages['line']?.[0]

--- a/src/page-modules/contact/server/journey-planner/index.ts
+++ b/src/page-modules/contact/server/journey-planner/index.ts
@@ -30,6 +30,7 @@ export function createJourneyApi(
       const data: RecursivePartial<Line[]> = result.data.lines.map((line) => ({
         id: line.id,
         name: line.name ?? '',
+        publicCode: line.publicCode ?? null,
         transportMode: isTransportModeType(line.transportMode)
           ? line.transportMode
           : null,

--- a/src/page-modules/contact/server/journey-planner/journey-gql/lines.gql
+++ b/src/page-modules/contact/server/journey-planner/journey-gql/lines.gql
@@ -2,6 +2,7 @@ query lines($authority: String!) {
   lines(authorities: [$authority]) {
     id
     name
+    publicCode
     transportMode
     quays {
       id

--- a/src/page-modules/contact/server/journey-planner/validators.ts
+++ b/src/page-modules/contact/server/journey-planner/validators.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 export const lineSchema = z.object({
   id: z.string(),
   name: z.string(),
+  publicCode: z.string().nullable(),
   transportMode: transportModeSchema.nullable(),
   quays: z.array(
     z.object({

--- a/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
@@ -10,6 +10,7 @@ import { Typo } from '@atb/components/typography';
 import { FileInput } from '../../components/input/file';
 import { ticketControlFormEvents } from '../events';
 import { ContextProps } from '../ticket-control-form-machine';
+import { formatLineName } from '../../utils';
 
 type FeedbackFormProps = {
   state: { context: ContextProps };
@@ -63,7 +64,7 @@ export const FeedbackForm = ({ state, send }: FeedbackFormProps) => {
             state.context.transportMode as TransportModeType,
           )}
           valueToId={(line: Line) => line.id}
-          valueToText={(line: Line) => line.name}
+          valueToText={(line: Line) => formatLineName(line)}
           placeholder={t(PageText.Contact.input.line.optionLabel)}
           error={
             state.context?.errorMessages['line']?.[0] &&

--- a/src/page-modules/contact/travel-guarantee/forms/refundCarForm.tsx
+++ b/src/page-modules/contact/travel-guarantee/forms/refundCarForm.tsx
@@ -11,6 +11,7 @@ import ErrorMessage from '../../components/input/error-message';
 import { Checkbox } from '../../components/input/checkbox';
 import { Textarea } from '../../components/input/textarea';
 import { FileInput } from '../../components/input/file';
+import { formatLineName } from '../../utils';
 
 type RefundCarFormProps = {
   state: { context: ContextProps };
@@ -113,7 +114,7 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
             state.context.transportMode as TransportModeType,
           )}
           valueToId={(line: Line) => line.id}
-          valueToText={(line: Line) => line.name}
+          valueToText={(line: Line) => formatLineName(line)}
           placeholder={t(PageText.Contact.input.line.optionLabel)}
           error={
             state.context?.errorMessages['line']?.[0]

--- a/src/page-modules/contact/travel-guarantee/forms/refundTaxiForm.tsx
+++ b/src/page-modules/contact/travel-guarantee/forms/refundTaxiForm.tsx
@@ -11,6 +11,7 @@ import ErrorMessage from '../../components/input/error-message';
 import { Checkbox } from '../../components/input/checkbox';
 import { Textarea } from '../../components/input/textarea';
 import { FileInput } from '../../components/input/file';
+import { formatLineName } from '../../utils';
 
 type RefundTaxiFormProps = {
   state: { context: ContextProps };
@@ -65,7 +66,7 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
             state.context.transportMode as TransportModeType,
           )}
           valueToId={(line: Line) => line.id}
-          valueToText={(line: Line) => line.name}
+          valueToText={(line: Line) => formatLineName(line)}
           placeholder={t(PageText.Contact.input.line.optionLabel)}
           error={
             state.context?.errorMessages['line']?.[0]

--- a/src/page-modules/contact/utils.ts
+++ b/src/page-modules/contact/utils.ts
@@ -74,3 +74,7 @@ export const setLineAndResetStops = (context: any, line: Line) => {
     },
   };
 };
+
+export const formatLineName = (line: Line): string => {
+  return line.publicCode ? `${line.publicCode} - ${line.name}` : line.name;
+};


### PR DESCRIPTION
Added public code to the line selector in the contact form: 

<img width="1088" alt="image" src="https://github.com/user-attachments/assets/108ffd4e-b9ad-458d-afb3-4545a668c1a2">
