### PR TITLE
feat: add ticketing travelcard forms

### DIFF
--- a/src/page-modules/contact/ticketing/events.ts
+++ b/src/page-modules/contact/ticketing/events.ts
@@ -1,13 +1,18 @@
 import { TranslatedString } from '@atb/translations';
 import { commonEvents } from '../commoneEvents';
-import { AppForm, FormCategory, WebshopForm } from './ticketingStateMachine';
+import {
+  AppForm,
+  FormCategory,
+  WebshopForm,
+  TravelCardForm,
+} from './ticketingStateMachine';
 
 export type RefundReason = { id: string; name: TranslatedString };
 
 const ticketingSpecificFormEvents = {} as
   | {
       type: 'ON_INPUT_CHANGE';
-      inputName: 'question' | 'orderId' | 'customerNumber';
+      inputName: 'question' | 'orderId' | 'customerNumber' | 'travelCardNumber';
       value: string;
     }
   | {
@@ -25,6 +30,10 @@ const ticketingSpecificFormEvents = {} as
   | {
       type: 'SELECT_WEBSHOP_FORM';
       webshopForm: WebshopForm;
+    }
+  | {
+      type: 'SELECT_TRAVELCARD_FORM';
+      travelCardForm: TravelCardForm;
     }
   | {
       type: 'SUBMIT';

--- a/src/page-modules/contact/ticketing/forms/travel-card/index.tsx
+++ b/src/page-modules/contact/ticketing/forms/travel-card/index.tsx
@@ -1,0 +1,56 @@
+import style from '../../..//contact.module.css';
+import { StateFrom } from 'xstate';
+import { PageText, useTranslation } from '@atb/translations';
+import {
+  TravelCardForm,
+  ticketingStateMachine,
+} from '../../ticketingStateMachine';
+import { ticketingFormEvents } from '../../events';
+import { SectionCard, Radio } from '../../../components';
+import TravelCardQuestionForm from './travelCardQuestionForm';
+import OrderTravelCardForm from './orderTravelCardForm';
+
+type TravelcardFormsProps = {
+  state: StateFrom<typeof ticketingStateMachine>;
+  send: (event: typeof ticketingFormEvents) => void;
+};
+
+export const TravelCardForms = ({ state, send }: TravelcardFormsProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <div>
+      <SectionCard title={t(PageText.Contact.ticketing.travelCard.description)}>
+        <ul className={style.form_options__list}>
+          {Object.values(TravelCardForm).map((travelCardForm) => (
+            <li key={travelCardForm}>
+              <Radio
+                label={t(
+                  PageText.Contact.ticketing.travelCard[travelCardForm].label,
+                )}
+                checked={state.matches({
+                  editing: { travelCard: travelCardForm },
+                })}
+                onChange={(e) =>
+                  send({
+                    type: 'SELECT_TRAVELCARD_FORM',
+                    travelCardForm: travelCardForm,
+                  })
+                }
+              />
+            </li>
+          ))}
+        </ul>
+      </SectionCard>
+
+      {state.matches({ editing: { travelCard: 'orderTravelCard' } }) && (
+        <OrderTravelCardForm state={state} send={send} />
+      )}
+      {state.matches({ editing: { travelCard: 'travelCardQuestion' } }) && (
+        <TravelCardQuestionForm state={state} send={send} />
+      )}
+    </div>
+  );
+};
+
+export default TravelCardForms;

--- a/src/page-modules/contact/ticketing/forms/travel-card/orderTravelCardForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/travel-card/orderTravelCardForm.tsx
@@ -1,0 +1,130 @@
+import style from '../../../contact.module.css';
+import { PageText, TranslatedString, useTranslation } from '@atb/translations';
+import { ticketingFormEvents } from '../../events';
+import { TicketingContextType } from '../../ticketingStateMachine';
+import { Typo } from '@atb/components/typography';
+import { SectionCard, Input, Textarea, FileInput } from '../../../components';
+
+type OrderTravelCardFormProps = {
+  state: { context: TicketingContextType };
+  send: (event: typeof ticketingFormEvents) => void;
+};
+
+export const OrderTravelCardForm = ({
+  state,
+  send,
+}: OrderTravelCardFormProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <div>
+      <SectionCard
+        title={t(PageText.Contact.ticketing.travelCard.orderTravelCard.label)}
+      >
+        <ul className={style.rules__list}>
+          {PageText.Contact.ticketing.travelCard.orderTravelCard.info.map(
+            (paragraph: TranslatedString, index: number) => (
+              <li key={`info-paragraph-${index}`}>
+                <Typo.p textType="body__primary">{t(paragraph)}</Typo.p>
+              </li>
+            ),
+          )}
+        </ul>
+      </SectionCard>
+      <SectionCard title={t(PageText.Contact.aboutYouInfo.title)}>
+        <Input
+          label={PageText.Contact.input.firstName.label}
+          type="text"
+          autoComplete="given-name additional-name"
+          name="firstName"
+          value={state.context.firstName || ''}
+          errorMessage={state.context?.errorMessages['firstName']?.[0]}
+          onChange={(e) =>
+            send({
+              type: 'ON_INPUT_CHANGE',
+              inputName: 'firstName',
+              value: e.target.value,
+            })
+          }
+        />
+
+        <Input
+          label={PageText.Contact.input.lastName.label}
+          type="text"
+          autoComplete="family-name"
+          name="lastName"
+          value={state.context.lastName || ''}
+          errorMessage={state.context?.errorMessages['lastName']?.[0]}
+          onChange={(e) =>
+            send({
+              type: 'ON_INPUT_CHANGE',
+              inputName: 'lastName',
+              value: e.target.value,
+            })
+          }
+        />
+        <Input
+          label={PageText.Contact.input.address.label}
+          type="text"
+          autoComplete="street-address"
+          name="address"
+          value={state.context.address || ''}
+          errorMessage={state.context?.errorMessages['address']?.[0]}
+          onChange={(e) =>
+            send({
+              type: 'ON_INPUT_CHANGE',
+              inputName: 'address',
+              value: e.target.value,
+            })
+          }
+        />
+        <Input
+          label={PageText.Contact.input.postalCode.label}
+          type="number"
+          autoComplete="postal-code"
+          name="postalCode"
+          value={state.context.postalCode || ''}
+          errorMessage={state.context?.errorMessages['postalCode']?.[0]}
+          onChange={(e) =>
+            send({
+              type: 'ON_INPUT_CHANGE',
+              inputName: 'postalCode',
+              value: e.target.value,
+            })
+          }
+        />
+        <Input
+          label={PageText.Contact.input.city.label}
+          type="text"
+          name="city"
+          value={state.context.city || ''}
+          errorMessage={state.context?.errorMessages['city']?.[0]}
+          onChange={(e) =>
+            send({
+              type: 'ON_INPUT_CHANGE',
+              inputName: 'city',
+              value: e.target.value,
+            })
+          }
+        />
+        <Input
+          label={PageText.Contact.input.email.label}
+          type="email"
+          autoComplete="email"
+          name="email"
+          value={state.context.email || ''}
+          errorMessage={state.context?.errorMessages['email']?.[0]}
+          onChange={(e) =>
+            send({
+              type: 'ON_INPUT_CHANGE',
+              inputName: 'email',
+              value: e.target.value,
+            })
+          }
+        />
+      </SectionCard>
+    </div>
+  );
+};
+
+export default OrderTravelCardForm;

--- a/src/page-modules/contact/ticketing/forms/travel-card/travelCardQuestionForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/travel-card/travelCardQuestionForm.tsx
@@ -1,0 +1,140 @@
+import { PageText, useTranslation } from '@atb/translations';
+import { ticketingFormEvents } from '../../events';
+import { TicketingContextType } from '../../ticketingStateMachine';
+import { Typo } from '@atb/components/typography';
+import { SectionCard, Input, Textarea, FileInput } from '../../../components';
+
+type TravelCardQuestionFormProps = {
+  state: { context: TicketingContextType };
+  send: (event: typeof ticketingFormEvents) => void;
+};
+
+export const TravelCardQuestionForm = ({
+  state,
+  send,
+}: TravelCardQuestionFormProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <div>
+      <SectionCard
+        title={t(
+          PageText.Contact.ticketing.travelCard.travelCardQuestion.label,
+        )}
+      >
+        <Typo.p textType="body__primary">
+          {t(PageText.Contact.input.travelCardNumber.info)}
+        </Typo.p>
+        <Input
+          label={PageText.Contact.input.travelCardNumber.label}
+          type="text"
+          name="travelCardNumber"
+          value={state.context.travelCardNumber || ''}
+          errorMessage={state.context?.errorMessages['travelCardNumber']?.[0]}
+          onChange={(e) =>
+            send({
+              type: 'ON_INPUT_CHANGE',
+              inputName: 'travelCardNumber',
+              value: e.target.value,
+            })
+          }
+        />
+      </SectionCard>
+      <SectionCard title={t(PageText.Contact.input.question.title)}>
+        <Typo.p textType="body__primary">
+          {t(PageText.Contact.input.question.info)}
+        </Typo.p>
+        <Textarea
+          value={state.context.question || ''}
+          onChange={(e) =>
+            send({
+              type: 'ON_INPUT_CHANGE',
+              inputName: 'question',
+              value: e.target.value,
+            })
+          }
+          error={
+            state.context.errorMessages['question']?.[0]
+              ? t(state.context.errorMessages['question']?.[0])
+              : undefined
+          }
+        />
+        <FileInput
+          name="attachments"
+          label={t(PageText.Contact.input.question.attachment)}
+          onChange={(files) => {
+            send({
+              type: 'ON_INPUT_CHANGE',
+              inputName: 'attachments',
+              value: files,
+            });
+          }}
+        />
+      </SectionCard>
+      <SectionCard title={t(PageText.Contact.aboutYouInfo.title)}>
+        <Input
+          label={PageText.Contact.input.firstName.label}
+          type="text"
+          autoComplete="given-name additional-name"
+          name="firstName"
+          value={state.context.firstName || ''}
+          errorMessage={state.context?.errorMessages['firstName']?.[0]}
+          onChange={(e) =>
+            send({
+              type: 'ON_INPUT_CHANGE',
+              inputName: 'firstName',
+              value: e.target.value,
+            })
+          }
+        />
+
+        <Input
+          label={PageText.Contact.input.lastName.label}
+          type="text"
+          autoComplete="family-name"
+          name="lastName"
+          value={state.context.lastName || ''}
+          errorMessage={state.context?.errorMessages['lastName']?.[0]}
+          onChange={(e) =>
+            send({
+              type: 'ON_INPUT_CHANGE',
+              inputName: 'lastName',
+              value: e.target.value,
+            })
+          }
+        />
+        <Input
+          label={PageText.Contact.input.email.label}
+          type="email"
+          autoComplete="email"
+          name="email"
+          value={state.context.email || ''}
+          errorMessage={state.context?.errorMessages['email']?.[0]}
+          onChange={(e) =>
+            send({
+              type: 'ON_INPUT_CHANGE',
+              inputName: 'email',
+              value: e.target.value,
+            })
+          }
+        />
+        <Input
+          label={PageText.Contact.input.phoneNumber.label}
+          type="tel"
+          name="phoneNumber"
+          value={state.context.phoneNumber || ''}
+          errorMessage={state.context?.errorMessages['phoneNumber']?.[0]}
+          onChange={(e) =>
+            send({
+              type: 'ON_INPUT_CHANGE',
+              inputName: 'phoneNumber',
+              value: e.target.value,
+            })
+          }
+        />
+      </SectionCard>
+    </div>
+  );
+};
+
+export default TravelCardQuestionForm;

--- a/src/page-modules/contact/ticketing/index.tsx
+++ b/src/page-modules/contact/ticketing/index.tsx
@@ -8,6 +8,7 @@ import { SectionCard, Radio } from '../components';
 import PriceAndTicketTypesForm from './forms/priceAndTicketTypesForm';
 import AppForms from './forms/app';
 import WebshopForms from './forms/webshop';
+import TravelCardForms from './forms/travel-card';
 
 const TicketingContent = () => {
   const { t } = useTranslation();
@@ -49,6 +50,10 @@ const TicketingContent = () => {
 
       {state.matches({ editing: 'webshop' }) && (
         <WebshopForms state={state} send={send} />
+      )}
+
+      {state.matches({ editing: 'travelCard' }) && (
+        <TravelCardForms state={state} send={send} />
       )}
 
       {state.context.formType && (

--- a/src/page-modules/contact/ticketing/ticketingStateMachine.ts
+++ b/src/page-modules/contact/ticketing/ticketingStateMachine.ts
@@ -22,6 +22,11 @@ export enum WebshopForm {
   WebshopAccount = 'webshopAccount',
 }
 
+export enum TravelCardForm {
+  OrderTravelCard = 'orderTravelCard',
+  TravelCardQuestion = 'travelCardQuestion',
+}
+
 enum FormType {
   PriceAndTicketTypes = 'priceAndTicketTypes',
   AppTicketing = 'appTicketing',
@@ -143,7 +148,6 @@ const setInputsToValidate = (context: TicketingContextType) => {
     case FormType.TravelCardQuestion:
       return {
         formType,
-        travelCardNumber,
         question,
         firstName,
         lastName,
@@ -287,6 +291,10 @@ export const ticketingStateMachine = setup({
       target: '#webshopFormHandler',
     },
 
+    SELECT_TRAVELCARD_FORM: {
+      target: '#travelCardFormHandler',
+    },
+
     SUBMIT: { target: '#validating' },
   },
   states: {
@@ -367,6 +375,24 @@ export const ticketingStateMachine = setup({
       ],
     },
 
+    travelCardFormHandler: {
+      id: 'travelCardFormHandler',
+      always: [
+        {
+          guard: ({ event }) =>
+            event.type === 'SELECT_TRAVELCARD_FORM' &&
+            event.travelCardForm === TravelCardForm.TravelCardQuestion,
+          target: `#${TravelCardForm.TravelCardQuestion}`,
+        },
+        {
+          guard: ({ event }) =>
+            event.type === 'SELECT_TRAVELCARD_FORM' &&
+            event.travelCardForm === TravelCardForm.OrderTravelCard,
+          target: `#${TravelCardForm.OrderTravelCard}`,
+        },
+      ],
+    },
+
     editing: {
       initial: 'selectFormCategory',
       states: {
@@ -408,8 +434,24 @@ export const ticketingStateMachine = setup({
         },
         travelCard: {
           id: 'travelCard',
+          initial: 'selectTravelCardForm',
           entry: 'setFormTypeToUndefined',
           exit: 'clearValidationErrors',
+          states: {
+            selectTravelCardForm: {},
+            travelCardQuestion: {
+              id: 'travelCardQuestion',
+              entry: assign({
+                formType: () => FormType.TravelCardQuestion,
+              }),
+            },
+            orderTravelCard: {
+              id: 'orderTravelCard',
+              entry: assign({
+                formType: () => FormType.OrderTravelCard,
+              }),
+            },
+          },
         },
 
         webshop: {

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -513,7 +513,7 @@ export const Contact = {
       },
     },
     travelCard: {
-      description: _('Resekort', 'Travel card', 'Resiekort'),
+      description: _('Reisekort', 'Travel card', 'Reisekort'),
       question: _(
         'Hva gjelder forespørselen?',
         'What is the request about?',
@@ -540,7 +540,7 @@ export const Contact = {
           ),
         ],
       },
-      otherQuestionsRegardingTravelCard: {
+      travelCardQuestion: {
         label: _(
           'Andre spørsmål om reisekort',
           'Other questions regarding travel card',
@@ -1459,6 +1459,11 @@ export const Contact = {
 
     travelCardNumber: {
       label: _('Reisekort', 'Travelcard', 'Reisekort'),
+      info: _(
+        'Legg inn reisekortnummeret her hvis du allerede har et reisekort. Reisekortnummeret finner du på baksiden av reisekortet ditt',
+        'Enter the travel card number here if you already have a travel card. The travel card number can be found on the back of your travel card',
+        'Legg inn reisekortnummeret her viss du allereie har eit reisekort. Reisekortnummeret finn du bak på reisekortet ditt.',
+      ),
       errorMessages: {
         empty: _(
           'Legg til reisekort',


### PR DESCRIPTION
This PR provides a forms for travel card, under the ticketing page.

Blocked until `handlerTravelCardForm` is added to `ticketingRouter`: https://github.com/mrfylke/pureservice-connect/pull/16