### PR TITLE
feat: extend line filtering to filter by bus, fast ferry and ferry.

### DIFF
--- a/src/page-modules/contact/commoneEvents.ts
+++ b/src/page-modules/contact/commoneEvents.ts
@@ -1,4 +1,4 @@
-import { TransportModeType } from '@atb-as/config-specs';
+import { TransportModeType } from './types';
 import { Line } from '.';
 
 export const commonEvents = {} as

--- a/src/page-modules/contact/lines/use-lines.ts
+++ b/src/page-modules/contact/lines/use-lines.ts
@@ -10,6 +10,20 @@ export const useLines = () => {
     isLoading,
   } = useSWR<Line[]>('/api/contact/lines', swrFetcher);
 
+  const subTransportModesExpressboat = [
+    'highSpeedVehicleService',
+    'internationalCarFerry',
+    'localCarFerry',
+    'nationalCarFerry',
+  ];
+
+  const subTransportModesFerry = [
+    'highSpeedVehicleService',
+    'internationalCarFerry',
+    'localCarFerry',
+    'nationalCarFerry',
+  ];
+
   const getLinesByMode = (transportMode: TransportModeType): Line[] => {
     if (!lines) return [];
 
@@ -21,21 +35,16 @@ export const useLines = () => {
         return lines.filter(
           (line) =>
             line.transportMode === 'water' &&
-            (line.transportSubmode === 'highSpeedPassengerService' ||
-              line.transportSubmode === 'highSpeedVehicleService' ||
-              line.transportSubmode === 'sightseeingService' ||
-              line.transportSubmode === 'localPassengerFerry' ||
-              line.transportSubmode === 'internationalPassengerFerry'),
+            line.transportSubmode !== null &&
+            subTransportModesExpressboat.includes(line.transportSubmode),
         );
 
       case 'ferry':
         return lines.filter(
           (line) =>
             line.transportMode === 'water' &&
-            (line.transportSubmode === 'highSpeedVehicleService' ||
-              line.transportSubmode === 'internationalCarFerry' ||
-              line.transportSubmode === 'localCarFerry' ||
-              line.transportSubmode === 'nationalCarFerry'),
+            line.transportSubmode !== null &&
+            subTransportModesFerry.includes(line.transportSubmode),
         );
       default:
         return [];

--- a/src/page-modules/contact/lines/use-lines.ts
+++ b/src/page-modules/contact/lines/use-lines.ts
@@ -1,5 +1,5 @@
 import { swrFetcher } from '@atb/modules/api-browser';
-import { TransportModeType } from '@atb/modules/transport-mode';
+import { TransportModeType } from '../types';
 import useSWR from 'swr';
 import { Line } from '../server/journey-planner/validators';
 
@@ -10,9 +10,36 @@ export const useLines = () => {
     isLoading,
   } = useSWR<Line[]>('/api/contact/lines', swrFetcher);
 
-  const getLinesByMode = (mode: TransportModeType): Line[] => {
+  const getLinesByMode = (transportMode: TransportModeType): Line[] => {
     if (!lines) return [];
-    return lines.filter((line) => line.transportMode === mode);
+
+    switch (transportMode) {
+      case 'bus':
+        return lines.filter((line) => line.transportMode === transportMode);
+
+      case 'expressboat':
+        return lines.filter(
+          (line) =>
+            line.transportMode === 'water' &&
+            (line.transportSubmode === 'highSpeedPassengerService' ||
+              line.transportSubmode === 'highSpeedVehicleService' ||
+              line.transportSubmode === 'sightseeingService' ||
+              line.transportSubmode === 'localPassengerFerry' ||
+              line.transportSubmode === 'internationalPassengerFerry'),
+        );
+
+      case 'ferry':
+        return lines.filter(
+          (line) =>
+            line.transportMode === 'water' &&
+            (line.transportSubmode === 'highSpeedVehicleService' ||
+              line.transportSubmode === 'internationalCarFerry' ||
+              line.transportSubmode === 'localCarFerry' ||
+              line.transportSubmode === 'nationalCarFerry'),
+        );
+      default:
+        return [];
+    }
   };
 
   const getQuaysByLine = (lineId: string): Line['quays'] => {

--- a/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
@@ -1,8 +1,7 @@
 import { PageText, useTranslation } from '@atb/translations';
 import { useLines } from '../../lines/use-lines';
 import { Typo } from '@atb/components/typography';
-import { ComponentText } from '@atb/translations';
-import { TransportModeType } from '@atb-as/config-specs';
+import { TransportModeType } from '../../types';
 import { Line } from '../..';
 import { ContextProps } from '../means-of-transport-form-machine';
 import { meansOfTransportFormEvents } from '../events';
@@ -44,8 +43,8 @@ export const DelayForm = ({ state, send }: DelayFormProps) => {
         </Typo.p>
 
         <Select
-          label={t(PageText.Contact.input.transportMode.label).toString()}
-          value={state.context.transportMode}
+          label={t(PageText.Contact.input.transportMode.label)}
+          value={state.context.transportMode || ''}
           onChange={(value) =>
             send({
               type: 'ON_TRANSPORTMODE_CHANGE',
@@ -57,32 +56,35 @@ export const DelayForm = ({ state, send }: DelayFormProps) => {
               ? t(state.context?.errorMessages['transportMode']?.[0])
               : undefined
           }
-          valueToText={(val: TransportModeType) =>
-            t(ComponentText.TransportMode.modes[val])
+          valueToId={(val: string) => val}
+          valueToText={(val: string) =>
+            t(
+              PageText.Contact.input.transportMode.modes[
+                val as TransportModeType
+              ],
+            )
           }
-          valueToId={(val: TransportModeType) => val}
-          options={['bus', 'water'] as TransportModeType[]}
+          options={['bus', 'expressboat', 'ferry']}
           placeholder={t(PageText.Contact.input.transportMode.optionLabel)}
         />
 
         <SearchableSelect
           label={t(PageText.Contact.input.line.label)}
           value={state.context.line}
+          placeholder={t(PageText.Contact.input.line.optionLabel)}
           isDisabled={!state.context.transportMode}
+          options={getLineOptions(
+            getLinesByMode(state.context.transportMode as TransportModeType),
+          )}
           onChange={(value: Line | undefined) => {
             send({
               type: 'ON_LINE_CHANGE',
               value: value,
             });
           }}
-          options={getLineOptions(
-            getLinesByMode(state.context.transportMode as TransportModeType),
-          )}
-          placeholder={t(PageText.Contact.input.line.optionLabel)}
           error={
-            state.context?.errorMessages['line']?.[0]
-              ? t(state.context?.errorMessages['line']?.[0])
-              : undefined
+            state.context?.errorMessages['line']?.[0] &&
+            t(state.context?.errorMessages['line']?.[0])
           }
         />
 

--- a/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
@@ -2,8 +2,7 @@ import { PageText, useTranslation } from '@atb/translations';
 import { ContextProps } from '../means-of-transport-form-machine';
 import { useLines } from '../../lines/use-lines';
 import { Typo } from '@atb/components/typography';
-import { ComponentText } from '@atb/translations';
-import { TransportModeType } from '@atb-as/config-specs';
+import { TransportModeType } from '../../types';
 import { Line } from '../..';
 import { meansOfTransportFormEvents } from '../events';
 import {
@@ -66,8 +65,8 @@ export const DriverForm = ({ state, send }: DriverFormProps) => {
         />
 
         <Select
-          label={t(PageText.Contact.input.transportMode.label).toString()}
-          value={state.context.transportMode}
+          label={t(PageText.Contact.input.transportMode.label)}
+          value={state.context.transportMode || ''}
           onChange={(value) =>
             send({
               type: 'ON_TRANSPORTMODE_CHANGE',
@@ -79,32 +78,35 @@ export const DriverForm = ({ state, send }: DriverFormProps) => {
               ? t(state.context?.errorMessages['transportMode']?.[0])
               : undefined
           }
-          valueToText={(val: TransportModeType) =>
-            t(ComponentText.TransportMode.modes[val])
+          valueToId={(val: string) => val}
+          valueToText={(val: string) =>
+            t(
+              PageText.Contact.input.transportMode.modes[
+                val as TransportModeType
+              ],
+            )
           }
-          valueToId={(val: TransportModeType) => val}
-          options={['bus', 'water'] as TransportModeType[]}
+          options={['bus', 'expressboat', 'ferry']}
           placeholder={t(PageText.Contact.input.transportMode.optionLabel)}
         />
 
         <SearchableSelect
           label={t(PageText.Contact.input.line.label)}
           value={state.context.line}
+          placeholder={t(PageText.Contact.input.line.optionLabel)}
           isDisabled={!state.context.transportMode}
+          options={getLineOptions(
+            getLinesByMode(state.context.transportMode as TransportModeType),
+          )}
           onChange={(value: Line | undefined) => {
             send({
               type: 'ON_LINE_CHANGE',
               value: value,
             });
           }}
-          options={getLineOptions(
-            getLinesByMode(state.context.transportMode as TransportModeType),
-          )}
-          placeholder={t(PageText.Contact.input.line.optionLabel)}
           error={
-            state.context?.errorMessages['line']?.[0]
-              ? t(state.context?.errorMessages['line']?.[0])
-              : undefined
+            state.context?.errorMessages['line']?.[0] &&
+            t(state.context?.errorMessages['line']?.[0])
           }
         />
 

--- a/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
@@ -2,8 +2,7 @@ import { PageText, useTranslation } from '@atb/translations';
 import { ContextProps } from '../means-of-transport-form-machine';
 import { useLines } from '../../lines/use-lines';
 import { Typo } from '@atb/components/typography';
-import { ComponentText } from '@atb/translations';
-import { TransportModeType } from '@atb-as/config-specs';
+import { TransportModeType } from '../../types';
 import { Line } from '../..';
 import { meansOfTransportFormEvents } from '../events';
 import {
@@ -65,8 +64,8 @@ export const InjuryForm = ({ state, send }: InjuryFormProps) => {
         />
 
         <Select
-          label={t(PageText.Contact.input.transportMode.label).toString()}
-          value={state.context.transportMode}
+          label={t(PageText.Contact.input.transportMode.label)}
+          value={state.context.transportMode || ''}
           onChange={(value) =>
             send({
               type: 'ON_TRANSPORTMODE_CHANGE',
@@ -78,32 +77,35 @@ export const InjuryForm = ({ state, send }: InjuryFormProps) => {
               ? t(state.context?.errorMessages['transportMode']?.[0])
               : undefined
           }
-          valueToText={(val: TransportModeType) =>
-            t(ComponentText.TransportMode.modes[val])
+          valueToId={(val: string) => val}
+          valueToText={(val: string) =>
+            t(
+              PageText.Contact.input.transportMode.modes[
+                val as TransportModeType
+              ],
+            )
           }
-          valueToId={(val: TransportModeType) => val}
-          options={['bus', 'water'] as TransportModeType[]}
+          options={['bus', 'expressboat', 'ferry']}
           placeholder={t(PageText.Contact.input.transportMode.optionLabel)}
         />
 
         <SearchableSelect
           label={t(PageText.Contact.input.line.label)}
           value={state.context.line}
+          placeholder={t(PageText.Contact.input.line.optionLabel)}
           isDisabled={!state.context.transportMode}
+          options={getLineOptions(
+            getLinesByMode(state.context.transportMode as TransportModeType),
+          )}
           onChange={(value: Line | undefined) => {
             send({
               type: 'ON_LINE_CHANGE',
               value: value,
             });
           }}
-          options={getLineOptions(
-            getLinesByMode(state.context.transportMode as TransportModeType),
-          )}
-          placeholder={t(PageText.Contact.input.line.optionLabel)}
           error={
-            state.context?.errorMessages['line']?.[0]
-              ? t(state.context?.errorMessages['line']?.[0])
-              : undefined
+            state.context?.errorMessages['line']?.[0] &&
+            t(state.context?.errorMessages['line']?.[0])
           }
         />
 

--- a/src/page-modules/contact/means-of-transport/forms/serviceOfferingForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/serviceOfferingForm.tsx
@@ -2,8 +2,7 @@ import { PageText, useTranslation } from '@atb/translations';
 import { ContextProps } from '../means-of-transport-form-machine';
 import { useLines } from '../../lines/use-lines';
 import { Typo } from '@atb/components/typography';
-import { ComponentText } from '@atb/translations';
-import { TransportModeType } from '@atb-as/config-specs';
+import { TransportModeType } from '../../types';
 import { Line } from '../..';
 import { meansOfTransportFormEvents } from '../events';
 import {
@@ -70,8 +69,8 @@ export const ServiceOfferingForm = ({
         />
 
         <Select
-          label={t(PageText.Contact.input.transportMode.label).toString()}
-          value={state.context.transportMode}
+          label={t(PageText.Contact.input.transportMode.label)}
+          value={state.context.transportMode || ''}
           onChange={(value) =>
             send({
               type: 'ON_TRANSPORTMODE_CHANGE',
@@ -83,32 +82,35 @@ export const ServiceOfferingForm = ({
               ? t(state.context?.errorMessages['transportMode']?.[0])
               : undefined
           }
-          valueToText={(val: TransportModeType) =>
-            t(ComponentText.TransportMode.modes[val])
+          valueToId={(val: string) => val}
+          valueToText={(val: string) =>
+            t(
+              PageText.Contact.input.transportMode.modes[
+                val as TransportModeType
+              ],
+            )
           }
-          valueToId={(val: TransportModeType) => val}
-          options={['bus', 'water'] as TransportModeType[]}
+          options={['bus', 'expressboat', 'ferry']}
           placeholder={t(PageText.Contact.input.transportMode.optionLabel)}
         />
 
         <SearchableSelect
           label={t(PageText.Contact.input.line.label)}
           value={state.context.line}
+          placeholder={t(PageText.Contact.input.line.optionLabel)}
           isDisabled={!state.context.transportMode}
+          options={getLineOptions(
+            getLinesByMode(state.context.transportMode as TransportModeType),
+          )}
           onChange={(value: Line | undefined) => {
             send({
               type: 'ON_LINE_CHANGE',
               value: value,
             });
           }}
-          options={getLineOptions(
-            getLinesByMode(state.context.transportMode as TransportModeType),
-          )}
-          placeholder={t(PageText.Contact.input.line.optionLabel)}
           error={
-            state.context?.errorMessages['line']?.[0]
-              ? t(state.context?.errorMessages['line']?.[0])
-              : undefined
+            state.context?.errorMessages['line']?.[0] &&
+            t(state.context?.errorMessages['line']?.[0])
           }
         />
       </SectionCard>

--- a/src/page-modules/contact/means-of-transport/forms/stopForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/stopForm.tsx
@@ -2,8 +2,7 @@ import { PageText, useTranslation } from '@atb/translations';
 import { ContextProps } from '../means-of-transport-form-machine';
 import { useLines } from '../../lines/use-lines';
 import { Typo } from '@atb/components/typography';
-import { ComponentText } from '@atb/translations';
-import { TransportModeType } from '@atb-as/config-specs';
+import { TransportModeType } from '../../types';
 import { Line } from '../..';
 import { meansOfTransportFormEvents } from '../events';
 import {
@@ -40,8 +39,8 @@ export const StopForm = ({ state, send }: StopFormProps) => {
         </Typo.p>
 
         <Select
-          label={t(PageText.Contact.input.transportMode.label).toString()}
-          value={state.context.transportMode}
+          label={t(PageText.Contact.input.transportMode.label)}
+          value={state.context.transportMode || ''}
           onChange={(value) =>
             send({
               type: 'ON_TRANSPORTMODE_CHANGE',
@@ -53,32 +52,35 @@ export const StopForm = ({ state, send }: StopFormProps) => {
               ? t(state.context?.errorMessages['transportMode']?.[0])
               : undefined
           }
-          valueToText={(val: TransportModeType) =>
-            t(ComponentText.TransportMode.modes[val])
+          valueToId={(val: string) => val}
+          valueToText={(val: string) =>
+            t(
+              PageText.Contact.input.transportMode.modes[
+                val as TransportModeType
+              ],
+            )
           }
-          valueToId={(val: TransportModeType) => val}
-          options={['bus', 'water'] as TransportModeType[]}
+          options={['bus', 'expressboat', 'ferry']}
           placeholder={t(PageText.Contact.input.transportMode.optionLabel)}
         />
 
         <SearchableSelect
           label={t(PageText.Contact.input.line.label)}
           value={state.context.line}
+          placeholder={t(PageText.Contact.input.line.optionLabel)}
           isDisabled={!state.context.transportMode}
+          options={getLineOptions(
+            getLinesByMode(state.context.transportMode as TransportModeType),
+          )}
           onChange={(value: Line | undefined) => {
             send({
               type: 'ON_LINE_CHANGE',
               value: value,
             });
           }}
-          options={getLineOptions(
-            getLinesByMode(state.context.transportMode as TransportModeType),
-          )}
-          placeholder={t(PageText.Contact.input.line.optionLabel)}
           error={
-            state.context?.errorMessages['line']?.[0]
-              ? t(state.context?.errorMessages['line']?.[0])
-              : undefined
+            state.context?.errorMessages['line']?.[0] &&
+            t(state.context?.errorMessages['line']?.[0])
           }
         />
 

--- a/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
@@ -2,8 +2,7 @@ import { PageText, useTranslation } from '@atb/translations';
 import { ContextProps } from '../means-of-transport-form-machine';
 import { useLines } from '../../lines/use-lines';
 import { Typo } from '@atb/components/typography';
-import { ComponentText } from '@atb/translations';
-import { TransportModeType } from '@atb-as/config-specs';
+import { TransportModeType } from '../../types';
 import { Line } from '../..';
 import { meansOfTransportFormEvents } from '../events';
 import {
@@ -48,8 +47,8 @@ export const TransportationForm = ({
         </Typo.p>
 
         <Select
-          label={t(PageText.Contact.input.transportMode.label).toString()}
-          value={state.context.transportMode}
+          label={t(PageText.Contact.input.transportMode.label)}
+          value={state.context.transportMode || ''}
           onChange={(value) =>
             send({
               type: 'ON_TRANSPORTMODE_CHANGE',
@@ -61,32 +60,35 @@ export const TransportationForm = ({
               ? t(state.context?.errorMessages['transportMode']?.[0])
               : undefined
           }
-          valueToText={(val: TransportModeType) =>
-            t(ComponentText.TransportMode.modes[val])
+          valueToId={(val: string) => val}
+          valueToText={(val: string) =>
+            t(
+              PageText.Contact.input.transportMode.modes[
+                val as TransportModeType
+              ],
+            )
           }
-          valueToId={(val: TransportModeType) => val}
-          options={['bus', 'water'] as TransportModeType[]}
+          options={['bus', 'expressboat', 'ferry']}
           placeholder={t(PageText.Contact.input.transportMode.optionLabel)}
         />
 
         <SearchableSelect
           label={t(PageText.Contact.input.line.label)}
           value={state.context.line}
+          placeholder={t(PageText.Contact.input.line.optionLabel)}
           isDisabled={!state.context.transportMode}
+          options={getLineOptions(
+            getLinesByMode(state.context.transportMode as TransportModeType),
+          )}
           onChange={(value: Line | undefined) => {
             send({
               type: 'ON_LINE_CHANGE',
               value: value,
             });
           }}
-          options={getLineOptions(
-            getLinesByMode(state.context.transportMode as TransportModeType),
-          )}
-          placeholder={t(PageText.Contact.input.line.optionLabel)}
           error={
-            state.context?.errorMessages['line']?.[0]
-              ? t(state.context?.errorMessages['line']?.[0])
-              : undefined
+            state.context?.errorMessages['line']?.[0] &&
+            t(state.context?.errorMessages['line']?.[0])
           }
         />
 

--- a/src/page-modules/contact/means-of-transport/means-of-transport-form-machine.ts
+++ b/src/page-modules/contact/means-of-transport/means-of-transport-form-machine.ts
@@ -1,4 +1,4 @@
-import { TransportModeType } from '@atb-as/config-specs';
+import { TransportModeType } from '../types';
 import { assign, fromPromise, setup } from 'xstate';
 import { Line } from '../server/journey-planner/validators';
 import { commonInputValidator, InputErrorMessages } from '../validation';

--- a/src/page-modules/contact/server/journey-planner/index.ts
+++ b/src/page-modules/contact/server/journey-planner/index.ts
@@ -6,7 +6,10 @@ import {
 } from './journey-gql/lines.generated';
 import { getOrgData } from '@atb/modules/org-data';
 import { Line, linesSchema } from './validators';
-import { isTransportModeType } from '@atb/modules/transport-mode';
+import {
+  isTransportModeType,
+  isTransportSubmodeType,
+} from '@atb/modules/transport-mode';
 
 export type JourneyPlannerApi = {
   lines(): Promise<Line[]>;
@@ -33,6 +36,9 @@ export function createJourneyApi(
         publicCode: line.publicCode ?? null,
         transportMode: isTransportModeType(line.transportMode)
           ? line.transportMode
+          : null,
+        transportSubmode: isTransportSubmodeType(line.transportSubmode)
+          ? line.transportSubmode
           : null,
         quays: line.quays.map((quay) => ({
           id: quay.id,

--- a/src/page-modules/contact/server/journey-planner/journey-gql/lines.gql
+++ b/src/page-modules/contact/server/journey-planner/journey-gql/lines.gql
@@ -4,6 +4,7 @@ query lines($authority: String!) {
     name
     publicCode
     transportMode
+    transportSubmode
     quays {
       id
       name

--- a/src/page-modules/contact/server/journey-planner/validators.ts
+++ b/src/page-modules/contact/server/journey-planner/validators.ts
@@ -1,4 +1,7 @@
-import { transportModeSchema } from '@atb/modules/transport-mode';
+import {
+  transportModeSchema,
+  transportSubmodeSchema,
+} from '@atb/modules/transport-mode';
 import { z } from 'zod';
 
 export const lineSchema = z.object({
@@ -6,6 +9,7 @@ export const lineSchema = z.object({
   name: z.string(),
   publicCode: z.string().nullable(),
   transportMode: transportModeSchema.nullable(),
+  transportSubmode: transportSubmodeSchema.nullable(),
   quays: z.array(
     z.object({
       id: z.string(),

--- a/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
@@ -1,9 +1,9 @@
-import { ComponentText, PageText, useTranslation } from '@atb/translations';
-import { TransportModeType } from '@atb-as/config-specs';
+import { PageText, useTranslation } from '@atb/translations';
 import { Line } from '../..';
 import { Typo } from '@atb/components/typography';
 import { ticketControlFormEvents } from '../events';
 import { ContextProps } from '../ticket-control-form-machine';
+import { TransportModeType } from '../../types';
 import { useLines } from '../../lines/use-lines';
 import {
   SectionCard,
@@ -33,8 +33,8 @@ export const FeedbackForm = ({ state, send }: FeedbackFormProps) => {
         </Typo.p>
 
         <Select
-          label={t(PageText.Contact.input.transportMode.label).toString()}
-          value={state.context.transportMode}
+          label={t(PageText.Contact.input.transportMode.label)}
+          value={state.context.transportMode || ''}
           onChange={(value) =>
             send({
               type: 'ON_TRANSPORTMODE_CHANGE',
@@ -46,11 +46,15 @@ export const FeedbackForm = ({ state, send }: FeedbackFormProps) => {
               ? t(state.context?.errorMessages['transportMode']?.[0])
               : undefined
           }
-          valueToText={(val: TransportModeType) =>
-            t(ComponentText.TransportMode.modes[val])
+          valueToId={(val: string) => val}
+          valueToText={(val: string) =>
+            t(
+              PageText.Contact.input.transportMode.modes[
+                val as TransportModeType
+              ],
+            )
           }
-          valueToId={(val: TransportModeType) => val}
-          options={['bus', 'water'] as TransportModeType[]}
+          options={['bus', 'expressboat', 'ferry']}
           placeholder={t(PageText.Contact.input.transportMode.optionLabel)}
         />
 

--- a/src/page-modules/contact/ticket-control/ticket-control-form-machine.ts
+++ b/src/page-modules/contact/ticket-control/ticket-control-form-machine.ts
@@ -7,9 +7,9 @@ import {
   setLineAndResetStops,
   setTransportModeAndResetLineAndStops,
 } from '../utils';
-import { TransportModeType } from '@atb-as/config-specs';
 import { Line } from '../server/journey-planner/validators';
 import { commonInputValidator, InputErrorMessages } from '../validation';
+import { TransportModeType } from '../types';
 
 export enum FormType {
   FeeComplaint = 'feeComplaint',

--- a/src/page-modules/contact/travel-guarantee/forms/refundCarForm.tsx
+++ b/src/page-modules/contact/travel-guarantee/forms/refundCarForm.tsx
@@ -1,6 +1,6 @@
-import { ComponentText, PageText, useTranslation } from '@atb/translations';
+import { PageText, useTranslation } from '@atb/translations';
 import { useLines } from '../../lines/use-lines';
-import { TransportModeType } from '@atb-as/config-specs';
+import { TransportModeType } from '../../types';
 import { Line } from '../..';
 import { TravelGuaranteeFormEvents } from '../events';
 import { ContextProps } from '../travelGuaranteeFormMachine';
@@ -81,8 +81,8 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
           }
         />
         <Select
-          label={t(PageText.Contact.input.transportMode.label).toString()}
-          value={state.context.transportMode}
+          label={t(PageText.Contact.input.transportMode.label)}
+          value={state.context.transportMode || ''}
           onChange={(value) =>
             send({
               type: 'ON_TRANSPORTMODE_CHANGE',
@@ -94,32 +94,35 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
               ? t(state.context?.errorMessages['transportMode']?.[0])
               : undefined
           }
-          valueToText={(val: TransportModeType) =>
-            t(ComponentText.TransportMode.modes[val])
+          valueToId={(val: string) => val}
+          valueToText={(val: string) =>
+            t(
+              PageText.Contact.input.transportMode.modes[
+                val as TransportModeType
+              ],
+            )
           }
-          valueToId={(val: TransportModeType) => val}
-          options={['bus', 'water'] as TransportModeType[]}
+          options={['bus', 'expressboat', 'ferry']}
           placeholder={t(PageText.Contact.input.transportMode.optionLabel)}
         />
 
         <SearchableSelect
           label={t(PageText.Contact.input.line.label)}
           value={state.context.line}
+          placeholder={t(PageText.Contact.input.line.optionLabel)}
           isDisabled={!state.context.transportMode}
+          options={getLineOptions(
+            getLinesByMode(state.context.transportMode as TransportModeType),
+          )}
           onChange={(value: Line | undefined) => {
             send({
               type: 'ON_LINE_CHANGE',
               value: value,
             });
           }}
-          options={getLineOptions(
-            getLinesByMode(state.context.transportMode as TransportModeType),
-          )}
-          placeholder={t(PageText.Contact.input.line.optionLabel)}
           error={
-            state.context?.errorMessages['line']?.[0]
-              ? t(state.context?.errorMessages['line']?.[0])
-              : undefined
+            state.context?.errorMessages['line']?.[0] &&
+            t(state.context?.errorMessages['line']?.[0])
           }
         />
 

--- a/src/page-modules/contact/travel-guarantee/forms/refundTaxiForm.tsx
+++ b/src/page-modules/contact/travel-guarantee/forms/refundTaxiForm.tsx
@@ -1,6 +1,6 @@
-import { ComponentText, PageText, useTranslation } from '@atb/translations';
+import { PageText, useTranslation } from '@atb/translations';
 import { useLines } from '../../lines/use-lines';
-import { TransportModeType } from '@atb-as/config-specs';
+import { TransportModeType } from '../../types';
 import { Line } from '../..';
 import { TravelGuaranteeFormEvents } from '../events';
 import { ContextProps } from '../travelGuaranteeFormMachine';
@@ -33,8 +33,8 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
         )}
       >
         <Select
-          label={t(PageText.Contact.input.transportMode.label).toString()}
-          value={state.context.transportMode}
+          label={t(PageText.Contact.input.transportMode.label)}
+          value={state.context.transportMode || ''}
           onChange={(value) =>
             send({
               type: 'ON_TRANSPORTMODE_CHANGE',
@@ -46,32 +46,35 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
               ? t(state.context?.errorMessages['transportMode']?.[0])
               : undefined
           }
-          valueToText={(val: TransportModeType) =>
-            t(ComponentText.TransportMode.modes[val])
+          valueToId={(val: string) => val}
+          valueToText={(val: string) =>
+            t(
+              PageText.Contact.input.transportMode.modes[
+                val as TransportModeType
+              ],
+            )
           }
-          valueToId={(val: TransportModeType) => val}
-          options={['bus', 'water'] as TransportModeType[]}
+          options={['bus', 'expressboat', 'ferry']}
           placeholder={t(PageText.Contact.input.transportMode.optionLabel)}
         />
 
         <SearchableSelect
           label={t(PageText.Contact.input.line.label)}
           value={state.context.line}
+          placeholder={t(PageText.Contact.input.line.optionLabel)}
           isDisabled={!state.context.transportMode}
+          options={getLineOptions(
+            getLinesByMode(state.context.transportMode as TransportModeType),
+          )}
           onChange={(value: Line | undefined) => {
             send({
               type: 'ON_LINE_CHANGE',
               value: value,
             });
           }}
-          options={getLineOptions(
-            getLinesByMode(state.context.transportMode as TransportModeType),
-          )}
-          placeholder={t(PageText.Contact.input.line.optionLabel)}
           error={
-            state.context?.errorMessages['line']?.[0]
-              ? t(state.context?.errorMessages['line']?.[0])
-              : undefined
+            state.context?.errorMessages['line']?.[0] &&
+            t(state.context?.errorMessages['line']?.[0])
           }
         />
 

--- a/src/page-modules/contact/travel-guarantee/travelGuaranteeFormMachine.ts
+++ b/src/page-modules/contact/travel-guarantee/travelGuaranteeFormMachine.ts
@@ -1,4 +1,4 @@
-import { TransportModeType } from '@atb-as/config-specs';
+import { TransportModeType } from '../types';
 import { assign, fromPromise, setup } from 'xstate';
 import { Line } from '../server/journey-planner/validators';
 import { ReasonForTransportFailure } from './events';

--- a/src/page-modules/contact/types.ts
+++ b/src/page-modules/contact/types.ts
@@ -1,0 +1,1 @@
+export type TransportModeType = 'bus' | 'expressboat' | 'ferry';

--- a/src/page-modules/contact/utils.ts
+++ b/src/page-modules/contact/utils.ts
@@ -1,4 +1,4 @@
-import { TransportModeType } from '@atb-as/config-specs';
+import { TransportModeType } from './types';
 import { Line } from '.';
 
 export const shouldShowContactPage = (): boolean => {

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -1108,6 +1108,11 @@ export const Contact = {
         'Select transport mode',
         'Vel transportmiddel',
       ),
+      modes: {
+        bus: _('Buss', 'Bus', 'Buss'),
+        expressboat: _('Hurtigbåt', 'Express boat', 'Hurtigbåt'),
+        ferry: _('Ferge', 'Ferry', 'Ferje'),
+      },
       errorMessages: {
         empty: _(
           'Velg transportmiddel',


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/19324


### Background
I FRAM har vi buss, hurtigbåt og ferje. Avviksinformasjonen vår er også delt inn på dette. Burde det ikke være mulig å velge «ferje» eller «hurtigbåt» under transportmiddel, i stedet for bare «båt»?

### Proposed solution
Update getLinesByMode() to be able to filter on bus, express boats and ferry


#### Illustrations
<!-- When relevant, include screenshots, wireframes and graphic design. -->
<details>
<summary>screenshots/video/figma</summary>
<img width="1057" alt="Skjermbilde 2024-10-24 kl  14 16 25" src="https://github.com/user-attachments/assets/ecf9047d-34fa-4275-b67e-4547120689bc">
<img width="999" alt="Skjermbilde 2024-10-24 kl  14 16 40" src="https://github.com/user-attachments/assets/23c5eab3-2b4f-4e72-8c7b-bee768c9ac9e">
<img width="996" alt="Skjermbilde 2024-10-24 kl  14 16 56" src="https://github.com/user-attachments/assets/18e293b4-5000-4344-9aa3-2daa85828631">

</details>


### Acceptance Criteria

- [x] Enables filtering on bus, express boats and ferry.





