### PR TITLE
fix: travel guarantee - split section into two sections

### DIFF
--- a/src/page-modules/contact/travel-guarantee/forms/refundCarForm.tsx
+++ b/src/page-modules/contact/travel-guarantee/forms/refundCarForm.tsx
@@ -28,9 +28,7 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
   return (
     <div>
       <SectionCard
-        title={t(
-          PageText.Contact.travelGuarantee.refundTaxi.aboutYourTrip.title,
-        )}
+        title={t(PageText.Contact.travelGuarantee.refundTaxi.carTrip.title)}
       >
         <Input
           label={PageText.Contact.input.kilometersDriven.label}
@@ -80,6 +78,12 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
             })
           }
         />
+      </SectionCard>
+      <SectionCard
+        title={t(
+          PageText.Contact.travelGuarantee.refundTaxi.aboutYourTrip.title,
+        )}
+      >
         <Select
           label={t(PageText.Contact.input.transportMode.label).toString()}
           value={state.context.transportMode}

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -260,7 +260,7 @@ export const Contact = {
       information: {
         title: _(
           'Informasjon fra drosjekvitteringen',
-          'Information from the taxi reciet',
+          'Information from the taxi receipt',
           'Informasjon frå drosjekvitteringa',
         ),
       },
@@ -271,7 +271,7 @@ export const Contact = {
 
       aboutYourTrip: {
         title: _(
-          'Om den planlagte reisa di',
+          'Om den planlagte reisen din',
           'About your planed trip',
           'Om den planlagde reisa di',
         ),

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -264,6 +264,11 @@ export const Contact = {
           'Informasjon frå drosjekvitteringa',
         ),
       },
+
+      carTrip: {
+        title: _('Om bilturen', 'About the car trip', 'Om bilturen'),
+      },
+
       aboutYourTrip: {
         title: _(
           'Om den planlagte reisa di',


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/19328

### Backround
Feedback from FRAM:
Her blir jeg veldig forvirret. Burde det ikke spørres om bilreisen først, slik Ruter gjør? Hos oss kommer spørsmål om antall kjørte kilometer og til/fra under tittelen
Om den planlagte reisa di.

### Proposed solution
Spilt up the section `Om den planlagte reisa di` into two sections:

##### Om bilturen
Kilometer køyrd
Frå adresse
Til adresse


##### Om den planlagde reisa di
Fortel kvifor du ikkje fekk reist som du skulle med oss, slik at du måtte ta drosje.
Transportmiddel
[Moglege val]
Buss
Hurtigbåt
.....