### PR TITLE
fix: add missing section in travel guarantee taxi refund form

### DIFF
--- a/src/page-modules/contact/travel-guarantee/events.ts
+++ b/src/page-modules/contact/travel-guarantee/events.ts
@@ -11,6 +11,7 @@ const TravelGuaranteeSpecificFormEvents = {} as
         | 'kilometersDriven'
         | 'fromAddress'
         | 'toAddress'
+        | 'amount'
         | 'reasonForTransportFailure'
         | 'isIntialAgreementChecked'
         | 'hasInternationalBankAccount';

--- a/src/page-modules/contact/travel-guarantee/forms/refundTaxiForm.tsx
+++ b/src/page-modules/contact/travel-guarantee/forms/refundTaxiForm.tsx
@@ -4,6 +4,7 @@ import { TransportModeType } from '@atb-as/config-specs';
 import { Line } from '../..';
 import { TravelGuaranteeFormEvents } from '../events';
 import { ContextProps } from '../travelGuaranteeFormMachine';
+import { Typo } from '@atb/components/typography';
 import {
   SectionCard,
   Input,
@@ -27,6 +28,44 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
 
   return (
     <div>
+      <SectionCard
+        title={t(PageText.Contact.travelGuarantee.refundTaxi.taxiReceipt.title)}
+      >
+        <Typo.p textType="body__primary">
+          {t(PageText.Contact.travelGuarantee.refundTaxi.taxiReceipt.info)}
+        </Typo.p>
+
+        {/*Should here add a component for using camara in phone directly.*/}
+        <FileInput
+          label={t(PageText.Contact.input.feedback.attachment)}
+          name="attachments"
+          onChange={(files) => {
+            send({
+              type: 'ON_INPUT_CHANGE',
+              inputName: 'attachments',
+              value: files,
+            });
+          }}
+          errorMessage={state.context?.errorMessages['attachments']?.[0]}
+        />
+        <Input
+          label={PageText.Contact.input.amount.label}
+          type="text"
+          name="amount"
+          value={state.context.amount || ''}
+          errorMessage={state.context?.errorMessages['amount']?.[0]}
+          onChange={(e) =>
+            send({
+              type: 'ON_INPUT_CHANGE',
+              inputName: 'amount',
+              value: e.target.value,
+            })
+          }
+        />
+        <Typo.p textType="body__primary">
+          {t(PageText.Contact.input.amount.info)}
+        </Typo.p>
+      </SectionCard>
       <SectionCard
         title={t(
           PageText.Contact.travelGuarantee.refundTaxi.aboutYourTrip.title,

--- a/src/page-modules/contact/travel-guarantee/forms/refundTaxiForm.tsx
+++ b/src/page-modules/contact/travel-guarantee/forms/refundTaxiForm.tsx
@@ -35,7 +35,6 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
           {t(PageText.Contact.travelGuarantee.refundTaxi.taxiReceipt.info)}
         </Typo.p>
 
-        {/* TODO: Add a component for using camera in phone directly. */}
         <FileInput
           label={t(PageText.Contact.input.feedback.attachment)}
           name="attachments"

--- a/src/page-modules/contact/travel-guarantee/forms/refundTaxiForm.tsx
+++ b/src/page-modules/contact/travel-guarantee/forms/refundTaxiForm.tsx
@@ -35,7 +35,7 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
           {t(PageText.Contact.travelGuarantee.refundTaxi.taxiReceipt.info)}
         </Typo.p>
 
-        {/*Should here add a component for using camara in phone directly.*/}
+        {/* TODO: Add a component for using camera in phone directly. */}
         <FileInput
           label={t(PageText.Contact.input.feedback.attachment)}
           name="attachments"

--- a/src/page-modules/contact/travel-guarantee/travelGuaranteeFormMachine.ts
+++ b/src/page-modules/contact/travel-guarantee/travelGuaranteeFormMachine.ts
@@ -40,6 +40,7 @@ type submitInput = {
   fromAddress?: string;
   toAddress?: string;
   reasonForTransportFailureName?: string;
+  amount?: string;
 };
 
 export type ContextProps = {
@@ -66,6 +67,7 @@ export type ContextProps = {
   fromAddress?: string;
   toAddress?: string;
   reasonForTransportFailure?: ReasonForTransportFailure;
+  amount?: string;
 
   isIntialAgreementChecked: boolean;
   hasInternationalBankAccount: boolean;
@@ -118,6 +120,8 @@ const setInputToValidate = (context: ContextProps) => {
     toAddress,
     plannedDepartureTime,
     reasonForTransportFailure,
+    amount,
+    attachments,
   } = context;
 
   const commonFields = {
@@ -142,6 +146,8 @@ const setInputToValidate = (context: ContextProps) => {
     case FormType.RefundTaxi:
       return {
         ...commonFields,
+        attachments,
+        amount,
       };
 
     case FormType.RefundCar:
@@ -231,6 +237,7 @@ export const fetchMachine = setup({
           bankAccountNumber,
           IBAN,
           SWIFT,
+          amount,
         },
       }: {
         input: submitInput;
@@ -263,6 +270,7 @@ export const fetchMachine = setup({
             kilometersDriven: kilometersDriven,
             fromAddress: fromAddress,
             toAddress: toAddress,
+            amount: amount,
           }),
         }).then((response) => {
           // throw an error to force onError
@@ -340,6 +348,7 @@ export const fetchMachine = setup({
           bankAccountNumber: context?.bankAccountNumber,
           IBAN: context?.IBAN,
           SWIFT: context?.SWIFT,
+          amount: context?.amount,
         }),
 
         onDone: {

--- a/src/page-modules/contact/validation/commonInputValidator.ts
+++ b/src/page-modules/contact/validation/commonInputValidator.ts
@@ -174,6 +174,11 @@ export const commonInputValidator = (context: any) => {
       validCondition: context.amount,
       errorMessage: PageText.Contact.input.amount.errorMessages.empty,
     },
+    {
+      inputName: 'attachments',
+      validCondition: context.attachments,
+      errorMessage: PageText.Contact.components.fileinput.errorMessages.empty,
+    },
   ];
 
   // Iterate over each field and apply validation

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -257,11 +257,16 @@ export const Contact = {
         'If you are unable to reach your destination by an alternative service, we will refund taxi expenses according to the applicable regulations.',
         'Viss du ikkje kjem fram med eit anna rutetilbod, refunderer vi utlegg til drosje etter gjeldande reglar.',
       ),
-      information: {
+      taxiReceipt: {
         title: _(
           'Informasjon fra drosjekvitteringen',
           'Information from the taxi receipt',
           'Informasjon frå drosjekvitteringa',
+        ),
+        info: _(
+          'Last opp en kopi eller et bilde av kvitteringen fra drosjeturen. Kvitteringen må inneholde informasjon om hvor du reiste fra og til.',
+          'Upload a copy or a photo of the receipt from the taxi ride. The receipt must contain information about where you traveled from and to.',
+          'Last opp ein kopi eller eit bilde av kvitteringa frå drosjeturen. Kvitteringa må innehalde informasjon om kor du reiste frå og til.',
         ),
       },
 
@@ -1566,16 +1571,12 @@ export const Contact = {
     amount: {
       label: _('Beløp', 'Amount', 'Beløp'),
       info: _(
-        'Skriv inn beløpet du ønsker utbetalt, i norske kroner.',
-        'Enter the amount you want paid out, in Norwegian kroner.',
-        'Skriv inn beløpet du ønsker utbetalt, i norske kroner. ',
+        'Skriv inn beløpet du ønsker utbetalt i norske kroner.',
+        'Enter the amount you want paid out in Norwegian kroner.',
+        'Skriv inn beløpet du ønsker utbetalt i norske kroner. ',
       ),
       errorMessages: {
-        empty: _(
-          'Grunn for refusjon mangler',
-          'Reason for refund is missing',
-          'Grunn for refusjon mangler',
-        ),
+        empty: _('Beløp mangler', 'Amount is missing', 'Beløp mangler'),
       },
     },
   },


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/19327

This PR adds the missing section in the travel guarantee taxi refund form. A component for enable use of mobile camera to directly upload images is not included. This should be a separate PR.

<img width="1041" alt="Skjermbilde 2024-10-28 kl  10 04 18" src="https://github.com/user-attachments/assets/e23572df-91fd-4bb8-b1c3-cc4c8b46b079">
