### PR TITLE
fix: specify the correct sub transport modes for express boat

### DIFF
--- a/src/page-modules/contact/lines/use-lines.ts
+++ b/src/page-modules/contact/lines/use-lines.ts
@@ -11,10 +11,11 @@ export const useLines = () => {
   } = useSWR<Line[]>('/api/contact/lines', swrFetcher);
 
   const subTransportModesExpressboat = [
+    'highSpeedPassengerService',
     'highSpeedVehicleService',
-    'internationalCarFerry',
-    'localCarFerry',
-    'nationalCarFerry',
+    'sightseeingService',
+    'localPassengerFerry',
+    'internationalPassengerFerry',
   ];
 
   const subTransportModesFerry = [


### PR DESCRIPTION
This PR specifies the correct sub transport modes for express boat. 