### PR TITLE
feat: add link to travel guarantee page

### DIFF
--- a/src/page-modules/contact/travel-guarantee/index.tsx
+++ b/src/page-modules/contact/travel-guarantee/index.tsx
@@ -8,6 +8,7 @@ import RefundCarForm from './forms/refundCarForm';
 import style from '../contact.module.css';
 import { Typo } from '@atb/components/typography';
 import { SectionCard, Radio, Checkbox } from '../components';
+import Link from 'next/link';
 
 const TravelGuaranteeContent = () => {
   const { t } = useTranslation();
@@ -71,7 +72,18 @@ const TravelGuaranteeContent = () => {
           {t(
             PageText.Contact.travelGuarantee.agreement.travelGuaranteeExceptions
               .exclusion,
-          )}
+          )}{' '}
+          <Link
+            href={t(
+              PageText.Contact.travelGuarantee.agreement
+                .travelGuaranteeExceptions.link.href,
+            )}
+          >
+            {t(
+              PageText.Contact.travelGuarantee.agreement
+                .travelGuaranteeExceptions.link.text,
+            )}
+          </Link>
         </Typo.p>
 
         <Checkbox

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -238,9 +238,9 @@ export const Contact = {
           _('pandemi', 'pandemic', 'pandemi'),
         ],
         exclusion: _(
-          'Reisegarantien omfatter heller ikke tap som følge av forsinkelsen, som for eksempel mistet tannlegetime, jobbavtale, togavgang eller flyavgang.',
-          'The travel guarantee does not cover losses resulting from the delay, such as missed dental appointments, job agreements, train departures, or flight departures.',
-          'Reisegarantien omfattar heller ikkje tap som følge av forseinkinga, som for eksempel mista tannlegetime, jobbavtale, togavgang eller flyavgang.',
+          'Reisegarantien omfatter heller ikke tap som følge av forsinkelsen, som for eksempel mistet tannlegetime, jobbavtale, togavgang, fergeavgang eller flyavgang.',
+          'The travel guarantee does not cover losses resulting from the delay, such as missed dental appointments, job agreements, train departures, ferry departures or flight departures.',
+          'Reisegarantien omfattar heller ikkje tap som følge av forseinkinga, som for eksempel mista tannlegetime, jobbavtale, togavgang, ferjeavgang eller flyavgang.',
         ),
 
         link: {

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -242,6 +242,19 @@ export const Contact = {
           'The travel guarantee does not cover losses resulting from the delay, such as missed dental appointments, job agreements, train departures, or flight departures.',
           'Reisegarantien omfattar heller ikkje tap som følge av forseinkinga, som for eksempel mista tannlegetime, jobbavtale, togavgang eller flyavgang.',
         ),
+
+        link: {
+          text: _(
+            'Les mer om reisegranti',
+            'Read more about travel guarantee',
+            'Les meir om reisegaranti',
+          ),
+          href: _(
+            'https://frammr.no/hjelp-og-kontakt/reisegaranti/',
+            'https://frammr.no/hjelp-og-kontakt/reisegaranti/?sprak=3',
+            'https://frammr.no/hjelp-og-kontakt/reisegaranti/',
+          ),
+        },
         checkbox: _('Jeg forstår', 'I understand', 'Eg forstår'),
       },
     },


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/19326

This PR specifies that travel guarantee does not apply for ferries, and adds a link to the travel guarantee info page on frammr.no. 

<img width="1051" alt="Skjermbilde 2024-10-28 kl  10 33 52" src="https://github.com/user-attachments/assets/a67d4647-33af-46e1-9a27-2c56bcd2050d">
