### PR TITLE
feat: display contact page layout as dropdown in mobile view 

### DIFF
--- a/src/page-modules/contact/components/form/select.tsx
+++ b/src/page-modules/contact/components/form/select.tsx
@@ -5,7 +5,7 @@ import { Typo } from '@atb/components/typography';
 import style from './form.module.css';
 
 export type SelectProps<T> = {
-  label: string;
+  label?: string;
   onChange: (value?: T) => void;
   error?: string;
   value?: T;
@@ -39,9 +39,11 @@ export default function Select<T>({
 
   return (
     <div className={style.select}>
-      <label>
-        <Typo.span textType="body__primary">{label}</Typo.span>
-      </label>
+      {label && (
+        <label>
+          <Typo.span textType="body__primary">{label}</Typo.span>
+        </label>
+      )}
       <select
         id={`select-${id}`}
         onChange={(e) => onChangeInternal(e.target.value)}

--- a/src/page-modules/contact/layouts/contact-page-layout.tsx
+++ b/src/page-modules/contact/layouts/contact-page-layout.tsx
@@ -1,12 +1,14 @@
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, useEffect, useState } from 'react';
 import style from './layout.module.css';
 import { PageText, TranslatedString, useTranslation } from '@atb/translations';
 import { usePathname } from 'next/navigation';
+import { useRouter } from 'next/router';
 import Link from 'next/link';
 import { andIf } from '@atb/utils/css';
 import { Typo } from '@atb/components/typography';
 import { MonoIcon, MonoIcons } from '@atb/components/icon';
 import { ButtonLink } from '@atb/components/button';
+import { Select } from '../components';
 
 export type ContactPage = {
   title: TranslatedString;
@@ -56,6 +58,24 @@ export type ContactPageLayoutProps = PropsWithChildren<{
 function ContactPageLayout({ children }: ContactPageLayoutProps) {
   const { t } = useTranslation();
   const pathname = usePathname();
+  const router = useRouter();
+  const [selectedContactPage, setSelectedContactPage] = useState<
+    ContactPage | undefined
+  >(undefined);
+
+  useEffect(() => {
+    const activePage = contactPages.find((contactPage) =>
+      pathname.includes(contactPage.href),
+    );
+    setSelectedContactPage(activePage);
+  }, [pathname]);
+
+  const handleSelectChange = (contactPage?: ContactPage) => {
+    if (contactPage) {
+      setSelectedContactPage(contactPage);
+      router.push(contactPage.href);
+    }
+  };
 
   return (
     <div className={style.layout}>
@@ -64,14 +84,24 @@ function ContactPageLayout({ children }: ContactPageLayoutProps) {
           <ButtonLink
             mode="transparent"
             href="/"
-            title={t(PageText.Contact.homeLink)}
+            title={t(PageText.Contact.contactPageLayout.homeLink)}
             icon={{ left: <MonoIcon icon="navigation/ArrowLeft" /> }}
           />
         </div>
         <div className={style.layout__container}>
           <Typo.h2 textType="heading--jumbo">
-            {t(PageText.Contact.title)}
+            {t(PageText.Contact.contactPageLayout.title)}
           </Typo.h2>
+          <div className={style.contact_page_navigator__dropdown}>
+            <Select
+              options={contactPages}
+              value={selectedContactPage}
+              placeholder={t(PageText.Contact.contactPageLayout.placeholder)}
+              onChange={handleSelectChange}
+              valueToId={(contactPage) => contactPage.href}
+              valueToText={(contactPage) => t(contactPage.title)}
+            />
+          </div>
           <nav className={style.contact_page_navigator__container}>
             {contactPages.map((contactPage, index) => {
               const isActive = pathname.includes(contactPage.href);

--- a/src/page-modules/contact/layouts/contact-page-layout.tsx
+++ b/src/page-modules/contact/layouts/contact-page-layout.tsx
@@ -71,10 +71,7 @@ function ContactPageLayout({ children }: ContactPageLayoutProps) {
   }, [pathname]);
 
   const handleSelectChange = (contactPage?: ContactPage) => {
-    if (contactPage) {
-      setSelectedContactPage(contactPage);
-      router.push(contactPage.href);
-    }
+    if (contactPage) router.push(contactPage.href);
   };
 
   return (

--- a/src/page-modules/contact/layouts/layout.module.css
+++ b/src/page-modules/contact/layouts/layout.module.css
@@ -56,3 +56,17 @@
   border: var(--border-width-medium) solid
     var(--interactive-interactive_2-outline-background);
 }
+
+.contact_page_navigator__dropdown {
+  display: none;
+}
+
+@media (max-width: 600px) {
+  .contact_page_navigator__container {
+    display: none;
+  }
+
+  .contact_page_navigator__dropdown {
+    display: block;
+  }
+}

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -4,16 +4,20 @@ import { ReasonForTransportFailure } from '@atb/page-modules/contact/travel-guar
 import { translation as _ } from '@atb/translations/commons';
 
 export const Contact = {
-  title: _(
-    'Hva kan vi hjelpe deg med?',
-    'What can we help you with?',
-    'Kva kan vi hjelpe deg med?',
-  ),
-  homeLink: _(
-    'Tilbake til reisesøk',
-    'Back to travel search',
-    'Tilbake til reisesøk',
-  ),
+  contactPageLayout: {
+    title: _(
+      'Hva kan vi hjelpe deg med?',
+      'What can we help you with?',
+      'Kva kan vi hjelpe deg med?',
+    ),
+    homeLink: _(
+      'Tilbake til reisesøk',
+      'Back to travel search',
+      'Tilbake til reisesøk',
+    ),
+    placeholder: _('Velg et skjema', 'Select a form', 'Vel eit skjema'),
+  },
+
   ticketControl: {
     title: _(
       'Billettkontroll og gebyr',


### PR DESCRIPTION
### Backround
This PR extends the contact page layout to be displayed as a dropdown in mobile view. 

#### Illustrations
<details>
<summary>screenshots/video/figma</summary>




https://github.com/user-attachments/assets/4737592f-f5d1-44d0-8f28-62484ab0b07f


</details>