### PR TITLE
chore: minor styling update for searchable selector and select

### DIFF
--- a/src/page-modules/contact/components/form/form.module.css
+++ b/src/page-modules/contact/components/form/form.module.css
@@ -439,17 +439,33 @@
 .searchable_select__item {
   width: 100%;
   display: flex;
-  justify-content: flex-start;
+  justify-content: space-between;
   align-items: center;
   gap: var(--spacings-small);
   padding: var(--spacings-small);
+}
+
+.select__item:active,
+.searchable_select__item:active {
+  background-color: var(--interactive-interactive_3-active-background);
+  color: var(--interactive-interactive_3-active-text);
+  z-index: 2;
 }
 
 .select__highlight,
 .searchable_select__highlight {
   position: relative;
   border-radius: var(--border-radius-small);
-  background-color: var(--interactive-interactive_2-hover-background);
+  background-color: var(--interactive-interactive_2-active-background);
+  color: var(--interactive-interactive_2-active-text);
+  z-index: 2;
+}
+
+.searchable_select__selected {
+  position: relative;
+  border-radius: var(--border-radius-small);
+  background-color: var(--interactive-interactive_2-active-background);
+  color: var(--interactive-interactive_2-active-text);
   z-index: 2;
 }
 
@@ -480,16 +496,13 @@
 .select__placholder {
   font-style: italic;
   opacity: 0.7;
+  padding-right: var(--spacings-small);
 }
-
 @media (max-width: 600px) {
-  .select,
-  .select__label,
-  .select__placholder,
   .select__listBoxItem,
+  .select__select_container,
   .searchable_select__comboBox,
-  .searchable_select__listBoxItem,
-  .searchable_select__input:not(:focus):placeholder-shown {
+  .searchable_select__listBoxItem {
     font-size: 1.25rem;
   }
   .select__popover,

--- a/src/page-modules/contact/components/form/searchable-select/searchable-select.tsx
+++ b/src/page-modules/contact/components/form/searchable-select/searchable-select.tsx
@@ -113,12 +113,10 @@ export default function SearchableSelect<T>({
             className={style.searchable_select__listBoxItem}
           >
             <div className={style.searchable_select__item}>
-              <span>
-                {!value ? <MonoIcon icon={'actions/Confirm'} /> : '\u00A0'}
-              </span>
               <span className={style.searchable_select__truncate}>
                 {placeholder}
               </span>
+              <span>{!value && <MonoIcon icon={'actions/Confirm'} />}</span>
             </div>
           </ListBoxItem>
           {filteredOptions.map((item) => (
@@ -132,17 +130,15 @@ export default function SearchableSelect<T>({
                 <div
                   className={`${style.searchable_select__item} ${
                     isFocused ? style.searchable_select__highlight : ''
-                  }`}
+                  } ${isSelected && value ? style.searchable_select__selected : ''}`}
                 >
-                  <span>
-                    {value && isSelected ? (
-                      <MonoIcon icon={'actions/Confirm'} />
-                    ) : (
-                      '\u00A0'
-                    )}
-                  </span>
                   <span className={style.searchable_select__truncate}>
                     {item.name}
+                  </span>
+                  <span>
+                    {value && isSelected && (
+                      <MonoIcon icon={'actions/Confirm'} />
+                    )}
                   </span>
                 </div>
               )}

--- a/src/page-modules/contact/components/form/select.tsx
+++ b/src/page-modules/contact/components/form/select.tsx
@@ -47,64 +47,61 @@ export default function CustomeSelect<T>({
   };
 
   return (
-    <div className={style.select__select_container}>
+    <Select
+      id={`select-${id}`}
+      onSelectionChange={onChangeInternal}
+      isDisabled={disabled}
+      className={style.select__select_container}
+    >
       <Label>{label}</Label>
-      <Select
-        id={`select-${id}`}
-        onSelectionChange={onChangeInternal}
-        isDisabled={disabled}
-      >
-        <Button className={style.select__button}>
-          {value ? (
-            <span>{valueToText(value)}</span>
-          ) : (
-            <span className={style.select__placholder}>{placeholder}</span>
-          )}
-          <MonoIcon icon={'navigation/ExpandMore'} />
-        </Button>
-        <Popover className={style.select__popover}>
-          <ListBox className={style.select__listBox}>
+      <Button className={style.select__button}>
+        {value ? (
+          <span>{valueToText(value)}</span>
+        ) : (
+          <span className={style.select__placholder}>{placeholder}</span>
+        )}
+        <MonoIcon icon={'navigation/ExpandMore'} />
+      </Button>
+      <Popover className={style.select__popover}>
+        <ListBox className={style.select__listBox}>
+          <ListBoxItem
+            isDisabled
+            textValue={placeholder}
+            className={style.select__listBoxItem}
+          >
+            <div className={style.select__item}>
+              <span className={style.select__placholder}>{placeholder}</span>
+              {!value && <MonoIcon icon={'actions/Confirm'} />}
+            </div>
+          </ListBoxItem>
+          {options.map((option) => (
             <ListBoxItem
-              isDisabled
-              textValue={placeholder}
+              id={`${valueToId(option)}`}
+              key={`key-option-${valueToId(option)}`}
+              textValue={valueToText(option)}
               className={style.select__listBoxItem}
             >
-              <div className={style.select__item}>
-                <span>
-                  {!value ? <MonoIcon icon={'actions/Confirm'} /> : '\u00A0'}
-                </span>
-                <span>{placeholder}</span>
-              </div>
+              {({ isSelected, isFocused }) => (
+                <div
+                  className={`${style.select__item} ${
+                    isFocused ? style.select__highlight : ''
+                  }`}
+                >
+                  <span>{valueToText(option)}</span>
+                  <span>
+                    {value && isSelected ? (
+                      <MonoIcon icon={'actions/Confirm'} />
+                    ) : (
+                      '\u00A0'
+                    )}
+                  </span>
+                </div>
+              )}
             </ListBoxItem>
-            {options.map((option) => (
-              <ListBoxItem
-                id={`${valueToId(option)}`}
-                key={`key-option-${valueToId(option)}`}
-                textValue={valueToText(option)}
-                className={style.select__listBoxItem}
-              >
-                {({ isSelected, isFocused }) => (
-                  <div
-                    className={`${style.select__item} ${
-                      isFocused ? style.select__highlight : ''
-                    }`}
-                  >
-                    <span>
-                      {value && isSelected ? (
-                        <MonoIcon icon={'actions/Confirm'} />
-                      ) : (
-                        '\u00A0'
-                      )}
-                    </span>
-                    <span>{valueToText(option)}</span>
-                  </div>
-                )}
-              </ListBoxItem>
-            ))}
-          </ListBox>
-        </Popover>
-      </Select>
+          ))}
+        </ListBox>
+      </Popover>
       {showError && <ErrorMessage message={error} />}
-    </div>
+    </Select>
   );
 }


### PR DESCRIPTION
Minor changes to the css styling of `Select` and `SearchableSelect`. The PR includes the following changes:

- Checkmark is moved to the right side of the selector option text.
- Bg-color for highlighted option is changes to  `var(--interactive-interactive_2-active-background)`, same as used in `webshop2`.
- Added :active to highlight active options for user in both `Select` and `SearchableSelect`.  


I also considered doing more changes to make the selectors more similar the combobox in `webshop2`, but decided not to because the combobox in my opinion takes  up a bit too much space in the mobile view. Feel free to give feedback on this.

<img width="984" alt="Skjermbilde 2024-10-31 kl  14 02 39" src="https://github.com/user-attachments/assets/0ac63f3a-5ca6-4826-bbce-cf086e67098c">
<img width="984" alt="Skjermbilde 2024-10-31 kl  14 02 51" src="https://github.com/user-attachments/assets/cc4e517d-1ac7-4c6b-9e65-81425d149cce">
<img width="453" alt="Skjermbilde 2024-10-31 kl  14 03 46" src="https://github.com/user-attachments/assets/0f5b2bb5-805f-486e-b146-7f6d68d0b648">
