### PR TITLE
feat: custom date selector component 

### DIFF
--- a/src/page-modules/contact/components/form/date-selector.tsx
+++ b/src/page-modules/contact/components/form/date-selector.tsx
@@ -1,0 +1,86 @@
+import style from './form.module.css';
+import { MonoIcon } from '@atb/components/icon';
+import { TranslatedString, useTranslation } from '@atb/translations';
+import { fromDate, parseDate } from '@internationalized/date';
+import {
+  Button,
+  Calendar,
+  CalendarCell,
+  CalendarGrid,
+  DateInput,
+  DatePicker,
+  DateSegment,
+  Dialog,
+  Group,
+  Heading,
+  Label,
+  Popover,
+} from 'react-aria-components';
+
+export type DateSelectorProps = {
+  label: TranslatedString;
+  value?: string;
+  min: string;
+  onChange: (value: string) => void;
+};
+
+export default function DateSelector({
+  label,
+  value,
+  onChange,
+  min,
+}: DateSelectorProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className={style.dateSelectorContainer}>
+      <Label>{t(label)}</Label>
+      <DatePicker
+        granularity="day"
+        value={fromDate(new Date(value || ''), 'Europe/Oslo')}
+        onChange={(e) => onChange(e.toString().slice(0, 10))}
+        minValue={parseDate(min)}
+        className={style.dateSelector}
+        shouldForceLeadingZeros
+      >
+        <Group className={style.calendarSelectorGroup}>
+          <DateInput className={style.dateSelectorInput}>
+            {(segment) => <DateSegment segment={segment} />}
+          </DateInput>
+          <Button className={style.calendarButton}>
+            <MonoIcon icon="time/Date" />
+          </Button>
+        </Group>
+        <Popover className={style.calendarDialog} placement="bottom right">
+          <Dialog>
+            <Calendar>
+              <header className={style.calendarDialog__header}>
+                <Button
+                  slot="previous"
+                  className={style.calendarDialog__headerButtons}
+                >
+                  <MonoIcon icon="navigation/ArrowLeft" />
+                </Button>
+                <Heading className={style.calendarDialog__title} />
+                <Button
+                  slot="next"
+                  className={style.calendarDialog__headerButtons}
+                >
+                  <MonoIcon icon="navigation/ArrowRight" />
+                </Button>
+              </header>
+              <CalendarGrid className={style.calendarGrid}>
+                {(date) => (
+                  <CalendarCell
+                    date={date}
+                    className={style.calendarGrid__cell}
+                  />
+                )}
+              </CalendarGrid>
+            </Calendar>
+          </Dialog>
+        </Popover>
+      </DatePicker>
+    </div>
+  );
+}

--- a/src/page-modules/contact/components/form/date-selector.tsx
+++ b/src/page-modules/contact/components/form/date-selector.tsx
@@ -20,7 +20,6 @@ import {
 export type DateSelectorProps = {
   label: TranslatedString;
   value?: string;
-  min: string;
   onChange: (value: string) => void;
 };
 
@@ -28,7 +27,6 @@ export default function DateSelector({
   label,
   value,
   onChange,
-  min,
 }: DateSelectorProps) {
   const { t } = useTranslation();
 
@@ -39,7 +37,6 @@ export default function DateSelector({
         granularity="day"
         value={fromDate(new Date(value || ''), 'Europe/Oslo')}
         onChange={(e) => onChange(e.toString().slice(0, 10))}
-        minValue={parseDate(min)}
         className={style.dateSelector}
         shouldForceLeadingZeros
       >

--- a/src/page-modules/contact/components/form/form.module.css
+++ b/src/page-modules/contact/components/form/form.module.css
@@ -498,11 +498,14 @@
   opacity: 0.7;
   padding-right: var(--spacings-small);
 }
+
 @media (max-width: 600px) {
+  .select,
+  .select__placholder,
   .select__listBoxItem,
-  .select__select_container,
   .searchable_select__comboBox,
-  .searchable_select__listBoxItem {
+  .searchable_select__listBoxItem,
+  .searchable_select__input:not(:focus):placeholder-shown {
     font-size: 1.25rem;
   }
   .select__popover,
@@ -510,4 +513,128 @@
     overflow-y: auto;
     box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.3);
   }
+}
+
+/* Time and date selector */
+.dateSelectorContainer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacings-small);
+  font-size: 1rem !important;
+}
+
+.dateSelector,
+.timeSelector {
+  --height: 2.75rem;
+  border-radius: var(--border-radius-small);
+  overflow: hidden;
+}
+
+.dateSelector input[type='date'],
+.timeSelector input[type='time'] {
+  height: var(--height);
+  padding: var(--spacings-medium);
+  border: none;
+  background-color: transparent;
+  color: var(--static-background-background_0-text);
+  flex: 1;
+}
+
+.calendarSelectorGroup {
+  display: flex;
+  position: relative;
+  width: 100%;
+}
+
+.calendarButton {
+  position: absolute;
+  right: 0;
+  border: none;
+  cursor: pointer;
+  background: none;
+  margin: var(--spacings-medium);
+  border-radius: var(--border-radius-small);
+}
+
+.calendarDialog {
+  padding: var(--spacings-xSmall);
+  background: var(--static-background-background_0-background);
+  box-shadow: 0.2rem 0.2rem 0.3rem rgba(0, 0, 0, 0.15);
+}
+
+.calendarDialog__header {
+  display: flex;
+  gap: var(--spacings-medium);
+  justify-content: center;
+  align-items: center;
+  padding: var(--spacings-small);
+}
+
+.calendarDialog__title {
+  composes: typo-heading__component from '@atb/theme/typography.module.css';
+}
+
+.calendarDialog__headerButtons {
+  background: none;
+  border: none;
+  padding: var(--spacings-xSmall) var(--spacings-medium);
+  cursor: pointer;
+}
+
+.calendarGrid {
+  width: 100%;
+}
+
+.calendarGrid__cell {
+  padding: var(--spacings-xSmall) var(--spacings-medium);
+  cursor: pointer;
+  text-align: center;
+}
+
+.calendarGrid__cell[data-disabled] {
+  opacity: 0.3;
+  cursor: default;
+}
+
+.calendarGrid__cell[data-selected] {
+  background-color: var(--interactive-interactive_2-active-background);
+  color: var(--interactive-interactive_2-active-text);
+  font-weight: bold;
+  border-radius: var(--border-radius-small);
+}
+
+.dateSelectorInput,
+.timeSelectorInput {
+  height: var(--height);
+  padding: var(--spacings-medium);
+  color: var(--static-background-background_0-text);
+  border-top-right-radius: 0.75rem;
+  border-bottom-right-radius: 0.75rem;
+  display: flex;
+  border: var(--border-width-slim) solid var(--text-colors-primary);
+  width: 100%;
+  border-radius: var(--border-radius-small);
+
+  border: var(--border-width-slim) solid var(--text-colors-primary);
+  align-items: center;
+}
+
+.dateSelector input[type='date']:focus,
+.timeSelector input[type='time']:focus {
+  outline: 0;
+}
+
+.dateSelector:focus-within,
+.timeSelector:focus-within {
+  box-shadow: inset 0 0 0 var(--border-width-medium)
+    var(--interactive-interactive_2-outline-background);
+}
+
+:global(.dark)
+  .dateSelector
+  input[type='date']::-webkit-calendar-picker-indicator,
+:global(.dark)
+  .timeSelector
+  input[type='time']::-webkit-calendar-picker-indicator {
+  filter: invert(1);
 }

--- a/src/page-modules/contact/components/form/form.module.css
+++ b/src/page-modules/contact/components/form/form.module.css
@@ -589,6 +589,7 @@
   padding: var(--spacings-xSmall) var(--spacings-medium);
   cursor: pointer;
   text-align: center;
+  border-radius: var(--border-radius-small);
 }
 
 .calendarGrid__cell[data-disabled] {
@@ -613,7 +614,6 @@
   display: flex;
   border: var(--border-width-slim) solid var(--text-colors-primary);
   width: 100%;
-  border-radius: var(--border-radius-small);
 
   border: var(--border-width-slim) solid var(--text-colors-primary);
   align-items: center;

--- a/src/page-modules/contact/components/form/index.ts
+++ b/src/page-modules/contact/components/form/index.ts
@@ -6,6 +6,7 @@ export { default as Input } from './input';
 export { default as Radio } from './radio';
 export { default as Select } from './select';
 export { default as Textarea } from './textarea';
+export { default as DateSelector } from './date-selector';
 export {
   SearchableSelect,
   getLineOptions,

--- a/src/page-modules/contact/components/index.tsx
+++ b/src/page-modules/contact/components/index.tsx
@@ -10,5 +10,6 @@ export {
   SearchableSelect,
   getLineOptions,
   getStopOptions,
+  DateSelector,
 } from './form';
 export { SectionCard } from './section-card';

--- a/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
@@ -5,6 +5,7 @@ import { TransportModeType } from '../../types';
 import { Line } from '../..';
 import { ContextProps } from '../means-of-transport-form-machine';
 import { meansOfTransportFormEvents } from '../events';
+import { format, subDays } from 'date-fns';
 import {
   SectionCard,
   Select,
@@ -14,6 +15,7 @@ import {
   SearchableSelect,
   getLineOptions,
   getStopOptions,
+  DateSelector,
 } from '../../components';
 
 type DelayFormProps = {
@@ -24,6 +26,7 @@ type DelayFormProps = {
 export const DelayForm = ({ state, send }: DelayFormProps) => {
   const { t } = useTranslation();
   const { getLinesByMode, getQuaysByLine } = useLines();
+  const yesterday = format(subDays(new Date(), 1), 'yyyy-MM-dd');
 
   return (
     <div>
@@ -128,17 +131,15 @@ export const DelayForm = ({ state, send }: DelayFormProps) => {
           }
         />
 
-        <Input
+        <DateSelector
           label={PageText.Contact.input.date.label}
-          type="date"
-          name="date"
+          min={yesterday}
           value={state.context.date}
-          errorMessage={state.context?.errorMessages['date']?.[0]}
-          onChange={(e) =>
+          onChange={(date) =>
             send({
               type: 'ON_INPUT_CHANGE',
               inputName: 'date',
-              value: e.target.value,
+              value: date,
             })
           }
         />

--- a/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
@@ -5,7 +5,6 @@ import { TransportModeType } from '../../types';
 import { Line } from '../..';
 import { ContextProps } from '../means-of-transport-form-machine';
 import { meansOfTransportFormEvents } from '../events';
-import { format, subDays } from 'date-fns';
 import {
   SectionCard,
   Select,
@@ -26,7 +25,6 @@ type DelayFormProps = {
 export const DelayForm = ({ state, send }: DelayFormProps) => {
   const { t } = useTranslation();
   const { getLinesByMode, getQuaysByLine } = useLines();
-  const yesterday = format(subDays(new Date(), 1), 'yyyy-MM-dd');
 
   return (
     <div>
@@ -133,7 +131,6 @@ export const DelayForm = ({ state, send }: DelayFormProps) => {
 
         <DateSelector
           label={PageText.Contact.input.date.label}
-          min={yesterday}
           value={state.context.date}
           onChange={(date) =>
             send({

--- a/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
@@ -5,7 +5,6 @@ import { Typo } from '@atb/components/typography';
 import { TransportModeType } from '../../types';
 import { Line } from '../..';
 import { meansOfTransportFormEvents } from '../events';
-import { format, subDays } from 'date-fns';
 import {
   SectionCard,
   Select,
@@ -26,7 +25,6 @@ type DriverFormProps = {
 export const DriverForm = ({ state, send }: DriverFormProps) => {
   const { t } = useTranslation();
   const { getLinesByMode, getQuaysByLine } = useLines();
-  const yesterday = format(subDays(new Date(), 1), 'yyyy-MM-dd');
 
   return (
     <div>
@@ -155,7 +153,6 @@ export const DriverForm = ({ state, send }: DriverFormProps) => {
 
         <DateSelector
           label={PageText.Contact.input.date.label}
-          min={yesterday}
           value={state.context.date}
           onChange={(date) =>
             send({

--- a/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
@@ -5,6 +5,7 @@ import { Typo } from '@atb/components/typography';
 import { TransportModeType } from '../../types';
 import { Line } from '../..';
 import { meansOfTransportFormEvents } from '../events';
+import { format, subDays } from 'date-fns';
 import {
   SectionCard,
   Select,
@@ -14,6 +15,7 @@ import {
   SearchableSelect,
   getLineOptions,
   getStopOptions,
+  DateSelector,
 } from '../../components';
 
 type DriverFormProps = {
@@ -24,6 +26,7 @@ type DriverFormProps = {
 export const DriverForm = ({ state, send }: DriverFormProps) => {
   const { t } = useTranslation();
   const { getLinesByMode, getQuaysByLine } = useLines();
+  const yesterday = format(subDays(new Date(), 1), 'yyyy-MM-dd');
 
   return (
     <div>
@@ -150,17 +153,15 @@ export const DriverForm = ({ state, send }: DriverFormProps) => {
           }
         />
 
-        <Input
+        <DateSelector
           label={PageText.Contact.input.date.label}
-          type="date"
-          name="date"
+          min={yesterday}
           value={state.context.date}
-          errorMessage={state.context?.errorMessages['date']?.[0]}
-          onChange={(e) =>
+          onChange={(date) =>
             send({
               type: 'ON_INPUT_CHANGE',
               inputName: 'date',
-              value: e.target.value,
+              value: date,
             })
           }
         />

--- a/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
@@ -5,6 +5,7 @@ import { Typo } from '@atb/components/typography';
 import { TransportModeType } from '../../types';
 import { Line } from '../..';
 import { meansOfTransportFormEvents } from '../events';
+import { format, subDays } from 'date-fns';
 import {
   SectionCard,
   Select,
@@ -14,6 +15,7 @@ import {
   SearchableSelect,
   getLineOptions,
   getStopOptions,
+  DateSelector,
 } from '../../components';
 
 type InjuryFormProps = {
@@ -24,6 +26,7 @@ type InjuryFormProps = {
 export const InjuryForm = ({ state, send }: InjuryFormProps) => {
   const { t } = useTranslation();
   const { getLinesByMode, getQuaysByLine } = useLines();
+  const yesterday = format(subDays(new Date(), 1), 'yyyy-MM-dd');
 
   return (
     <div>
@@ -149,17 +152,15 @@ export const InjuryForm = ({ state, send }: InjuryFormProps) => {
           }
         />
 
-        <Input
+        <DateSelector
           label={PageText.Contact.input.date.label}
-          type="date"
-          name="date"
+          min={yesterday}
           value={state.context.date}
-          errorMessage={state.context?.errorMessages['date']?.[0]}
-          onChange={(e) =>
+          onChange={(date) =>
             send({
               type: 'ON_INPUT_CHANGE',
               inputName: 'date',
-              value: e.target.value,
+              value: date,
             })
           }
         />

--- a/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
@@ -5,7 +5,6 @@ import { Typo } from '@atb/components/typography';
 import { TransportModeType } from '../../types';
 import { Line } from '../..';
 import { meansOfTransportFormEvents } from '../events';
-import { format, subDays } from 'date-fns';
 import {
   SectionCard,
   Select,
@@ -26,7 +25,6 @@ type InjuryFormProps = {
 export const InjuryForm = ({ state, send }: InjuryFormProps) => {
   const { t } = useTranslation();
   const { getLinesByMode, getQuaysByLine } = useLines();
-  const yesterday = format(subDays(new Date(), 1), 'yyyy-MM-dd');
 
   return (
     <div>
@@ -154,7 +152,6 @@ export const InjuryForm = ({ state, send }: InjuryFormProps) => {
 
         <DateSelector
           label={PageText.Contact.input.date.label}
-          min={yesterday}
           value={state.context.date}
           onChange={(date) =>
             send({

--- a/src/page-modules/contact/means-of-transport/forms/stopForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/stopForm.tsx
@@ -5,6 +5,7 @@ import { Typo } from '@atb/components/typography';
 import { TransportModeType } from '../../types';
 import { Line } from '../..';
 import { meansOfTransportFormEvents } from '../events';
+import { format, subDays } from 'date-fns';
 import {
   SectionCard,
   Select,
@@ -14,6 +15,7 @@ import {
   SearchableSelect,
   getLineOptions,
   getStopOptions,
+  DateSelector,
 } from '../../components';
 
 type StopFormProps = {
@@ -24,6 +26,7 @@ type StopFormProps = {
 export const StopForm = ({ state, send }: StopFormProps) => {
   const { t } = useTranslation();
   const { getLinesByMode, getQuaysByLine } = useLines();
+  const yesterday = format(subDays(new Date(), 1), 'yyyy-MM-dd');
 
   return (
     <div>
@@ -104,17 +107,15 @@ export const StopForm = ({ state, send }: StopFormProps) => {
           }
         />
 
-        <Input
+        <DateSelector
           label={PageText.Contact.input.date.label}
-          type="date"
-          name="date"
+          min={yesterday}
           value={state.context.date}
-          errorMessage={state.context?.errorMessages['date']?.[0]}
-          onChange={(e) =>
+          onChange={(date) =>
             send({
               type: 'ON_INPUT_CHANGE',
               inputName: 'date',
-              value: e.target.value,
+              value: date,
             })
           }
         />

--- a/src/page-modules/contact/means-of-transport/forms/stopForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/stopForm.tsx
@@ -5,7 +5,6 @@ import { Typo } from '@atb/components/typography';
 import { TransportModeType } from '../../types';
 import { Line } from '../..';
 import { meansOfTransportFormEvents } from '../events';
-import { format, subDays } from 'date-fns';
 import {
   SectionCard,
   Select,
@@ -26,7 +25,6 @@ type StopFormProps = {
 export const StopForm = ({ state, send }: StopFormProps) => {
   const { t } = useTranslation();
   const { getLinesByMode, getQuaysByLine } = useLines();
-  const yesterday = format(subDays(new Date(), 1), 'yyyy-MM-dd');
 
   return (
     <div>
@@ -109,7 +107,6 @@ export const StopForm = ({ state, send }: StopFormProps) => {
 
         <DateSelector
           label={PageText.Contact.input.date.label}
-          min={yesterday}
           value={state.context.date}
           onChange={(date) =>
             send({

--- a/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
@@ -5,7 +5,6 @@ import { Typo } from '@atb/components/typography';
 import { TransportModeType } from '../../types';
 import { Line } from '../..';
 import { meansOfTransportFormEvents } from '../events';
-import { format, subDays } from 'date-fns';
 import {
   SectionCard,
   Select,
@@ -30,7 +29,6 @@ export const TransportationForm = ({
 }: TransportationFormProps) => {
   const { t } = useTranslation();
   const { getLinesByMode, getQuaysByLine } = useLines();
-  const yesterday = format(subDays(new Date(), 1), 'yyyy-MM-dd');
 
   return (
     <div>
@@ -137,7 +135,6 @@ export const TransportationForm = ({
 
         <DateSelector
           label={PageText.Contact.input.date.label}
-          min={yesterday}
           value={state.context.date}
           onChange={(date) =>
             send({

--- a/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
@@ -5,6 +5,7 @@ import { Typo } from '@atb/components/typography';
 import { TransportModeType } from '../../types';
 import { Line } from '../..';
 import { meansOfTransportFormEvents } from '../events';
+import { format, subDays } from 'date-fns';
 import {
   SectionCard,
   Select,
@@ -15,6 +16,7 @@ import {
   SearchableSelect,
   getLineOptions,
   getStopOptions,
+  DateSelector,
 } from '../../components';
 
 type TransportationFormProps = {
@@ -28,6 +30,7 @@ export const TransportationForm = ({
 }: TransportationFormProps) => {
   const { t } = useTranslation();
   const { getLinesByMode, getQuaysByLine } = useLines();
+  const yesterday = format(subDays(new Date(), 1), 'yyyy-MM-dd');
 
   return (
     <div>
@@ -132,17 +135,15 @@ export const TransportationForm = ({
           }
         />
 
-        <Input
+        <DateSelector
           label={PageText.Contact.input.date.label}
-          type="date"
-          name="date"
+          min={yesterday}
           value={state.context.date}
-          errorMessage={state.context?.errorMessages['date']?.[0]}
-          onChange={(e) =>
+          onChange={(date) =>
             send({
               type: 'ON_INPUT_CHANGE',
               inputName: 'date',
-              value: e.target.value,
+              value: date,
             })
           }
         />

--- a/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
@@ -5,6 +5,7 @@ import { ticketControlFormEvents } from '../events';
 import { ContextProps } from '../ticket-control-form-machine';
 import { TransportModeType } from '../../types';
 import { useLines } from '../../lines/use-lines';
+import { format, subDays } from 'date-fns';
 import {
   SectionCard,
   Input,
@@ -14,6 +15,7 @@ import {
   SearchableSelect,
   getLineOptions,
   getStopOptions,
+  DateSelector,
 } from '../../components';
 
 type FeedbackFormProps = {
@@ -24,6 +26,7 @@ type FeedbackFormProps = {
 export const FeedbackForm = ({ state, send }: FeedbackFormProps) => {
   const { t } = useTranslation();
   const { getLinesByMode, getQuaysByLine } = useLines();
+  const yesterday = format(subDays(new Date(), 1), 'yyyy-MM-dd');
 
   return (
     <div>
@@ -118,20 +121,19 @@ export const FeedbackForm = ({ state, send }: FeedbackFormProps) => {
           }
         />
 
-        <Input
+        <DateSelector
           label={PageText.Contact.input.date.label}
-          type="date"
-          name="date"
+          min={yesterday}
           value={state.context.date}
-          errorMessage={state.context?.errorMessages['date']?.[0]}
-          onChange={(e) =>
+          onChange={(date) =>
             send({
               type: 'ON_INPUT_CHANGE',
               inputName: 'date',
-              value: e.target.value,
+              value: date,
             })
           }
         />
+
         <Input
           label={PageText.Contact.input.plannedDepartureTime.label}
           type="time"

--- a/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
@@ -5,7 +5,6 @@ import { ticketControlFormEvents } from '../events';
 import { ContextProps } from '../ticket-control-form-machine';
 import { TransportModeType } from '../../types';
 import { useLines } from '../../lines/use-lines';
-import { format, subDays } from 'date-fns';
 import {
   SectionCard,
   Input,
@@ -26,7 +25,6 @@ type FeedbackFormProps = {
 export const FeedbackForm = ({ state, send }: FeedbackFormProps) => {
   const { t } = useTranslation();
   const { getLinesByMode, getQuaysByLine } = useLines();
-  const yesterday = format(subDays(new Date(), 1), 'yyyy-MM-dd');
 
   return (
     <div>
@@ -123,7 +121,6 @@ export const FeedbackForm = ({ state, send }: FeedbackFormProps) => {
 
         <DateSelector
           label={PageText.Contact.input.date.label}
-          min={yesterday}
           value={state.context.date}
           onChange={(date) =>
             send({

--- a/src/page-modules/contact/travel-guarantee/forms/refundCarForm.tsx
+++ b/src/page-modules/contact/travel-guarantee/forms/refundCarForm.tsx
@@ -4,6 +4,7 @@ import { TransportModeType } from '../../types';
 import { Line } from '../..';
 import { TravelGuaranteeFormEvents } from '../events';
 import { ContextProps } from '../travelGuaranteeFormMachine';
+import { format, subDays } from 'date-fns';
 import {
   SectionCard,
   Input,
@@ -14,6 +15,7 @@ import {
   SearchableSelect,
   getLineOptions,
   getStopOptions,
+  DateSelector,
 } from '../../components';
 
 type RefundCarFormProps = {
@@ -24,6 +26,7 @@ type RefundCarFormProps = {
 export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
   const { t } = useTranslation();
   const { getLinesByMode, getQuaysByLine } = useLines();
+  const yesterday = format(subDays(new Date(), 1), 'yyyy-MM-dd');
 
   return (
     <div>
@@ -170,20 +173,19 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
           }
         />
 
-        <Input
+        <DateSelector
           label={PageText.Contact.input.date.label}
-          type="date"
-          name="date"
+          min={yesterday}
           value={state.context.date}
-          errorMessage={state.context?.errorMessages['date']?.[0]}
-          onChange={(e) =>
+          onChange={(date) =>
             send({
               type: 'ON_INPUT_CHANGE',
               inputName: 'date',
-              value: e.target.value,
+              value: date,
             })
           }
         />
+
         <Input
           label={PageText.Contact.input.plannedDepartureTime.label}
           type="time"

--- a/src/page-modules/contact/travel-guarantee/forms/refundCarForm.tsx
+++ b/src/page-modules/contact/travel-guarantee/forms/refundCarForm.tsx
@@ -4,7 +4,6 @@ import { TransportModeType } from '../../types';
 import { Line } from '../..';
 import { TravelGuaranteeFormEvents } from '../events';
 import { ContextProps } from '../travelGuaranteeFormMachine';
-import { format, subDays } from 'date-fns';
 import {
   SectionCard,
   Input,
@@ -26,7 +25,6 @@ type RefundCarFormProps = {
 export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
   const { t } = useTranslation();
   const { getLinesByMode, getQuaysByLine } = useLines();
-  const yesterday = format(subDays(new Date(), 1), 'yyyy-MM-dd');
 
   return (
     <div>
@@ -175,7 +173,6 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
 
         <DateSelector
           label={PageText.Contact.input.date.label}
-          min={yesterday}
           value={state.context.date}
           onChange={(date) =>
             send({

--- a/src/page-modules/contact/travel-guarantee/forms/refundTaxiForm.tsx
+++ b/src/page-modules/contact/travel-guarantee/forms/refundTaxiForm.tsx
@@ -5,6 +5,7 @@ import { Line } from '../..';
 import { TravelGuaranteeFormEvents } from '../events';
 import { ContextProps } from '../travelGuaranteeFormMachine';
 import { Typo } from '@atb/components/typography';
+import { format, subDays } from 'date-fns';
 import {
   SectionCard,
   Input,
@@ -15,6 +16,7 @@ import {
   SearchableSelect,
   getLineOptions,
   getStopOptions,
+  DateSelector,
 } from '../../components';
 
 type RefundTaxiFormProps = {
@@ -25,6 +27,7 @@ type RefundTaxiFormProps = {
 export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
   const { t } = useTranslation();
   const { getLinesByMode, getQuaysByLine } = useLines();
+  const yesterday = format(subDays(new Date(), 1), 'yyyy-MM-dd');
 
   return (
     <div>
@@ -156,20 +159,19 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
           }
         />
 
-        <Input
+        <DateSelector
           label={PageText.Contact.input.date.label}
-          type="date"
-          name="date"
+          min={yesterday}
           value={state.context.date}
-          errorMessage={state.context?.errorMessages['date']?.[0]}
-          onChange={(e) =>
+          onChange={(date) =>
             send({
               type: 'ON_INPUT_CHANGE',
               inputName: 'date',
-              value: e.target.value,
+              value: date,
             })
           }
         />
+
         <Input
           label={PageText.Contact.input.plannedDepartureTime.label}
           type="time"

--- a/src/page-modules/contact/travel-guarantee/forms/refundTaxiForm.tsx
+++ b/src/page-modules/contact/travel-guarantee/forms/refundTaxiForm.tsx
@@ -5,7 +5,6 @@ import { Line } from '../..';
 import { TravelGuaranteeFormEvents } from '../events';
 import { ContextProps } from '../travelGuaranteeFormMachine';
 import { Typo } from '@atb/components/typography';
-import { format, subDays } from 'date-fns';
 import {
   SectionCard,
   Input,
@@ -27,7 +26,6 @@ type RefundTaxiFormProps = {
 export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
   const { t } = useTranslation();
   const { getLinesByMode, getQuaysByLine } = useLines();
-  const yesterday = format(subDays(new Date(), 1), 'yyyy-MM-dd');
 
   return (
     <div>
@@ -161,7 +159,6 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
 
         <DateSelector
           label={PageText.Contact.input.date.label}
-          min={yesterday}
           value={state.context.date}
           onChange={(date) =>
             send({


### PR DESCRIPTION
### Background
Currently, the date format displayed on the contact page depends on the date format the users browsers is set to. It is desirable to always displayed the date as dd.mm.yyyy - format. 

#### Illustrations
In FireFox:

<details>
<summary>Before</summary>
<img width="956" alt="Skjermbilde 2024-11-05 kl  11 01 59" src="https://github.com/user-attachments/assets/ebe4c4ee-32e2-432d-b49d-bd59e6a199b1">
</details>

<details>
<summary>After</summary>
<img width="951" alt="Skjermbilde 2024-11-05 kl  11 02 06" src="https://github.com/user-attachments/assets/d079fa66-7c18-4483-a5ad-14ac8fdd73a4">

</details>

### Proposed solution

Use  a custom date picker component to always display the correct date format.