### PR TITLE
feat: custom time selector component 

### DIFF
--- a/src/page-modules/contact/components/form/form.module.css
+++ b/src/page-modules/contact/components/form/form.module.css
@@ -606,17 +606,14 @@
 
 .dateSelectorInput,
 .timeSelectorInput {
+  width: 100%;
   height: var(--height);
+  display: flex;
+  align-items: center;
   padding: var(--spacings-medium);
   color: var(--static-background-background_0-text);
-  border-top-right-radius: 0.75rem;
-  border-bottom-right-radius: 0.75rem;
-  display: flex;
+  border-radius: var(--border-radius-small);
   border: var(--border-width-slim) solid var(--text-colors-primary);
-  width: 100%;
-
-  border: var(--border-width-slim) solid var(--text-colors-primary);
-  align-items: center;
 }
 
 .dateSelector input[type='date']:focus,

--- a/src/page-modules/contact/components/form/form.module.css
+++ b/src/page-modules/contact/components/form/form.module.css
@@ -500,18 +500,18 @@
 }
 
 /* Time and date selector */
-.dateSelectorContainer {
+.dateSelectorContainer,
+.timeSelectorContainer {
   display: flex;
   flex-direction: column;
   gap: var(--spacings-small);
-  font-size: 1rem !important;
 }
 
 .dateSelector,
 .timeSelector {
   --height: 2.75rem;
-  border-radius: var(--border-radius-small);
   overflow: hidden;
+  border-radius: var(--border-radius-small);
 }
 
 .dateSelector input[type='date'],

--- a/src/page-modules/contact/components/form/form.module.css
+++ b/src/page-modules/contact/components/form/form.module.css
@@ -499,22 +499,6 @@
   padding-right: var(--spacings-small);
 }
 
-@media (max-width: 600px) {
-  .select,
-  .select__placholder,
-  .select__listBoxItem,
-  .searchable_select__comboBox,
-  .searchable_select__listBoxItem,
-  .searchable_select__input:not(:focus):placeholder-shown {
-    font-size: 1.25rem;
-  }
-  .select__popover,
-  .searchable_select__popover {
-    overflow-y: auto;
-    box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.3);
-  }
-}
-
 /* Time and date selector */
 .dateSelectorContainer {
   display: flex;

--- a/src/page-modules/contact/components/form/index.ts
+++ b/src/page-modules/contact/components/form/index.ts
@@ -7,6 +7,7 @@ export { default as Radio } from './radio';
 export { default as Select } from './select';
 export { default as Textarea } from './textarea';
 export { default as DateSelector } from './date-selector';
+export { default as TimeSelector } from './time-selector';
 export {
   SearchableSelect,
   getLineOptions,

--- a/src/page-modules/contact/components/form/time-selector.tsx
+++ b/src/page-modules/contact/components/form/time-selector.tsx
@@ -22,7 +22,7 @@ export default function TimeSelector({
   const parsedValue = parseTime(value);
 
   return (
-    <div className={style.time_field_container}>
+    <div className={style.timeSelectorContainer}>
       <Label>{t(label)}</Label>
       <TimeField
         value={parsedValue}

--- a/src/page-modules/contact/components/form/time-selector.tsx
+++ b/src/page-modules/contact/components/form/time-selector.tsx
@@ -1,0 +1,47 @@
+import style from './form.module.css';
+import { TranslatedString, useTranslation } from '@atb/translations';
+import { parseTime } from '@internationalized/date';
+import {
+  DateInput,
+  DateSegment,
+  Label,
+  TimeField,
+} from 'react-aria-components';
+
+export type TimeSelectorProps = {
+  label: TranslatedString;
+  value: string;
+  onChange: (value: string) => void;
+};
+export default function TimeSelector({
+  label,
+  value,
+  onChange,
+}: TimeSelectorProps) {
+  const { t } = useTranslation();
+  const parsedValue = parseTime(value);
+
+  return (
+    <div className={style.time_field_container}>
+      <Label>{t(label)}</Label>
+      <TimeField
+        value={parsedValue}
+        onChange={(change) => onChange(change.toString())}
+        hourCycle={24}
+        shouldForceLeadingZeros
+        className={style.timeSelector}
+        data-testid="searchTimeSelector-time"
+        granularity="minute"
+      >
+        <DateInput className={style.timeSelectorInput}>
+          {(segment) => (
+            <DateSegment
+              className={style.timeSelectorSegment}
+              segment={segment}
+            />
+          )}
+        </DateInput>
+      </TimeField>
+    </div>
+  );
+}

--- a/src/page-modules/contact/components/index.tsx
+++ b/src/page-modules/contact/components/index.tsx
@@ -11,5 +11,6 @@ export {
   getLineOptions,
   getStopOptions,
   DateSelector,
+  TimeSelector,
 } from './form';
 export { SectionCard } from './section-card';

--- a/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
@@ -15,6 +15,7 @@ import {
   getLineOptions,
   getStopOptions,
   DateSelector,
+  TimeSelector,
 } from '../../components';
 
 type DelayFormProps = {
@@ -141,19 +142,14 @@ export const DelayForm = ({ state, send }: DelayFormProps) => {
           }
         />
 
-        <Input
+        <TimeSelector
           label={PageText.Contact.input.plannedDepartureTime.label}
-          type="time"
-          name="time"
-          value={state.context.plannedDepartureTime}
-          errorMessage={
-            state.context?.errorMessages['plannedDepartureTime']?.[0]
-          }
-          onChange={(e) =>
+          value={state.context.plannedDepartureTime || ''}
+          onChange={(time: string) =>
             send({
               type: 'ON_INPUT_CHANGE',
               inputName: 'plannedDepartureTime',
-              value: e.target.value,
+              value: time,
             })
           }
         />

--- a/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
@@ -15,6 +15,7 @@ import {
   getLineOptions,
   getStopOptions,
   DateSelector,
+  TimeSelector,
 } from '../../components';
 
 type DriverFormProps = {
@@ -163,19 +164,14 @@ export const DriverForm = ({ state, send }: DriverFormProps) => {
           }
         />
 
-        <Input
+        <TimeSelector
           label={PageText.Contact.input.plannedDepartureTime.label}
-          type="time"
-          name="time"
-          value={state.context.plannedDepartureTime}
-          errorMessage={
-            state.context?.errorMessages['plannedDepartureTime']?.[0]
-          }
-          onChange={(e) =>
+          value={state.context.plannedDepartureTime || ''}
+          onChange={(time: string) =>
             send({
               type: 'ON_INPUT_CHANGE',
               inputName: 'plannedDepartureTime',
-              value: e.target.value,
+              value: time,
             })
           }
         />

--- a/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
@@ -15,6 +15,7 @@ import {
   getLineOptions,
   getStopOptions,
   DateSelector,
+  TimeSelector,
 } from '../../components';
 
 type InjuryFormProps = {
@@ -162,19 +163,14 @@ export const InjuryForm = ({ state, send }: InjuryFormProps) => {
           }
         />
 
-        <Input
+        <TimeSelector
           label={PageText.Contact.input.plannedDepartureTime.label}
-          type="time"
-          name="time"
-          value={state.context.plannedDepartureTime}
-          errorMessage={
-            state.context?.errorMessages['plannedDepartureTime']?.[0]
-          }
-          onChange={(e) =>
+          value={state.context.plannedDepartureTime || ''}
+          onChange={(time: string) =>
             send({
               type: 'ON_INPUT_CHANGE',
               inputName: 'plannedDepartureTime',
-              value: e.target.value,
+              value: time,
             })
           }
         />

--- a/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
@@ -16,6 +16,7 @@ import {
   getLineOptions,
   getStopOptions,
   DateSelector,
+  TimeSelector,
 } from '../../components';
 
 type TransportationFormProps = {
@@ -145,19 +146,14 @@ export const TransportationForm = ({
           }
         />
 
-        <Input
+        <TimeSelector
           label={PageText.Contact.input.plannedDepartureTime.label}
-          type="time"
-          name="time"
-          value={state.context.plannedDepartureTime}
-          errorMessage={
-            state.context?.errorMessages['plannedDepartureTime']?.[0]
-          }
-          onChange={(e) =>
+          value={state.context.plannedDepartureTime || ''}
+          onChange={(time: string) =>
             send({
               type: 'ON_INPUT_CHANGE',
               inputName: 'plannedDepartureTime',
-              value: e.target.value,
+              value: time,
             })
           }
         />

--- a/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
@@ -15,6 +15,7 @@ import {
   getLineOptions,
   getStopOptions,
   DateSelector,
+  TimeSelector,
 } from '../../components';
 
 type FeedbackFormProps = {
@@ -131,19 +132,14 @@ export const FeedbackForm = ({ state, send }: FeedbackFormProps) => {
           }
         />
 
-        <Input
+        <TimeSelector
           label={PageText.Contact.input.plannedDepartureTime.label}
-          type="time"
-          name="time"
-          value={state.context.plannedDepartureTime}
-          errorMessage={
-            state.context?.errorMessages['plannedDepartureTime']?.[0]
-          }
-          onChange={(e) =>
+          value={state.context.plannedDepartureTime || ''}
+          onChange={(time: string) =>
             send({
               type: 'ON_INPUT_CHANGE',
               inputName: 'plannedDepartureTime',
-              value: e.target.value,
+              value: time,
             })
           }
         />

--- a/src/page-modules/contact/travel-guarantee/forms/refundCarForm.tsx
+++ b/src/page-modules/contact/travel-guarantee/forms/refundCarForm.tsx
@@ -15,6 +15,7 @@ import {
   getLineOptions,
   getStopOptions,
   DateSelector,
+  TimeSelector,
 } from '../../components';
 
 type RefundCarFormProps = {
@@ -182,20 +183,14 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
             })
           }
         />
-
-        <Input
+        <TimeSelector
           label={PageText.Contact.input.plannedDepartureTime.label}
-          type="time"
-          name="time"
-          value={state.context.plannedDepartureTime}
-          errorMessage={
-            state.context?.errorMessages['plannedDepartureTime']?.[0]
-          }
-          onChange={(e) =>
+          value={state.context.plannedDepartureTime || ''}
+          onChange={(time: string) =>
             send({
               type: 'ON_INPUT_CHANGE',
               inputName: 'plannedDepartureTime',
-              value: e.target.value,
+              value: time,
             })
           }
         />

--- a/src/page-modules/contact/travel-guarantee/forms/refundTaxiForm.tsx
+++ b/src/page-modules/contact/travel-guarantee/forms/refundTaxiForm.tsx
@@ -16,6 +16,7 @@ import {
   getLineOptions,
   getStopOptions,
   DateSelector,
+  TimeSelector,
 } from '../../components';
 
 type RefundTaxiFormProps = {
@@ -169,19 +170,14 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
           }
         />
 
-        <Input
+        <TimeSelector
           label={PageText.Contact.input.plannedDepartureTime.label}
-          type="time"
-          name="time"
-          value={state.context.plannedDepartureTime}
-          errorMessage={
-            state.context?.errorMessages['plannedDepartureTime']?.[0]
-          }
-          onChange={(e) =>
+          value={state.context.plannedDepartureTime || ''}
+          onChange={(time: string) =>
             send({
               type: 'ON_INPUT_CHANGE',
               inputName: 'plannedDepartureTime',
-              value: e.target.value,
+              value: time,
             })
           }
         />


### PR DESCRIPTION
### Background
Currently, the time format displayed on the contact page depends on the time format the users browsers is set to. This means that both the 12 hours (AM/PM time format) and 24 hours (military time format) can be displayed. It is desirable to always displayed the time in 24 hour format.  


Corresponding styling of component is already defined in this PR: https://github.com/AtB-AS/planner-web/pull/417

#### Illustrations
In FireFox:

<details>
<summary>Before</summary>

| Before    | After |
| -------- | ------- |
|<img width="368" alt="Skjermbilde 2024-11-07 kl  09 40 05" src="https://github.com/user-attachments/assets/a472b9d2-c57e-4dd0-b6b3-267209f71148"> | <img width="368" alt="Skjermbilde 2024-11-07 kl  09 39 34" src="https://github.com/user-attachments/assets/6e25f20a-d682-4864-b2c1-95f9952b4e62"> |
| <img width="996" alt="Skjermbilde 2024-11-07 kl  09 40 25" src="https://github.com/user-attachments/assets/907ba93c-41b9-40fb-83cb-3df6d829b22a"> | <img width="996" alt="Skjermbilde 2024-11-07 kl  09 41 00" src="https://github.com/user-attachments/assets/b82bc684-5058-4734-8cb9-653b7015b17b">|
</details>



### Proposed solution

Use  a custom time selector component to always display the correct date format.