### PR TITLE
feat: extend description mode with list and instruction properties

### DIFF
--- a/src/page-modules/contact/components/form/description-modal.tsx
+++ b/src/page-modules/contact/components/form/description-modal.tsx
@@ -5,12 +5,13 @@ import { FocusScope } from '@react-aria/focus';
 import { MonoIcon } from '@atb/components/icon';
 import { useEffect, useRef } from 'react';
 import { Button } from '@atb/components/button';
-import { PageText, useTranslation } from '@atb/translations';
+import { PageText, TranslatedString, useTranslation } from '@atb/translations';
 
 type DescriptionModalProps = {
   title: string;
   modalDescription?: string;
   modalInstruction?: string;
+  modalBulletPoints?: TranslatedString[];
   isModalOpen: boolean;
   closeModal: () => void;
 };
@@ -19,6 +20,7 @@ const DescriptionModal = ({
   title,
   modalDescription,
   modalInstruction,
+  modalBulletPoints,
   isModalOpen,
   closeModal,
 }: DescriptionModalProps) => {
@@ -86,8 +88,25 @@ const DescriptionModal = ({
                 }}
               />
             </div>
+
             {modalDescription && (
               <Typo.p textType="body__primary">{modalDescription}</Typo.p>
+            )}
+
+            {modalBulletPoints && (
+              <ul className={style.modal__rules_list}>
+                {modalBulletPoints.map((desc, index) => (
+                  <li key={index}>
+                    <Typo.p textType="body__primary" key={index}>
+                      {t(desc)}
+                    </Typo.p>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            {modalInstruction && (
+              <Typo.p textType="body__primary--bold">{modalInstruction}</Typo.p>
             )}
           </dialog>
         </motion.div>

--- a/src/page-modules/contact/components/form/description-modal.tsx
+++ b/src/page-modules/contact/components/form/description-modal.tsx
@@ -9,23 +9,24 @@ import { PageText, TranslatedString, useTranslation } from '@atb/translations';
 
 type DescriptionModalProps = {
   title: string;
-  modalDescription?: string;
-  modalInstruction?: string;
-  modalBulletPoints?: TranslatedString[];
+  modalContent: {
+    description?: string;
+    instruction?: string;
+    bulletPoints?: TranslatedString[];
+  };
   isModalOpen: boolean;
   closeModal: () => void;
 };
 
 const DescriptionModal = ({
   title,
-  modalDescription,
-  modalInstruction,
-  modalBulletPoints,
+  modalContent,
   isModalOpen,
   closeModal,
 }: DescriptionModalProps) => {
   const { t } = useTranslation();
   const modalRef = useRef<HTMLDivElement | null>(null);
+  const { description, instruction, bulletPoints } = modalContent;
 
   const handleEscapeOrClickOutside = (event: KeyboardEvent | MouseEvent) => {
     if (event instanceof KeyboardEvent && event.key === 'Escape') {
@@ -89,13 +90,13 @@ const DescriptionModal = ({
               />
             </div>
 
-            {modalDescription && (
-              <Typo.p textType="body__primary">{modalDescription}</Typo.p>
+            {description && (
+              <Typo.p textType="body__primary">{description}</Typo.p>
             )}
 
-            {modalBulletPoints && (
+            {bulletPoints && (
               <ul className={style.modal__rules_list}>
-                {modalBulletPoints.map((desc, index) => (
+                {bulletPoints.map((desc, index) => (
                   <li key={index}>
                     <Typo.p textType="body__primary" key={index}>
                       {t(desc)}
@@ -105,8 +106,8 @@ const DescriptionModal = ({
               </ul>
             )}
 
-            {modalInstruction && (
-              <Typo.p textType="body__primary--bold">{modalInstruction}</Typo.p>
+            {instruction && (
+              <Typo.p textType="body__primary--bold">{instruction}</Typo.p>
             )}
           </dialog>
         </motion.div>

--- a/src/page-modules/contact/components/form/description-modal.tsx
+++ b/src/page-modules/contact/components/form/description-modal.tsx
@@ -5,14 +5,14 @@ import { FocusScope } from '@react-aria/focus';
 import { MonoIcon } from '@atb/components/icon';
 import { useEffect, useRef } from 'react';
 import { Button } from '@atb/components/button';
-import { PageText, TranslatedString, useTranslation } from '@atb/translations';
+import { PageText, useTranslation } from '@atb/translations';
 
 type DescriptionModalProps = {
   title: string;
   modalContent: {
     description?: string;
     instruction?: string;
-    bulletPoints?: TranslatedString[];
+    bulletPoints?: string[];
   };
   isModalOpen: boolean;
   closeModal: () => void;
@@ -99,7 +99,7 @@ const DescriptionModal = ({
                 {bulletPoints.map((desc, index) => (
                   <li key={index}>
                     <Typo.p textType="body__primary" key={index}>
-                      {t(desc)}
+                      {desc}
                     </Typo.p>
                   </li>
                 ))}

--- a/src/page-modules/contact/components/form/description-modal.tsx
+++ b/src/page-modules/contact/components/form/description-modal.tsx
@@ -9,14 +9,16 @@ import { PageText, useTranslation } from '@atb/translations';
 
 type DescriptionModalProps = {
   title: string;
-  description: string;
+  modalDescription?: string;
+  modalInstruction?: string;
   isModalOpen: boolean;
   closeModal: () => void;
 };
 
 const DescriptionModal = ({
   title,
-  description,
+  modalDescription,
+  modalInstruction,
   isModalOpen,
   closeModal,
 }: DescriptionModalProps) => {
@@ -84,7 +86,9 @@ const DescriptionModal = ({
                 }}
               />
             </div>
-            <Typo.p textType="body__primary">{description}</Typo.p>
+            {modalDescription && (
+              <Typo.p textType="body__primary">{modalDescription}</Typo.p>
+            )}
           </dialog>
         </motion.div>
       </FocusScope>

--- a/src/page-modules/contact/components/form/form.module.css
+++ b/src/page-modules/contact/components/form/form.module.css
@@ -309,9 +309,10 @@
 }
 
 .modal_content {
+  position: relative;
   display: flex;
   flex-direction: column;
-  max-width: 22.5rem;
+  max-width: 32rem;
   padding: var(--spacings-large);
   border: var(--border-width-medium) solid
     var(--interactive-interactive_2-outline-background); /* Use border property */
@@ -320,16 +321,23 @@
   color: var(--static-background-background_0-text);
   background-color: var(--static-background-background_0-background);
   border-radius: var(--border-radius-regular);
-  position: relative;
 }
 
 .modal_content > * + * {
-  margin-top: var(--spacings-large);
+  margin-top: var(--spacings-small);
 }
-
-.modal_header {
+* .modal_header {
   display: flex;
   justify-content: space-between;
+}
+
+.modal__rules_list {
+  padding: var(--spacings-medium);
+  padding-left: var(--spacings-xLarge);
+}
+
+.modal__rules_list > li {
+  padding: var(--spacings-xSmall) 0;
 }
 
 /* select and searchable-select*/

--- a/src/page-modules/contact/components/form/form.module.css
+++ b/src/page-modules/contact/components/form/form.module.css
@@ -326,7 +326,8 @@
 .modal_content > * + * {
   margin-top: var(--spacings-small);
 }
-* .modal_header {
+
+.modal_header {
   display: flex;
   justify-content: space-between;
 }

--- a/src/page-modules/contact/components/form/index.ts
+++ b/src/page-modules/contact/components/form/index.ts
@@ -1,5 +1,4 @@
 export { default as Checkbox } from './checkbox';
-export { default as DescriptionModal } from './description-modal';
 export { default as ErrorMessage } from './error-message';
 export { default as FileInput } from './file-input';
 export { default as Input } from './input';

--- a/src/page-modules/contact/components/form/input.tsx
+++ b/src/page-modules/contact/components/form/input.tsx
@@ -4,14 +4,15 @@ import { PageText, TranslatedString, useTranslation } from '@atb/translations';
 import { andIf } from '@atb/utils/css';
 import { Typo } from '@atb/components/typography';
 import ErrorMessage from './error-message';
-import DescriptionModal from './description-modal';
 import { MonoIcon } from '@atb/components/icon';
 import { Button } from '@atb/components/button';
+import { DescriptionModal } from '.';
 
 type InputProps = {
   label: TranslatedString;
   modalDescription?: string;
   modalInstruction?: string;
+  modalBulletPoints?: TranslatedString[];
   errorMessage?: TranslatedString;
   onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
 } & JSX.IntrinsicElements['input'];
@@ -25,11 +26,15 @@ export const Input = ({
   value,
   modalDescription,
   modalInstruction,
+  modalBulletPoints,
   onChange,
 }: InputProps) => {
   const { t } = useTranslation();
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const displayDescriptionModalIconButton =
     modalDescription || modalBulletPoints || modalInstruction;
+  const displayDescriptionModal =
+    displayDescriptionModalIconButton && isModalOpen; // Condition to avoid rendering of useEffect inside DescriptionModal before opened.
 
   const toggleModalState = () => {
     setIsModalOpen(!isModalOpen);
@@ -47,7 +52,7 @@ export const Input = ({
           <Typo.span textType="body__primary">{t(label)}</Typo.span>
         </label>
 
-        {description && (
+        {displayDescriptionModalIconButton && (
           <Button
             className={style.iconButton}
             onClick={toggleModalState}
@@ -78,6 +83,7 @@ export const Input = ({
           title={t(label)}
           modalDescription={modalDescription}
           modalBulletPoints={modalBulletPoints}
+          modalInstruction={modalInstruction}
           isModalOpen={isModalOpen}
           closeModal={toggleModalState}
         />

--- a/src/page-modules/contact/components/form/input.tsx
+++ b/src/page-modules/contact/components/form/input.tsx
@@ -10,7 +10,8 @@ import { Button } from '@atb/components/button';
 
 type InputProps = {
   label: TranslatedString;
-  description?: string;
+  modalDescription?: string;
+  modalInstruction?: string;
   errorMessage?: TranslatedString;
   onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
 } & JSX.IntrinsicElements['input'];
@@ -22,12 +23,13 @@ export const Input = ({
   name,
   checked,
   value,
-  description,
+  modalDescription,
+  modalInstruction,
   onChange,
 }: InputProps) => {
   const { t } = useTranslation();
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const displayDescriptionModal = description && isModalOpen; // Condition to avoid rendering of useEffect inside DescriptionModal before opened.
+    modalDescription || modalBulletPoints || modalInstruction;
 
   const toggleModalState = () => {
     setIsModalOpen(!isModalOpen);
@@ -74,7 +76,8 @@ export const Input = ({
       {displayDescriptionModal && (
         <DescriptionModal
           title={t(label)}
-          description={description}
+          modalDescription={modalDescription}
+          modalBulletPoints={modalBulletPoints}
           isModalOpen={isModalOpen}
           closeModal={toggleModalState}
         />

--- a/src/page-modules/contact/components/form/input.tsx
+++ b/src/page-modules/contact/components/form/input.tsx
@@ -13,7 +13,7 @@ type InputProps = {
   modalContent?: {
     description?: string;
     instruction?: string;
-    bulletPoints?: TranslatedString[];
+    bulletPoints?: string[];
   };
   errorMessage?: TranslatedString;
   onChange?: (event: ChangeEvent<HTMLInputElement>) => void;

--- a/src/page-modules/contact/components/form/input.tsx
+++ b/src/page-modules/contact/components/form/input.tsx
@@ -10,9 +10,11 @@ import { DescriptionModal } from '.';
 
 type InputProps = {
   label: TranslatedString;
-  modalDescription?: string;
-  modalInstruction?: string;
-  modalBulletPoints?: TranslatedString[];
+  modalContent?: {
+    description?: string;
+    instruction?: string;
+    bulletPoints?: TranslatedString[];
+  };
   errorMessage?: TranslatedString;
   onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
 } & JSX.IntrinsicElements['input'];
@@ -24,17 +26,12 @@ export const Input = ({
   name,
   checked,
   value,
-  modalDescription,
-  modalInstruction,
-  modalBulletPoints,
+  modalContent,
   onChange,
 }: InputProps) => {
   const { t } = useTranslation();
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const displayDescriptionModalIconButton =
-    modalDescription || modalBulletPoints || modalInstruction;
-  const displayDescriptionModal =
-    displayDescriptionModalIconButton && isModalOpen; // Condition to avoid rendering of useEffect inside DescriptionModal before opened.
+  const displayDescriptionModal = modalContent && isModalOpen; // Condition to avoid rendering of useEffect inside DescriptionModal before opened.
 
   const toggleModalState = () => {
     setIsModalOpen(!isModalOpen);
@@ -52,7 +49,7 @@ export const Input = ({
           <Typo.span textType="body__primary">{t(label)}</Typo.span>
         </label>
 
-        {displayDescriptionModalIconButton && (
+        {modalContent && (
           <Button
             className={style.iconButton}
             onClick={toggleModalState}
@@ -81,9 +78,7 @@ export const Input = ({
       {displayDescriptionModal && (
         <DescriptionModal
           title={t(label)}
-          modalDescription={modalDescription}
-          modalBulletPoints={modalBulletPoints}
-          modalInstruction={modalInstruction}
+          modalContent={modalContent}
           isModalOpen={isModalOpen}
           closeModal={toggleModalState}
         />

--- a/src/page-modules/contact/components/form/input.tsx
+++ b/src/page-modules/contact/components/form/input.tsx
@@ -6,7 +6,7 @@ import { Typo } from '@atb/components/typography';
 import ErrorMessage from './error-message';
 import { MonoIcon } from '@atb/components/icon';
 import { Button } from '@atb/components/button';
-import { DescriptionModal } from '.';
+import DescriptionModal from './description-modal';
 
 type InputProps = {
   label: TranslatedString;

--- a/src/page-modules/contact/components/form/input.tsx
+++ b/src/page-modules/contact/components/form/input.tsx
@@ -31,8 +31,8 @@ export const Input = ({
 }: InputProps) => {
   const { t } = useTranslation();
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const displayDescriptionModal = modalContent && isModalOpen; // Condition to avoid rendering of useEffect inside DescriptionModal before opened.
-
+  const isModalContentProvided = hasModalContent(modalContent);
+  const displayDescriptionModal = isModalOpen && isModalContentProvided;
   const toggleModalState = () => {
     setIsModalOpen(!isModalOpen);
   };
@@ -49,7 +49,7 @@ export const Input = ({
           <Typo.span textType="body__primary">{t(label)}</Typo.span>
         </label>
 
-        {modalContent && (
+        {isModalContentProvided && (
           <Button
             className={style.iconButton}
             onClick={toggleModalState}
@@ -78,7 +78,7 @@ export const Input = ({
       {displayDescriptionModal && (
         <DescriptionModal
           title={t(label)}
-          modalContent={modalContent}
+          modalContent={modalContent || {}}
           isModalOpen={isModalOpen}
           closeModal={toggleModalState}
         />
@@ -88,3 +88,16 @@ export const Input = ({
 };
 
 export default Input;
+
+function hasModalContent(content?: {
+  description?: string;
+  instruction?: string;
+  bulletPoints?: string[];
+}): boolean {
+  return !!(
+    content &&
+    (content.description ||
+      content.instruction ||
+      (content.bulletPoints && content.bulletPoints?.length > 0))
+  );
+}

--- a/src/page-modules/contact/components/index.tsx
+++ b/src/page-modules/contact/components/index.tsx
@@ -1,6 +1,5 @@
 export {
   Checkbox,
-  DescriptionModal,
   ErrorMessage,
   FileInput,
   Input,

--- a/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
@@ -116,7 +116,6 @@ const FormContent = ({ state, send }: FormProps) => {
           type="text"
           name="feeNumber"
           value={state.context.feeNumber || ''}
-          modalDescription={t(PageText.Contact.input.feeNumber.description)}
           errorMessage={state.context?.errorMessages['feeNumber']?.[0]}
           onChange={(e) =>
             send({
@@ -125,6 +124,9 @@ const FormContent = ({ state, send }: FormProps) => {
               value: e.target.value,
             })
           }
+          modalContent={{
+            description: t(PageText.Contact.input.feeNumber.description),
+          }}
         />
 
         <Typo.h3 textType="heading__component">

--- a/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
@@ -116,7 +116,7 @@ const FormContent = ({ state, send }: FormProps) => {
           type="text"
           name="feeNumber"
           value={state.context.feeNumber || ''}
-          description={t(PageText.Contact.input.feeNumber.description)}
+          modalDescription={t(PageText.Contact.input.feeNumber.description)}
           errorMessage={state.context?.errorMessages['feeNumber']?.[0]}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/ticket-control/forms/postponePayment.tsx
+++ b/src/page-modules/contact/ticket-control/forms/postponePayment.tsx
@@ -29,7 +29,6 @@ export const PostponePaymentForm = ({
           type="text"
           name="feeNumber"
           value={state.context.feeNumber || ''}
-          modalDescription={t(PageText.Contact.input.feeNumber.description)}
           errorMessage={state.context?.errorMessages['feeNumber']?.[0]}
           onChange={(e) =>
             send({
@@ -38,6 +37,9 @@ export const PostponePaymentForm = ({
               value: e.target.value,
             })
           }
+          modalContent={{
+            description: t(PageText.Contact.input.feeNumber.description),
+          }}
         />
 
         <Input
@@ -45,7 +47,6 @@ export const PostponePaymentForm = ({
           type="text"
           name="invoiceNumber"
           value={state.context.invoiceNumber || ''}
-          modalDescription={t(PageText.Contact.input.invoiceNumber.description)}
           errorMessage={state.context?.errorMessages['invoiceNumber']?.[0]}
           onChange={(e) =>
             send({
@@ -54,6 +55,9 @@ export const PostponePaymentForm = ({
               value: e.target.value,
             })
           }
+          modalContent={{
+            description: t(PageText.Contact.input.invoiceNumber.description),
+          }}
         />
       </SectionCard>
       <SectionCard title={t(PageText.Contact.aboutYouInfo.title)}>

--- a/src/page-modules/contact/ticket-control/forms/postponePayment.tsx
+++ b/src/page-modules/contact/ticket-control/forms/postponePayment.tsx
@@ -29,7 +29,7 @@ export const PostponePaymentForm = ({
           type="text"
           name="feeNumber"
           value={state.context.feeNumber || ''}
-          description={t(PageText.Contact.input.feeNumber.description)}
+          modalDescription={t(PageText.Contact.input.feeNumber.description)}
           errorMessage={state.context?.errorMessages['feeNumber']?.[0]}
           onChange={(e) =>
             send({
@@ -45,7 +45,7 @@ export const PostponePaymentForm = ({
           type="text"
           name="invoiceNumber"
           value={state.context.invoiceNumber || ''}
-          description={t(PageText.Contact.input.invoiceNumber.description)}
+          modalDescription={t(PageText.Contact.input.invoiceNumber.description)}
           errorMessage={state.context?.errorMessages['invoiceNumber']?.[0]}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/ticketing/forms/app/appAccountForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/app/appAccountForm.tsx
@@ -50,9 +50,6 @@ export const AppAccountForm = ({ state, send }: AppAccountFormProps) => {
           label={PageText.Contact.input.customerNumber.label}
           type="text"
           name="customerNumber"
-          modalDescription={t(
-            PageText.Contact.input.customerNumber.description,
-          )}
           value={state.context.customerNumber || ''}
           errorMessage={state.context?.errorMessages['customerNumber']?.[0]}
           onChange={(e) =>
@@ -62,6 +59,9 @@ export const AppAccountForm = ({ state, send }: AppAccountFormProps) => {
               value: e.target.value,
             })
           }
+          modalContent={{
+            description: t(PageText.Contact.input.customerNumber.description),
+          }}
         />
         <Input
           label={PageText.Contact.input.firstName.label}

--- a/src/page-modules/contact/ticketing/forms/app/appAccountForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/app/appAccountForm.tsx
@@ -50,7 +50,9 @@ export const AppAccountForm = ({ state, send }: AppAccountFormProps) => {
           label={PageText.Contact.input.customerNumber.label}
           type="text"
           name="customerNumber"
-          description={t(PageText.Contact.input.customerNumber.description)}
+          modalDescription={t(
+            PageText.Contact.input.customerNumber.description,
+          )}
           value={state.context.customerNumber || ''}
           errorMessage={state.context?.errorMessages['customerNumber']?.[0]}
           onChange={(e) =>

--- a/src/page-modules/contact/ticketing/forms/app/appTicketingForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/app/appTicketingForm.tsx
@@ -19,7 +19,8 @@ export const AppTicketingForm = ({ state, send }: AppTicketingFormProps) => {
           label={PageText.Contact.input.orderId.label(false)}
           type="text"
           name="orderId"
-          description={t(PageText.Contact.input.orderId.description(false))}
+          modalDescription={t(PageText.Contact.input.orderId.description)}
+          modalBulletPoints={
           value={state.context.orderId || ''}
           errorMessage={state.context?.errorMessages['orderId']?.[0]}
           onChange={(e) =>
@@ -67,7 +68,9 @@ export const AppTicketingForm = ({ state, send }: AppTicketingFormProps) => {
           label={PageText.Contact.input.customerNumber.labelOptional}
           type="text"
           name="customerNumber"
-          description={t(PageText.Contact.input.customerNumber.description)}
+          modalDescription={t(
+            PageText.Contact.input.customerNumber.description,
+          )}
           value={state.context.customerNumber || ''}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/ticketing/forms/app/appTicketingForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/app/appTicketingForm.tsx
@@ -21,6 +21,9 @@ export const AppTicketingForm = ({ state, send }: AppTicketingFormProps) => {
           name="orderId"
           modalDescription={t(PageText.Contact.input.orderId.description)}
           modalBulletPoints={
+            PageText.Contact.input.orderId.descriptionBulletPoints
+          }
+          modalInstruction={t(PageText.Contact.input.orderId.instruction)}
           value={state.context.orderId || ''}
           errorMessage={state.context?.errorMessages['orderId']?.[0]}
           onChange={(e) =>

--- a/src/page-modules/contact/ticketing/forms/app/appTicketingForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/app/appTicketingForm.tsx
@@ -32,7 +32,9 @@ export const AppTicketingForm = ({ state, send }: AppTicketingFormProps) => {
             description: t(PageText.Contact.input.orderId.description),
             instruction: t(PageText.Contact.input.orderId.instruction),
             bulletPoints:
-              PageText.Contact.input.orderId.descriptionBulletPoints,
+              PageText.Contact.input.orderId.descriptionBulletPoints.map(
+                (bulletpoint) => t(bulletpoint),
+              ),
           }}
         />
       </SectionCard>

--- a/src/page-modules/contact/ticketing/forms/app/appTicketingForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/app/appTicketingForm.tsx
@@ -19,11 +19,6 @@ export const AppTicketingForm = ({ state, send }: AppTicketingFormProps) => {
           label={PageText.Contact.input.orderId.label(false)}
           type="text"
           name="orderId"
-          modalDescription={t(PageText.Contact.input.orderId.description)}
-          modalBulletPoints={
-            PageText.Contact.input.orderId.descriptionBulletPoints
-          }
-          modalInstruction={t(PageText.Contact.input.orderId.instruction)}
           value={state.context.orderId || ''}
           errorMessage={state.context?.errorMessages['orderId']?.[0]}
           onChange={(e) =>
@@ -33,6 +28,12 @@ export const AppTicketingForm = ({ state, send }: AppTicketingFormProps) => {
               value: e.target.value,
             })
           }
+          modalContent={{
+            description: t(PageText.Contact.input.orderId.description),
+            instruction: t(PageText.Contact.input.orderId.instruction),
+            bulletPoints:
+              PageText.Contact.input.orderId.descriptionBulletPoints,
+          }}
         />
       </SectionCard>
       <SectionCard title={t(PageText.Contact.input.question.title)}>
@@ -71,9 +72,6 @@ export const AppTicketingForm = ({ state, send }: AppTicketingFormProps) => {
           label={PageText.Contact.input.customerNumber.labelOptional}
           type="text"
           name="customerNumber"
-          modalDescription={t(
-            PageText.Contact.input.customerNumber.description,
-          )}
           value={state.context.customerNumber || ''}
           onChange={(e) =>
             send({
@@ -82,6 +80,9 @@ export const AppTicketingForm = ({ state, send }: AppTicketingFormProps) => {
               value: e.target.value,
             })
           }
+          modalContent={{
+            description: t(PageText.Contact.input.customerNumber.description),
+          }}
         />
         <Input
           label={PageText.Contact.input.firstName.label}

--- a/src/page-modules/contact/ticketing/forms/refund/appTicketRefund.tsx
+++ b/src/page-modules/contact/ticketing/forms/refund/appTicketRefund.tsx
@@ -19,7 +19,6 @@ export const AppTicketRefund = ({ state, send }: AppTicketRefundProps) => {
         label={PageText.Contact.input.customerNumber.label}
         type="text"
         name="customerNumber"
-        modalDescription={t(PageText.Contact.input.customerNumber.description)}
         value={state.context.customerNumber || ''}
         errorMessage={state.context?.errorMessages['customerNumber']?.[0]}
         onChange={(e) =>
@@ -29,16 +28,15 @@ export const AppTicketRefund = ({ state, send }: AppTicketRefundProps) => {
             value: e.target.value,
           })
         }
+        modalContent={{
+          description: t(PageText.Contact.input.customerNumber.description),
+        }}
       />
 
       <Input
         label={PageText.Contact.input.orderId.label(true)}
         type="text"
         name="orderId"
-        modalDescription={t(PageText.Contact.input.orderId.description)}
-        modalBulletPoints={
-          PageText.Contact.input.orderId.descriptionBulletPoints
-        }
         value={state.context.orderId || ''}
         errorMessage={state.context?.errorMessages['orderId']?.[0]}
         onChange={(e) =>
@@ -48,6 +46,10 @@ export const AppTicketRefund = ({ state, send }: AppTicketRefundProps) => {
             value: e.target.value,
           })
         }
+        modalContent={{
+          description: t(PageText.Contact.input.orderId.description),
+          bulletPoints: PageText.Contact.input.orderId.descriptionBulletPoints,
+        }}
       />
     </SectionCard>
   );

--- a/src/page-modules/contact/ticketing/forms/refund/appTicketRefund.tsx
+++ b/src/page-modules/contact/ticketing/forms/refund/appTicketRefund.tsx
@@ -37,6 +37,8 @@ export const AppTicketRefund = ({ state, send }: AppTicketRefundProps) => {
         name="orderId"
         modalDescription={t(PageText.Contact.input.orderId.description)}
         modalBulletPoints={
+          PageText.Contact.input.orderId.descriptionBulletPoints
+        }
         value={state.context.orderId || ''}
         errorMessage={state.context?.errorMessages['orderId']?.[0]}
         onChange={(e) =>

--- a/src/page-modules/contact/ticketing/forms/refund/appTicketRefund.tsx
+++ b/src/page-modules/contact/ticketing/forms/refund/appTicketRefund.tsx
@@ -20,7 +20,7 @@ export const AppTicketRefund = ({ state, send }: AppTicketRefundProps) => {
         label={PageText.Contact.input.customerNumber.label}
         type="text"
         name="customerNumber"
-        description={t(PageText.Contact.input.customerNumber.description)}
+        modalDescription={t(PageText.Contact.input.customerNumber.description)}
         value={state.context.customerNumber || ''}
         errorMessage={state.context?.errorMessages['customerNumber']?.[0]}
         onChange={(e) =>
@@ -36,7 +36,8 @@ export const AppTicketRefund = ({ state, send }: AppTicketRefundProps) => {
         label={PageText.Contact.input.orderId.label(true)}
         type="text"
         name="orderId"
-        description={t(PageText.Contact.input.orderId.description(true))}
+        modalDescription={t(PageText.Contact.input.orderId.description)}
+        modalBulletPoints={
         value={state.context.orderId || ''}
         errorMessage={state.context?.errorMessages['orderId']?.[0]}
         onChange={(e) =>

--- a/src/page-modules/contact/ticketing/forms/refund/appTicketRefund.tsx
+++ b/src/page-modules/contact/ticketing/forms/refund/appTicketRefund.tsx
@@ -1,7 +1,6 @@
 import { PageText, useTranslation } from '@atb/translations';
 import { ticketingFormEvents } from '../../events';
 import { TicketingContextType } from '../../ticketingStateMachine';
-import { Typo } from '@atb/components/typography';
 import { SectionCard, Input } from '../../../components';
 
 type AppTicketRefundProps = {

--- a/src/page-modules/contact/ticketing/forms/refund/appTicketRefund.tsx
+++ b/src/page-modules/contact/ticketing/forms/refund/appTicketRefund.tsx
@@ -48,7 +48,10 @@ export const AppTicketRefund = ({ state, send }: AppTicketRefundProps) => {
         }
         modalContent={{
           description: t(PageText.Contact.input.orderId.description),
-          bulletPoints: PageText.Contact.input.orderId.descriptionBulletPoints,
+          bulletPoints:
+            PageText.Contact.input.orderId.descriptionBulletPoints.map(
+              (bulletPoint) => t(bulletPoint),
+            ),
         }}
       />
     </SectionCard>

--- a/src/page-modules/contact/ticketing/forms/refund/otherTicketRefund.tsx
+++ b/src/page-modules/contact/ticketing/forms/refund/otherTicketRefund.tsx
@@ -94,7 +94,10 @@ const RefundSection = ({ state, send }: RefundSectionProps) => {
         modalContent={{
           description: t(PageText.Contact.input.orderId.description),
           instruction: t(PageText.Contact.input.orderId.instruction),
-          bulletPoints: PageText.Contact.input.orderId.descriptionBulletPoints,
+          bulletPoints:
+            PageText.Contact.input.orderId.descriptionBulletPoints.map(
+              (bulletPoint) => t(bulletPoint),
+            ),
         }}
       />
 

--- a/src/page-modules/contact/ticketing/forms/refund/otherTicketRefund.tsx
+++ b/src/page-modules/contact/ticketing/forms/refund/otherTicketRefund.tsx
@@ -82,6 +82,9 @@ const RefundSection = ({ state, send }: RefundSectionProps) => {
         name="orderId"
         modalDescription={t(PageText.Contact.input.orderId.description)}
         modalBulletPoints={
+          PageText.Contact.input.orderId.descriptionBulletPoints
+        }
+        modalInstruction={t(PageText.Contact.input.orderId.instruction)}
         value={state.context.orderId || ''}
         errorMessage={state.context?.errorMessages['orderId']?.[0]}
         onChange={(e) =>

--- a/src/page-modules/contact/ticketing/forms/refund/otherTicketRefund.tsx
+++ b/src/page-modules/contact/ticketing/forms/refund/otherTicketRefund.tsx
@@ -64,7 +64,6 @@ const RefundSection = ({ state, send }: RefundSectionProps) => {
         label={PageText.Contact.input.customerNumber.label}
         type="text"
         name="customerNumber"
-        modalDescription={t(PageText.Contact.input.customerNumber.description)}
         value={state.context.customerNumber || ''}
         errorMessage={state.context?.errorMessages['customerNumber']?.[0]}
         onChange={(e) =>
@@ -74,17 +73,15 @@ const RefundSection = ({ state, send }: RefundSectionProps) => {
             value: e.target.value,
           })
         }
+        modalContent={{
+          description: t(PageText.Contact.input.customerNumber.description),
+        }}
       />
 
       <Input
         label={PageText.Contact.input.orderId.label(false)}
         type="text"
         name="orderId"
-        modalDescription={t(PageText.Contact.input.orderId.description)}
-        modalBulletPoints={
-          PageText.Contact.input.orderId.descriptionBulletPoints
-        }
-        modalInstruction={t(PageText.Contact.input.orderId.instruction)}
         value={state.context.orderId || ''}
         errorMessage={state.context?.errorMessages['orderId']?.[0]}
         onChange={(e) =>
@@ -94,6 +91,11 @@ const RefundSection = ({ state, send }: RefundSectionProps) => {
             value: e.target.value,
           })
         }
+        modalContent={{
+          description: t(PageText.Contact.input.orderId.description),
+          instruction: t(PageText.Contact.input.orderId.instruction),
+          bulletPoints: PageText.Contact.input.orderId.descriptionBulletPoints,
+        }}
       />
 
       <Typo.p textType="body__primary">

--- a/src/page-modules/contact/ticketing/forms/refund/otherTicketRefund.tsx
+++ b/src/page-modules/contact/ticketing/forms/refund/otherTicketRefund.tsx
@@ -61,7 +61,7 @@ const RefundSection = ({ state, send }: RefundSectionProps) => {
       />
 
       <Radio
-        label={t(PageText.Contact.input.customerNumber.label)}  
+        label={t(PageText.Contact.input.customerNumber.label)}
         name="isAppTicketStorageMode"
         checked={!state.context.showInputTravelCardNumber}
         onChange={() =>
@@ -71,9 +71,6 @@ const RefundSection = ({ state, send }: RefundSectionProps) => {
             value: !state.context.showInputTravelCardNumber,
           })
         }
-        modalContent={{
-          description: t(PageText.Contact.input.customerNumber.description),
-        }}
       />
 
       {state.context.showInputTravelCardNumber && (
@@ -98,7 +95,6 @@ const RefundSection = ({ state, send }: RefundSectionProps) => {
           label={t(PageText.Contact.input.customerNumber.label)}
           type="text"
           name="customerNumber"
-          description={t(PageText.Contact.input.customerNumber.description)}
           value={state.context.customerNumber || ''}
           errorMessage={state.context?.errorMessages['customerNumber']?.[0]}
           onChange={(e) =>
@@ -108,6 +104,9 @@ const RefundSection = ({ state, send }: RefundSectionProps) => {
               value: e.target.value,
             })
           }
+          modalContent={{
+            description: t(PageText.Contact.input.customerNumber.description),
+          }}
         />
       )}
 

--- a/src/page-modules/contact/ticketing/forms/refund/otherTicketRefund.tsx
+++ b/src/page-modules/contact/ticketing/forms/refund/otherTicketRefund.tsx
@@ -64,7 +64,7 @@ const RefundSection = ({ state, send }: RefundSectionProps) => {
         label={PageText.Contact.input.customerNumber.label}
         type="text"
         name="customerNumber"
-        description={t(PageText.Contact.input.customerNumber.description)}
+        modalDescription={t(PageText.Contact.input.customerNumber.description)}
         value={state.context.customerNumber || ''}
         errorMessage={state.context?.errorMessages['customerNumber']?.[0]}
         onChange={(e) =>
@@ -80,7 +80,8 @@ const RefundSection = ({ state, send }: RefundSectionProps) => {
         label={PageText.Contact.input.orderId.label(false)}
         type="text"
         name="orderId"
-        description={t(PageText.Contact.input.orderId.description(false))}
+        modalDescription={t(PageText.Contact.input.orderId.description)}
+        modalBulletPoints={
         value={state.context.orderId || ''}
         errorMessage={state.context?.errorMessages['orderId']?.[0]}
         onChange={(e) =>

--- a/src/page-modules/contact/ticketing/forms/webshop/webshopTicketingForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/webshop/webshopTicketingForm.tsx
@@ -20,9 +20,14 @@ export const WebshopTicketingForm = ({
       <SectionCard
         title={t(PageText.Contact.ticketing.webshop.webshopTicketing.title)}
       >
-        <Typo.p textType="body__primary">
-          {t(PageText.Contact.input.orderId.description(false))}
-        </Typo.p>
+        {PageText.Contact.input.orderId.descriptionBulletPoints.map(
+          (desc, index) => (
+            <Typo.p textType="body__primary" key={index}>
+              {t(desc)}
+            </Typo.p>
+          ),
+        )}
+
         <Input
           label={PageText.Contact.input.orderId.label(false)}
           type="text"

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -1550,21 +1550,34 @@ export const Contact = {
         expectsSingleOrderId
           ? _('Ordre-id', 'Order ID', 'Ordre-id')
           : _('Ordre-id(er)', 'Order ID(s)', 'Ordre-id(er)'),
-      description: (expectsSingleOrderId: boolean) =>
-        expectsSingleOrderId
-          ? _(
-              'Ordre-id finner du på billetten i appen eller på kvitteringen din. Du finner ordre-id også på utgåtte billetter.',
-              'The order ID can be found on the ticket in the app or on your receipt. You can also find the order ID on expired tickets.',
-              'Ordre-id finn du på billetten i appen eller på kvitteringa di. Du finn ordre-id også på utgåtte billettar.',
-            )
-          : _(
-              "Hvis du vil ha hjelp med en billett du allrede har kjøpt, trenger vi å vite ordre-id. Den finner du på billetten i appen, eller på kvitteringen din. Du finner ordre-id også på utgåtte billetter. Gjelder forespørslen din flere billetter, må du huske å sende med ordre-id for alle billettene.<br><br>Ved flere ordre-id-er, skill med komma (',').",
-              "If you want help with a ticket you have already bought, we need to know the order ID. You can find it on the ticket in the app, or on your receipt. You can also find the order ID on expired tickets. If your request concerns several tickets, you must remember to send with the order ID for all the tickets.<br><br>For multiple order IDs, separate with commas (',').",
-              "Viss du vil ha hjelp med ein billett du allereie har kjøpt, treng vi å vite ordre-id. Den finn du på billetten i appen, eller på kvitteringa di. Du finn ordre-id også på utgåtte billettar. Gjeld førespurnaden din fleire billettar, må du hugse å sende med ordre-id for alle billettane.<br><br>Ved flere ordre-id-er, skill med komma (',').",
-            ),
 
+      description: _(
+        'Hvis du vil ha hjelp med en billett du allerede har kjøpt, trenger vi å vite ordre-id. Ordre-id finner du følgende steder: ',
+        'Hvis du vil ha hjelp med en billett du allerede har kjøpt, trenger vi å vite ordre-id. Ordre-id finner du følgende steder: ',
+        'Hvis du vil ha hjelp med en billett du allerede har kjøpt, trenger vi å vite ordre-id. Ordre-id finner du følgende steder:',
+      ),
+
+      descriptionBulletPoints: [
+        _(
+          'På billetten i appen',
+          'På billetten i appen',
+          'På billetten i appen',
+        ),
+
+        _('På kvitteringen', 'På kvitteringen', 'På kvitteringen'),
+        _(
+          'Du finner ordre-id også på utgåtte billetter',
+          'Du finner ordre-id også på utgåtte billetter',
+          'Du finner ordre-id også på utgåtte billetter',
+        ),
+      ],
+      instruction: _(
+        `Gjelder forespørslen flere billetter, sende ordre-id for alle billettene, separert med komma (' , ').`,
+        `Gjelder forespørslen flere billetter, send ordre-id for alle billettene, separert med komma (' , ').`,
+        `Gjelder forespørslen flere billetter, sende ordre-id for alle billettene, separert med komma (' , ').`,
+      ),
       errorMessages: {
-        empty: _('Ordre-id mangler', 'Order-id is missing', 'Ordre-id mangler'),
+        empty: _('Ordre-id mangler', 'Order-id is missing', 'Ordre-id manglar'),
       },
     },
 

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -1555,7 +1555,7 @@ export const Contact = {
       description: _(
         'Hvis du vil ha hjelp med en billett du allerede har kjøpt, trenger vi å vite ordre-id. Ordre-id finner du følgende steder:',
         'If you want help with a ticket you have already bought, we need to know the order ID. You can find the order ID in the following places:',
-        'Viss du vil ha hjelp med ein billett du allereie har kjøpt, treng vi å vite ordre-id. Ordre-id finn du følgende steder:',
+        'Viss du vil ha hjelp med ein billett du allereie har kjøpt, treng vi å vite ordre-id. Ordre-id finn du følgende stadar:',
       ),
 
       descriptionBulletPoints: [

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -1552,29 +1552,29 @@ export const Contact = {
           : _('Ordre-id(er)', 'Order ID(s)', 'Ordre-id(er)'),
 
       description: _(
-        'Hvis du vil ha hjelp med en billett du allerede har kjøpt, trenger vi å vite ordre-id. Ordre-id finner du følgende steder: ',
-        'Hvis du vil ha hjelp med en billett du allerede har kjøpt, trenger vi å vite ordre-id. Ordre-id finner du følgende steder: ',
         'Hvis du vil ha hjelp med en billett du allerede har kjøpt, trenger vi å vite ordre-id. Ordre-id finner du følgende steder:',
+        'If you want help with a ticket you have already bought, we need to know the order ID. You can find the order ID in the following places:',
+        'Viss du vil ha hjelp med ein billett du allereie har kjøpt, treng vi å vite ordre-id. Ordre-id finn du følgende steder:',
       ),
 
       descriptionBulletPoints: [
         _(
           'På billetten i appen',
-          'På billetten i appen',
+          'On the ticket in the app',
           'På billetten i appen',
         ),
 
-        _('På kvitteringen', 'På kvitteringen', 'På kvitteringen'),
+        _('På kvitteringen din', 'On your receipt ', 'På kvitteringa di'),
         _(
-          'Du finner ordre-id også på utgåtte billetter',
-          'Du finner ordre-id også på utgåtte billetter',
-          'Du finner ordre-id også på utgåtte billetter',
+          'Du finner også ordre-id på utgåtte billetter',
+          'You can also find the order ID on expired tickets',
+          'Du finn også ordre-id på utgåtte billettar',
         ),
       ],
       instruction: _(
-        `Gjelder forespørslen flere billetter, sende ordre-id for alle billettene, separert med komma (' , ').`,
         `Gjelder forespørslen flere billetter, send ordre-id for alle billettene, separert med komma (' , ').`,
-        `Gjelder forespørslen flere billetter, sende ordre-id for alle billettene, separert med komma (' , ').`,
+        `If the request applies to several tickets, send the order ID for all the tickets, separated by commas (' , ').`,
+        `Gjeld forespørslen flere billettar, send ordre-id for alle billettane, separert med komma (' , ').`,
       ),
       errorMessages: {
         empty: _('Ordre-id mangler', 'Order-id is missing', 'Ordre-id manglar'),

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -1574,7 +1574,7 @@ export const Contact = {
       instruction: _(
         `Gjelder forespørselen flere billetter, send ordre-id for alle billettene, separert med komma (' , ').`,
         `If the request applies to several tickets, send the order ID for all the tickets, separated by commas (' , ').`,
-        `Gjeld forespørslen flere billettar, send ordre-id for alle billettane, separert med komma (' , ').`,
+        `Gjeld førespurnaden flere billettar, send ordre-id for alle billettane, separert med komma (' , ').`,
       ),
       errorMessages: {
         empty: _('Ordre-id mangler', 'Order-id is missing', 'Ordre-id manglar'),

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -1572,7 +1572,7 @@ export const Contact = {
         ),
       ],
       instruction: _(
-        `Gjelder forespørslen flere billetter, send ordre-id for alle billettene, separert med komma (' , ').`,
+        `Gjelder forespørselen flere billetter, send ordre-id for alle billettene, separert med komma (' , ').`,
         `If the request applies to several tickets, send the order ID for all the tickets, separated by commas (' , ').`,
         `Gjeld forespørslen flere billettar, send ordre-id for alle billettane, separert med komma (' , ').`,
       ),


### PR DESCRIPTION
### Background
Currently, the description modal display information through a  single string. This can look a bit strange, especially when the string starts to get long, and if it is desired to list a lot of information. 

This PR extends the description model with more properties to present information in a nicer way.  

#### Illustrations
<details>
<summary>Before</summary>
<img width="996" alt="Skjermbilde 2024-11-11 kl  13 28 54" src="https://github.com/user-attachments/assets/db05fe2b-0d3b-417c-92b4-0e5285a804dd">

</details>

<details>
<summary>After</summary>
<img width="996" alt="Skjermbilde 2024-11-11 kl  09 42 00" src="https://github.com/user-attachments/assets/b375e805-f92d-48ae-abef-f581ca17fbad">


</details>


### Proposed solution
Add bullet point list and instruction properties to description modal. 