### PR TITLE
chore: add max width to submit button

### DIFF
--- a/src/page-modules/contact/contact.module.css
+++ b/src/page-modules/contact/contact.module.css
@@ -53,4 +53,12 @@
 .submitButton {
   margin: var(--spacings-large);
   margin-top: 0px;
+  max-width: 6rem;
+  text-align: center;
+}
+
+@media (max-width: 600px) {
+  .submitButton {
+    max-width: none;
+  }
 }


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/19502

### Background
Currently, the button is always as wide as the parent component. When displayed on wide screens, the button becomes very wide. 

#### Illustrations

<details>
<summary>screenshots</summary>

<img width="1018" alt="Skjermbilde 2024-11-12 kl  10 28 50" src="https://github.com/user-attachments/assets/08b33b1e-ddd4-4164-8076-9ef161cab19b">
<img width="350" alt="Skjermbilde 2024-11-12 kl  10 29 06" src="https://github.com/user-attachments/assets/d605db30-7bd7-4a58-a531-6b9273edefbf">



</details>

### Proposed solution

Add a max width to the submit button. The max width is removed in mobile view. 