### PR TITLE
chore: update the display of input fields for bank information 

### DIFF
--- a/src/page-modules/contact/components/form/form.module.css
+++ b/src/page-modules/contact/components/form/form.module.css
@@ -38,6 +38,15 @@
   opacity: 1;
 }
 
+.input:disabled {
+  background-color: var(--static-background-background_2-background);
+  cursor: not-allowed;
+}
+
+.input__label_disabled {
+  color: var(--static-background-background_2-text);
+}
+
 .input:focus-within {
   outline: 0;
   box-shadow: inset 0 0 0 var(--border-width-slim)

--- a/src/page-modules/contact/components/form/input.tsx
+++ b/src/page-modules/contact/components/form/input.tsx
@@ -12,6 +12,7 @@ type InputProps = {
   label: string;
   description?: string;
   errorMessage?: TranslatedString;
+  disabled?: boolean;
   onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
 } & JSX.IntrinsicElements['input'];
 
@@ -24,6 +25,7 @@ export const Input = ({
   value,
   description,
   onChange,
+  disabled,
 }: InputProps) => {
   const { t } = useTranslation();
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -42,7 +44,11 @@ export const Input = ({
     >
       <div className={style.label_container}>
         <label>
-          <Typo.span textType="body__primary">{label}</Typo.span>
+          <Typo.span
+            textType={disabled ? 'body__primary--strike' : 'body__primary'}
+          >
+            {label}
+          </Typo.span>
         </label>
 
         {description && (
@@ -68,6 +74,7 @@ export const Input = ({
         checked={checked}
         value={value}
         onChange={onChange}
+        disabled={disabled}
       />
       {errorMessage && <ErrorMessage message={t(errorMessage)} />}
 

--- a/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
@@ -345,6 +345,24 @@ const FormContent = ({ state, send }: FormProps) => {
           }
         />
 
+        <Input
+          label={t(
+            PageText.Contact.input.bankInformation.bankAccountNumber.label,
+          )}
+          type="number"
+          name="bankAccountNumber"
+          value={state.context.bankAccountNumber || ''}
+          disabled={state.context.hasInternationalBankAccount}
+          errorMessage={state.context?.errorMessages['bankAccountNumber']?.[0]}
+          onChange={(e) =>
+            send({
+              type: 'ON_INPUT_CHANGE',
+              inputName: 'bankAccountNumber',
+              value: e.target.value,
+            })
+          }
+        />
+
         <Checkbox
           label={t(PageText.Contact.input.bankInformation.checkbox)}
           checked={state.context.hasInternationalBankAccount}
@@ -356,27 +374,6 @@ const FormContent = ({ state, send }: FormProps) => {
             })
           }
         />
-
-        {!state.context.hasInternationalBankAccount && (
-          <Input
-            label={t(
-              PageText.Contact.input.bankInformation.bankAccountNumber.label,
-            )}
-            type="number"
-            name="bankAccountNumber"
-            value={state.context.bankAccountNumber || ''}
-            errorMessage={
-              state.context?.errorMessages['bankAccountNumber']?.[0]
-            }
-            onChange={(e) =>
-              send({
-                type: 'ON_INPUT_CHANGE',
-                inputName: 'bankAccountNumber',
-                value: e.target.value,
-              })
-            }
-          />
-        )}
 
         {state.context.hasInternationalBankAccount && (
           <div>

--- a/src/page-modules/contact/ticket-control/ticket-control-form-machine.ts
+++ b/src/page-modules/contact/ticket-control/ticket-control-form-machine.ts
@@ -4,6 +4,7 @@ import {
   convertFilesToBase64,
   getCurrentDateString,
   getCurrentTimeString,
+  setBankAccountInternationalStatus,
   setLineAndResetStops,
   setTransportModeAndResetLineAndStops,
 } from '../utils';
@@ -219,6 +220,10 @@ export const ticketControlFormMachine = setup({
         // Set both agreements to false if agreesFirstAgreement is set to false.
         if (inputName === 'agreesFirstAgreement' && !value)
           return disagreeAgreements(context);
+
+        if (inputName === 'hasInternationalBankAccount') {
+          return setBankAccountInternationalStatus(context, value as boolean);
+        }
 
         context.errorMessages[inputName] = [];
         return {

--- a/src/page-modules/contact/ticketing/forms/refund/otherTicketRefund.tsx
+++ b/src/page-modules/contact/ticketing/forms/refund/otherTicketRefund.tsx
@@ -288,6 +288,24 @@ const AboutYouSection = ({ state, send }: AboutYouSectionProps) => {
         }
       />
 
+      <Input
+        label={t(
+          PageText.Contact.input.bankInformation.bankAccountNumber.label,
+        )}
+        type="number"
+        name="bankAccountNumber"
+        value={state.context.bankAccountNumber || ''}
+        disabled={state.context.hasInternationalBankAccount}
+        errorMessage={state.context?.errorMessages['bankAccountNumber']?.[0]}
+        onChange={(e) =>
+          send({
+            type: 'ON_INPUT_CHANGE',
+            inputName: 'bankAccountNumber',
+            value: e.target.value,
+          })
+        }
+      />
+
       <Checkbox
         label={t(PageText.Contact.input.bankInformation.checkbox)}
         checked={state.context.hasInternationalBankAccount}
@@ -299,25 +317,6 @@ const AboutYouSection = ({ state, send }: AboutYouSectionProps) => {
           })
         }
       />
-
-      {!state.context.hasInternationalBankAccount && (
-        <Input
-          label={t(
-            PageText.Contact.input.bankInformation.bankAccountNumber.label,
-          )}
-          type="number"
-          name="bankAccountNumber"
-          value={state.context.bankAccountNumber || ''}
-          errorMessage={state.context?.errorMessages['bankAccountNumber']?.[0]}
-          onChange={(e) =>
-            send({
-              type: 'ON_INPUT_CHANGE',
-              inputName: 'bankAccountNumber',
-              value: e.target.value,
-            })
-          }
-        />
-      )}
 
       {state.context.hasInternationalBankAccount && (
         <div>

--- a/src/page-modules/contact/ticketing/ticketingStateMachine.ts
+++ b/src/page-modules/contact/ticketing/ticketingStateMachine.ts
@@ -1,7 +1,10 @@
 import { assign, fromPromise, setup } from 'xstate';
 import { ticketingFormEvents, TicketType } from './events';
 import { commonInputValidator, InputErrorMessages } from '../validation';
-import { convertFilesToBase64 } from '../utils';
+import {
+  convertFilesToBase64,
+  setBankAccountInternationalStatus,
+} from '../utils';
 
 export enum FormCategory {
   PriceAndTicketTypes = 'priceAndTicketTypes',
@@ -257,6 +260,10 @@ export const ticketingStateMachine = setup({
             isInitialAgreementChecked: false,
             formType: undefined,
           };
+        }
+
+        if (inputName === 'hasInternationalBankAccount') {
+          return setBankAccountInternationalStatus(context, value as boolean);
         }
 
         return {

--- a/src/page-modules/contact/travel-guarantee/forms/refundCarForm.tsx
+++ b/src/page-modules/contact/travel-guarantee/forms/refundCarForm.tsx
@@ -358,6 +358,24 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
           }
         />
 
+        <Input
+          label={t(
+            PageText.Contact.input.bankInformation.bankAccountNumber.label,
+          )}
+          type="number"
+          name="bankAccountNumber"
+          value={state.context.bankAccountNumber || ''}
+          disabled={state.context.hasInternationalBankAccount}
+          errorMessage={state.context?.errorMessages['bankAccountNumber']?.[0]}
+          onChange={(e) =>
+            send({
+              type: 'ON_INPUT_CHANGE',
+              inputName: 'bankAccountNumber',
+              value: e.target.value,
+            })
+          }
+        />
+
         <Checkbox
           label={t(PageText.Contact.input.bankInformation.checkbox)}
           checked={state.context.hasInternationalBankAccount}
@@ -369,27 +387,6 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
             })
           }
         />
-
-        {!state.context.hasInternationalBankAccount && (
-          <Input
-            label={t(
-              PageText.Contact.input.bankInformation.bankAccountNumber.label,
-            )}
-            type="number"
-            name="bankAccountNumber"
-            value={state.context.bankAccountNumber || ''}
-            errorMessage={
-              state.context?.errorMessages['bankAccountNumber']?.[0]
-            }
-            onChange={(e) =>
-              send({
-                type: 'ON_INPUT_CHANGE',
-                inputName: 'bankAccountNumber',
-                value: e.target.value,
-              })
-            }
-          />
-        )}
 
         {state.context.hasInternationalBankAccount && (
           <div>

--- a/src/page-modules/contact/travel-guarantee/forms/refundTaxiForm.tsx
+++ b/src/page-modules/contact/travel-guarantee/forms/refundTaxiForm.tsx
@@ -344,6 +344,24 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
           }
         />
 
+        <Input
+          label={t(
+            PageText.Contact.input.bankInformation.bankAccountNumber.label,
+          )}
+          type="number"
+          name="bankAccountNumber"
+          value={state.context.bankAccountNumber || ''}
+          disabled={state.context.hasInternationalBankAccount}
+          errorMessage={state.context?.errorMessages['bankAccountNumber']?.[0]}
+          onChange={(e) =>
+            send({
+              type: 'ON_INPUT_CHANGE',
+              inputName: 'bankAccountNumber',
+              value: e.target.value,
+            })
+          }
+        />
+
         <Checkbox
           label={t(PageText.Contact.input.bankInformation.checkbox)}
           checked={state.context.hasInternationalBankAccount}
@@ -355,27 +373,6 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
             })
           }
         />
-
-        {!state.context.hasInternationalBankAccount && (
-          <Input
-            label={t(
-              PageText.Contact.input.bankInformation.bankAccountNumber.label,
-            )}
-            type="number"
-            name="bankAccountNumber"
-            value={state.context.bankAccountNumber || ''}
-            errorMessage={
-              state.context?.errorMessages['bankAccountNumber']?.[0]
-            }
-            onChange={(e) =>
-              send({
-                type: 'ON_INPUT_CHANGE',
-                inputName: 'bankAccountNumber',
-                value: e.target.value,
-              })
-            }
-          />
-        )}
 
         {state.context.hasInternationalBankAccount && (
           <div>

--- a/src/page-modules/contact/travel-guarantee/travelGuaranteeFormMachine.ts
+++ b/src/page-modules/contact/travel-guarantee/travelGuaranteeFormMachine.ts
@@ -7,6 +7,7 @@ import {
   convertFilesToBase64,
   getCurrentDateString,
   getCurrentTimeString,
+  setBankAccountInternationalStatus,
   setLineAndResetStops,
   setTransportModeAndResetLineAndStops,
 } from '../utils';
@@ -189,6 +190,10 @@ export const fetchMachine = setup({
 
         if (inputName === 'isIntialAgreementChecked')
           return setInitialAgreementAndFormType(context, value);
+
+        if (inputName === 'hasInternationalBankAccount') {
+          return setBankAccountInternationalStatus(context, value as boolean);
+        }
 
         context.errorMessages[inputName] = [];
         return {

--- a/src/page-modules/contact/utils.ts
+++ b/src/page-modules/contact/utils.ts
@@ -74,3 +74,16 @@ export const setLineAndResetStops = (context: any, line: Line | undefined) => {
     },
   };
 };
+
+export const setBankAccountInternationalStatus = (
+  context: any,
+  hasInternationalBankAccount: boolean,
+) => {
+  return {
+    ...context,
+    hasInternationalBankAccount: hasInternationalBankAccount,
+    bankAccountNumber: undefined,
+    IBAN: undefined,
+    SWIFT: undefined,
+  };
+};


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/19509

### Background

Tilbakemelding fra FRAM:

Jeg syns det er litt forvirrende at det står «Jeg har et utenlandsk bankkontonummer» før feltet for bankkonto. Jeg tror jeg hadde kommet til å hoppe over å fylle ut bankkontonummer fordi jeg tenkte at dette kun gjaldt for de som har utenlandsk bankkontonummer. Ønsker avkryssingen for utenlandsk kontonummer under feltet for å fylle ut bankkonto, da jeg tror det er mer logisk.

#### Illustrations
<details>
<summary>screenshots</summary>

<img width="1108" alt="Skjermbilde 2024-11-13 kl  10 59 13" src="https://github.com/user-attachments/assets/3bf5a17f-7d0d-418c-9633-f7e7ee4dac52">



<img width="1108" alt="Skjermbilde 2024-11-13 kl  10 59 21" src="https://github.com/user-attachments/assets/31e31d18-234b-442b-8734-cff8923c362e">

</details>

### Proposed solution

- [x] Move the checkbox to under the input field for bank account number.
- [x] When checkbox `I have a foreign bank account` is checked, The input field for bank account number should be disabled and the input field for IBAN and SWIFT should appear bellow the checkbox. 
- [x] When toggling between the views, the values ​​`bankAccountNumber`, `IBAN` and `SWIFT` should be reset (set to `undefined`).   