### PR TITLE
fix: set bank account information to undefined when toggling between bank information input fields

### DIFF
--- a/src/page-modules/contact/ticket-control/ticket-control-form-machine.ts
+++ b/src/page-modules/contact/ticket-control/ticket-control-form-machine.ts
@@ -4,6 +4,7 @@ import {
   convertFilesToBase64,
   getCurrentDateString,
   getCurrentTimeString,
+  setBankAccountStatusAndResetBankInformation,
   setLineAndResetStops,
   setTransportModeAndResetLineAndStops,
 } from '../utils';
@@ -219,6 +220,13 @@ export const ticketControlFormMachine = setup({
         // Set both agreements to false if agreesFirstAgreement is set to false.
         if (inputName === 'agreesFirstAgreement' && !value)
           return disagreeAgreements(context);
+
+        if (inputName === 'hasInternationalBankAccount') {
+          return setBankAccountStatusAndResetBankInformation(
+            context,
+            value as boolean,
+          );
+        }
 
         context.errorMessages[inputName] = [];
         return {

--- a/src/page-modules/contact/ticketing/ticketingStateMachine.ts
+++ b/src/page-modules/contact/ticketing/ticketingStateMachine.ts
@@ -1,7 +1,10 @@
 import { assign, fromPromise, setup } from 'xstate';
 import { ticketingFormEvents, TicketType } from './events';
 import { commonInputValidator, InputErrorMessages } from '../validation';
-import { convertFilesToBase64 } from '../utils';
+import {
+  convertFilesToBase64,
+  setBankAccountStatusAndResetBankInformation,
+} from '../utils';
 
 export enum FormCategory {
   PriceAndTicketTypes = 'priceAndTicketTypes',
@@ -257,6 +260,13 @@ export const ticketingStateMachine = setup({
             isInitialAgreementChecked: false,
             formType: undefined,
           };
+        }
+
+        if (inputName === 'hasInternationalBankAccount') {
+          return setBankAccountStatusAndResetBankInformation(
+            context,
+            value as boolean,
+          );
         }
 
         return {

--- a/src/page-modules/contact/travel-guarantee/travelGuaranteeFormMachine.ts
+++ b/src/page-modules/contact/travel-guarantee/travelGuaranteeFormMachine.ts
@@ -7,6 +7,7 @@ import {
   convertFilesToBase64,
   getCurrentDateString,
   getCurrentTimeString,
+  setBankAccountStatusAndResetBankInformation,
   setLineAndResetStops,
   setTransportModeAndResetLineAndStops,
 } from '../utils';
@@ -189,6 +190,13 @@ export const fetchMachine = setup({
 
         if (inputName === 'isIntialAgreementChecked')
           return setInitialAgreementAndFormType(context, value);
+
+        if (inputName === 'hasInternationalBankAccount') {
+          return setBankAccountStatusAndResetBankInformation(
+            context,
+            value as boolean,
+          );
+        }
 
         context.errorMessages[inputName] = [];
         return {

--- a/src/page-modules/contact/utils.ts
+++ b/src/page-modules/contact/utils.ts
@@ -74,3 +74,16 @@ export const setLineAndResetStops = (context: any, line: Line | undefined) => {
     },
   };
 };
+
+export const setBankAccountStatusAndResetBankInformation = (
+  context: any,
+  hasInternationalBankAccount: boolean,
+) => {
+  return {
+    ...context,
+    hasInternationalBankAccount: hasInternationalBankAccount,
+    bankAccountNumber: undefined,
+    IBAN: undefined,
+    SWIFT: undefined,
+  };
+};


### PR DESCRIPTION
Ensure that bank account information is set to undefined when toggling between bank account input fields.