### PR TITLE
feat: reorganize display of bank account input fields

### DIFF
--- a/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
@@ -345,6 +345,24 @@ const FormContent = ({ state, send }: FormProps) => {
           }
         />
 
+        <Input
+          label={t(
+            PageText.Contact.input.bankInformation.bankAccountNumber.label,
+          )}
+          type="number"
+          name="bankAccountNumber"
+          value={state.context.bankAccountNumber || ''}
+          disabled={state.context.hasInternationalBankAccount}
+          errorMessage={state.context?.errorMessages['bankAccountNumber']?.[0]}
+          onChange={(e) =>
+            send({
+              type: 'ON_INPUT_CHANGE',
+              inputName: 'bankAccountNumber',
+              value: e.target.value,
+            })
+          }
+        />
+
         <Checkbox
           label={t(PageText.Contact.input.bankInformation.checkbox)}
           checked={state.context.hasInternationalBankAccount}
@@ -356,27 +374,6 @@ const FormContent = ({ state, send }: FormProps) => {
             })
           }
         />
-
-        {!state.context.hasInternationalBankAccount && (
-          <Input
-            label={t(
-              PageText.Contact.input.bankInformation.bankAccountNumber.label,
-            )}
-            type="number"
-            name="bankAccountNumber"
-            value={state.context.bankAccountNumber || ''}
-            errorMessage={
-              state.context?.errorMessages['bankAccountNumber']?.[0]
-            }
-            onChange={(e) =>
-              send({
-                type: 'ON_INPUT_CHANGE',
-                inputName: 'bankAccountNumber',
-                value: e.target.value,
-              })
-            }
-          />
-        )}
 
         {state.context.hasInternationalBankAccount && (
           <div>

--- a/src/page-modules/contact/ticketing/forms/refund/otherTicketRefund.tsx
+++ b/src/page-modules/contact/ticketing/forms/refund/otherTicketRefund.tsx
@@ -288,6 +288,24 @@ const AboutYouSection = ({ state, send }: AboutYouSectionProps) => {
         }
       />
 
+      <Input
+        label={t(
+          PageText.Contact.input.bankInformation.bankAccountNumber.label,
+        )}
+        type="number"
+        name="bankAccountNumber"
+        value={state.context.bankAccountNumber || ''}
+        disabled={state.context.hasInternationalBankAccount}
+        errorMessage={state.context?.errorMessages['bankAccountNumber']?.[0]}
+        onChange={(e) =>
+          send({
+            type: 'ON_INPUT_CHANGE',
+            inputName: 'bankAccountNumber',
+            value: e.target.value,
+          })
+        }
+      />
+
       <Checkbox
         label={t(PageText.Contact.input.bankInformation.checkbox)}
         checked={state.context.hasInternationalBankAccount}
@@ -299,25 +317,6 @@ const AboutYouSection = ({ state, send }: AboutYouSectionProps) => {
           })
         }
       />
-
-      {!state.context.hasInternationalBankAccount && (
-        <Input
-          label={t(
-            PageText.Contact.input.bankInformation.bankAccountNumber.label,
-          )}
-          type="number"
-          name="bankAccountNumber"
-          value={state.context.bankAccountNumber || ''}
-          errorMessage={state.context?.errorMessages['bankAccountNumber']?.[0]}
-          onChange={(e) =>
-            send({
-              type: 'ON_INPUT_CHANGE',
-              inputName: 'bankAccountNumber',
-              value: e.target.value,
-            })
-          }
-        />
-      )}
 
       {state.context.hasInternationalBankAccount && (
         <div>

--- a/src/page-modules/contact/travel-guarantee/forms/refundCarForm.tsx
+++ b/src/page-modules/contact/travel-guarantee/forms/refundCarForm.tsx
@@ -343,16 +343,20 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
             })
           }
         />
+
         <Input
-          label={t(PageText.Contact.input.phoneNumber.label)}
-          type="tel"
-          name="phoneNumber"
-          value={state.context.phoneNumber || ''}
-          errorMessage={state.context?.errorMessages['phoneNumber']?.[0]}
+          label={t(
+            PageText.Contact.input.bankInformation.bankAccountNumber.label,
+          )}
+          type="number"
+          name="bankAccountNumber"
+          value={state.context.bankAccountNumber || ''}
+          disabled={state.context.hasInternationalBankAccount}
+          errorMessage={state.context?.errorMessages['bankAccountNumber']?.[0]}
           onChange={(e) =>
             send({
               type: 'ON_INPUT_CHANGE',
-              inputName: 'phoneNumber',
+              inputName: 'bankAccountNumber',
               value: e.target.value,
             })
           }
@@ -369,27 +373,6 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
             })
           }
         />
-
-        {!state.context.hasInternationalBankAccount && (
-          <Input
-            label={t(
-              PageText.Contact.input.bankInformation.bankAccountNumber.label,
-            )}
-            type="number"
-            name="bankAccountNumber"
-            value={state.context.bankAccountNumber || ''}
-            errorMessage={
-              state.context?.errorMessages['bankAccountNumber']?.[0]
-            }
-            onChange={(e) =>
-              send({
-                type: 'ON_INPUT_CHANGE',
-                inputName: 'bankAccountNumber',
-                value: e.target.value,
-              })
-            }
-          />
-        )}
 
         {state.context.hasInternationalBankAccount && (
           <div>

--- a/src/page-modules/contact/travel-guarantee/forms/refundTaxiForm.tsx
+++ b/src/page-modules/contact/travel-guarantee/forms/refundTaxiForm.tsx
@@ -344,6 +344,24 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
           }
         />
 
+        <Input
+          label={t(
+            PageText.Contact.input.bankInformation.bankAccountNumber.label,
+          )}
+          type="number"
+          name="bankAccountNumber"
+          value={state.context.bankAccountNumber || ''}
+          disabled={state.context.hasInternationalBankAccount}
+          errorMessage={state.context?.errorMessages['bankAccountNumber']?.[0]}
+          onChange={(e) =>
+            send({
+              type: 'ON_INPUT_CHANGE',
+              inputName: 'bankAccountNumber',
+              value: e.target.value,
+            })
+          }
+        />
+
         <Checkbox
           label={t(PageText.Contact.input.bankInformation.checkbox)}
           checked={state.context.hasInternationalBankAccount}
@@ -355,27 +373,6 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
             })
           }
         />
-
-        {!state.context.hasInternationalBankAccount && (
-          <Input
-            label={t(
-              PageText.Contact.input.bankInformation.bankAccountNumber.label,
-            )}
-            type="number"
-            name="bankAccountNumber"
-            value={state.context.bankAccountNumber || ''}
-            errorMessage={
-              state.context?.errorMessages['bankAccountNumber']?.[0]
-            }
-            onChange={(e) =>
-              send({
-                type: 'ON_INPUT_CHANGE',
-                inputName: 'bankAccountNumber',
-                value: e.target.value,
-              })
-            }
-          />
-        )}
 
         {state.context.hasInternationalBankAccount && (
           <div>


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/19509

### Background

Tilbakemelding fra FRAM:

Jeg syns det er litt forvirrende at det står «Jeg har et utenlandsk bankkontonummer» før feltet for bankkonto. Jeg tror jeg hadde kommet til å hoppe over å fylle ut bankkontonummer fordi jeg tenkte at dette kun gjaldt for de som har utenlandsk bankkontonummer. Ønsker avkryssingen for utenlandsk kontonummer under feltet for å fylle ut bankkonto, da jeg tror det er mer logisk.

#### Illustrations
<details>
<summary>screenshots</summary>
<img width="1108" alt="Skjermbilde 2024-11-13 kl  14 56 53" src="https://github.com/user-attachments/assets/3b5c1a54-37cd-4c03-b139-4f64611fd471">
<img width="1108" alt="Skjermbilde 2024-11-13 kl  14 56 59" src="https://github.com/user-attachments/assets/bcf629fd-b72a-40e2-bf74-3db881d39ddb">




</details>

### Proposed solution

- [x] Move the checkbox to under the input field for bank account number.
