### PR TITLE
feat: extend selector label to better illustrate when the selector is disabled

### DIFF
--- a/src/page-modules/contact/components/form/form.module.css
+++ b/src/page-modules/contact/components/form/form.module.css
@@ -489,6 +489,10 @@
   border: var(--border-width-slim) solid var(--text-colors-primary);
 }
 
+.select__button:disabled {
+  cursor: not-allowed;
+}
+
 .select__button:focus-within {
   outline: 0;
   box-shadow: inset 0 0 0 var(--border-width-slim)

--- a/src/page-modules/contact/components/form/select.tsx
+++ b/src/page-modules/contact/components/form/select.tsx
@@ -53,12 +53,16 @@ export default function CustomeSelect<T>({
       isDisabled={disabled}
       className={style.select__select_container}
     >
-      <Label>{label}</Label>
+      <Label className={disabled ? style.label_disabled : ''}>{label}</Label>
       <Button className={style.select__button}>
         {value ? (
           <span>{valueToText(value)}</span>
         ) : (
-          <span className={style.select__placholder}>{placeholder}</span>
+          <span
+            className={`${style.select__placeholder} ${disabled ? style.label_disabled : ''}`}
+          >
+            {placeholder}
+          </span>
         )}
         <MonoIcon icon={'navigation/ExpandMore'} />
       </Button>


### PR DESCRIPTION
Extend selector label to better illustrate when the selector is disabled.