### PR TITLE
feat: set the time of the incident manually

### DIFF
--- a/src/page-modules/contact/components/form/time-selector.tsx
+++ b/src/page-modules/contact/components/form/time-selector.tsx
@@ -1,6 +1,7 @@
 import style from './form.module.css';
 import { TranslatedString, useTranslation } from '@atb/translations';
 import { parseTime } from '@internationalized/date';
+import ErrorMessage from './error-message';
 import {
   DateInput,
   DateSegment,
@@ -10,16 +11,18 @@ import {
 
 export type TimeSelectorProps = {
   label: TranslatedString;
-  value: string;
+  value?: string;
+  errorMessage?: TranslatedString;
   onChange: (value: string) => void;
 };
 export default function TimeSelector({
   label,
   value,
+  errorMessage,
   onChange,
 }: TimeSelectorProps) {
   const { t } = useTranslation();
-  const parsedValue = parseTime(value);
+  const parsedValue = value ? parseTime(value) : undefined;
 
   return (
     <div className={style.timeSelectorContainer}>
@@ -42,6 +45,7 @@ export default function TimeSelector({
           )}
         </DateInput>
       </TimeField>
+      {errorMessage && <ErrorMessage message={t(errorMessage)} />}
     </div>
   );
 }

--- a/src/page-modules/contact/group-travel/group-travel-state-machine.ts
+++ b/src/page-modules/contact/group-travel/group-travel-state-machine.ts
@@ -1,6 +1,6 @@
 import { assign, fromPromise, setup } from 'xstate';
 import { Line } from '../server/journey-planner/validators';
-import { getCurrentDateString, getCurrentTimeString } from '../utils';
+import { getCurrentDateString } from '../utils';
 
 export type GroupTravelContextType = {
   travelType: 'bus' | 'boat' | null;
@@ -139,7 +139,6 @@ export const groupTravelStateMachine = setup({
     travelType: null,
     formData: {
       dateOfTravel: getCurrentDateString(),
-      departureTime: getCurrentTimeString(),
     },
     errors: defaultErrors,
   } as GroupTravelContextType,

--- a/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
@@ -152,6 +152,10 @@ export const DelayForm = ({ state, send }: DelayFormProps) => {
               value: time,
             })
           }
+          errorMessage={
+            state.context?.errorMessages['plannedDepartureTime']?.[0] ||
+            undefined
+          }
         />
       </SectionCard>
 

--- a/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
@@ -174,6 +174,10 @@ export const DriverForm = ({ state, send }: DriverFormProps) => {
               value: time,
             })
           }
+          errorMessage={
+            state.context?.errorMessages['plannedDepartureTime']?.[0] ||
+            undefined
+          }
         />
       </SectionCard>
 

--- a/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
@@ -173,6 +173,10 @@ export const InjuryForm = ({ state, send }: InjuryFormProps) => {
               value: time,
             })
           }
+          errorMessage={
+            state.context?.errorMessages['plannedDepartureTime']?.[0] ||
+            undefined
+          }
         />
       </SectionCard>
 

--- a/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
@@ -156,6 +156,10 @@ export const TransportationForm = ({
               value: time,
             })
           }
+          errorMessage={
+            state.context?.errorMessages['plannedDepartureTime']?.[0] ||
+            undefined
+          }
         />
       </SectionCard>
 

--- a/src/page-modules/contact/means-of-transport/means-of-transport-form-machine.ts
+++ b/src/page-modules/contact/means-of-transport/means-of-transport-form-machine.ts
@@ -5,7 +5,6 @@ import { commonInputValidator, InputErrorMessages } from '../validation';
 import {
   convertFilesToBase64,
   getCurrentDateString,
-  getCurrentTimeString,
   setLineAndResetStops,
   setTransportModeAndResetLineAndStops,
 } from '../utils';
@@ -250,7 +249,6 @@ export const meansOfTransportFormMachine = setup({
   initial: 'editing',
   context: {
     date: getCurrentDateString(),
-    plannedDepartureTime: getCurrentTimeString(),
     isResponseWanted: false,
     errorMessages: {},
   },

--- a/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
@@ -142,6 +142,10 @@ export const FeedbackForm = ({ state, send }: FeedbackFormProps) => {
               value: time,
             })
           }
+          errorMessage={
+            state.context?.errorMessages['plannedDepartureTime']?.[0] ||
+            undefined
+          }
         />
       </SectionCard>
       <SectionCard title={t(PageText.Contact.input.feedback.title)}>

--- a/src/page-modules/contact/ticket-control/ticket-control-form-machine.ts
+++ b/src/page-modules/contact/ticket-control/ticket-control-form-machine.ts
@@ -3,7 +3,6 @@ import { ticketControlFormEvents } from './events';
 import {
   convertFilesToBase64,
   getCurrentDateString,
-  getCurrentTimeString,
   setBankAccountStatusAndResetBankInformation,
   setLineAndResetStops,
   setTransportModeAndResetLineAndStops,
@@ -327,7 +326,6 @@ export const ticketControlFormMachine = setup({
   initial: 'editing',
   context: {
     date: getCurrentDateString(),
-    plannedDepartureTime: getCurrentTimeString(),
     agreesFirstAgreement: false,
     agreesSecondAgreement: false,
     hasInternationalBankAccount: false,

--- a/src/page-modules/contact/travel-guarantee/forms/refundCarForm.tsx
+++ b/src/page-modules/contact/travel-guarantee/forms/refundCarForm.tsx
@@ -193,6 +193,10 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
               value: time,
             })
           }
+          errorMessage={
+            state.context?.errorMessages['plannedDepartureTime']?.[0] ||
+            undefined
+          }
         />
 
         <Select

--- a/src/page-modules/contact/travel-guarantee/forms/refundTaxiForm.tsx
+++ b/src/page-modules/contact/travel-guarantee/forms/refundTaxiForm.tsx
@@ -180,6 +180,10 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
               value: time,
             })
           }
+          errorMessage={
+            state.context?.errorMessages['plannedDepartureTime']?.[0] ||
+            undefined
+          }
         />
 
         <Select

--- a/src/page-modules/contact/travel-guarantee/travelGuaranteeFormMachine.ts
+++ b/src/page-modules/contact/travel-guarantee/travelGuaranteeFormMachine.ts
@@ -6,7 +6,6 @@ import { commonInputValidator, InputErrorMessages } from '../validation';
 import {
   convertFilesToBase64,
   getCurrentDateString,
-  getCurrentTimeString,
   setBankAccountStatusAndResetBankInformation,
   setLineAndResetStops,
   setTransportModeAndResetLineAndStops,
@@ -63,7 +62,7 @@ export type ContextProps = {
   fromStop?: Line['quays'][0] | undefined;
   toStop?: Line['quays'][0] | undefined;
   date: string;
-  plannedDepartureTime: string;
+  plannedDepartureTime?: string;
   kilometersDriven?: string;
   fromAddress?: string;
   toAddress?: string;
@@ -295,7 +294,6 @@ export const fetchMachine = setup({
     isIntialAgreementChecked: false,
     hasInternationalBankAccount: false,
     date: getCurrentDateString(),
-    plannedDepartureTime: getCurrentTimeString(),
     errorMessages: {},
   },
   states: {

--- a/src/page-modules/contact/utils.ts
+++ b/src/page-modules/contact/utils.ts
@@ -37,9 +37,6 @@ export const convertFilesToBase64 = (
 export const getCurrentDateString = (): string =>
   new Date().toISOString().split('T')[0];
 
-export const getCurrentTimeString = (): string =>
-  `${String(new Date().getHours()).padStart(2, '0')}:${String(new Date().getMinutes()).padStart(2, '0')}`;
-
 export const setTransportModeAndResetLineAndStops = (
   context: any,
   transporMode: TransportModeType,


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/19522

### Background
Currently, the time is automatically set when reporting an incident. This results in several users sloppily specifying the correct time, which is again critical information. 

Time of an incident should be mandatory to provided when needed. The user must specify the time himself.

#### Illustrations

<details>
<summary>screenshots</summary>
<img width="1099" alt="Skjermbilde 2024-11-14 kl  12 13 10" src="https://github.com/user-attachments/assets/49320650-1dab-4615-96d4-255ced81e731">


</details>

### Proposed solution

- [x] Add error message property to TimeSelector. 
- [x] Set plannedDepartureTime to `undefined` in the state machines.
