### PR TITLE
feat: set the date of the incident manually

### DIFF
--- a/src/page-modules/contact/components/form/date-selector.tsx
+++ b/src/page-modules/contact/components/form/date-selector.tsx
@@ -1,7 +1,7 @@
 import style from './form.module.css';
 import { MonoIcon } from '@atb/components/icon';
 import { TranslatedString, useTranslation } from '@atb/translations';
-import { fromDate, parseDate } from '@internationalized/date';
+import { fromDate } from '@internationalized/date';
 import {
   Button,
   Calendar,
@@ -16,26 +16,32 @@ import {
   Label,
   Popover,
 } from 'react-aria-components';
+import ErrorMessage from './error-message';
 
 export type DateSelectorProps = {
   label: TranslatedString;
   value?: string;
+  errorMessage?: TranslatedString;
   onChange: (value: string) => void;
 };
 
 export default function DateSelector({
   label,
   value,
+  errorMessage,
   onChange,
 }: DateSelectorProps) {
   const { t } = useTranslation();
+  const zonedDateTime = value
+    ? fromDate(new Date(value || ''), 'Europe/Oslo')
+    : undefined;
 
   return (
     <div className={style.dateSelectorContainer}>
       <Label>{t(label)}</Label>
       <DatePicker
         granularity="day"
-        value={fromDate(new Date(value || ''), 'Europe/Oslo')}
+        value={zonedDateTime}
         onChange={(e) => onChange(e.toString().slice(0, 10))}
         className={style.dateSelector}
         shouldForceLeadingZeros
@@ -78,6 +84,7 @@ export default function DateSelector({
           </Dialog>
         </Popover>
       </DatePicker>
+      {errorMessage && <ErrorMessage message={t(errorMessage)} />}
     </div>
   );
 }

--- a/src/page-modules/contact/group-travel/group-travel-state-machine.ts
+++ b/src/page-modules/contact/group-travel/group-travel-state-machine.ts
@@ -1,6 +1,5 @@
 import { assign, fromPromise, setup } from 'xstate';
 import { Line } from '../server/journey-planner/validators';
-import { getCurrentDateString } from '../utils';
 
 export type GroupTravelContextType = {
   travelType: 'bus' | 'boat' | null;
@@ -137,9 +136,6 @@ export const groupTravelStateMachine = setup({
   initial: 'selectTravelType',
   context: {
     travelType: null,
-    formData: {
-      dateOfTravel: getCurrentDateString(),
-    },
     errors: defaultErrors,
   } as GroupTravelContextType,
   on: {

--- a/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
@@ -140,6 +140,7 @@ export const DelayForm = ({ state, send }: DelayFormProps) => {
               value: date,
             })
           }
+          errorMessage={state.context?.errorMessages['date']?.[0]}
         />
 
         <TimeSelector

--- a/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
@@ -162,6 +162,7 @@ export const DriverForm = ({ state, send }: DriverFormProps) => {
               value: date,
             })
           }
+          errorMessage={state.context?.errorMessages['date']?.[0]}
         />
 
         <TimeSelector

--- a/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
@@ -161,6 +161,7 @@ export const InjuryForm = ({ state, send }: InjuryFormProps) => {
               value: date,
             })
           }
+          errorMessage={state.context?.errorMessages['date']?.[0]}
         />
 
         <TimeSelector

--- a/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
@@ -144,6 +144,7 @@ export const TransportationForm = ({
               value: date,
             })
           }
+          errorMessage={state.context?.errorMessages['date']?.[0]}
         />
 
         <TimeSelector

--- a/src/page-modules/contact/means-of-transport/means-of-transport-form-machine.ts
+++ b/src/page-modules/contact/means-of-transport/means-of-transport-form-machine.ts
@@ -4,7 +4,6 @@ import { Line } from '../server/journey-planner/validators';
 import { commonInputValidator, InputErrorMessages } from '../validation';
 import {
   convertFilesToBase64,
-  getCurrentDateString,
   setLineAndResetStops,
   setTransportModeAndResetLineAndStops,
 } from '../utils';
@@ -248,7 +247,6 @@ export const meansOfTransportFormMachine = setup({
   /** @xstate-layout N4IgpgJg5mDOIC5QAoC2BDAxgCwJYDswBKAOlwgBswBiAZQFUAhAWQEkAVAbQAYBdRUAAcA9rFwAXXMPwCQAD0QBGAGzcSAZgCsATnXLlAJi2rN6gDQgAnkoDsmktxsAObstN7FN5eoC+Pi2hYeISk5FTU7ADyAOLRADIAojz8SCAiYpLSsgoIACyKJNpFxSUlFtYIRvZO6rUqBg3c3Fp+ARg4BMRklDTsAIIAGqzJsukSUjKpOSpqWrr6VSbmVojqueoaBk6K3AbOqjYGyq0ggR0hJJDj+FB0TGxcfKOi41lTiJqaBdyKmoaKTmcTkB2nKtnsjhcblqyk83hOZ2CXSukhudAS7AA+uwAEp9ABytAACpEcVjmJEACJJJ6pMaZSagHJ2NSKXKudnqGw7TSAsGVdTaEhOYpOTQ2ZqmZS5BHtJGkCjCdAQAi3CDSMBkfAAN2EAGtNYjOgqlSqbggCLrMOgGckRnSXgzsh8vg5fv9AcCQfztiRcsVnHpuO4bLKgsaSIrlarqGAAE5x4RxkiCCg2gBmSdQJCNFyjZqgFp1wmttr49qEjomzoQn2+7oMAKB3pWlQM9nF20cn20nj8-hA+GEEDgslzxGeGWr7wQAFplA4mkvl8ubPz52Hzl0wmBJ69GfIPkLcgZtMpudovmze6DW7UbH7FGzT9wnA12TKB+PSCjVXunTO2wPq47anmK3DaGKuT8msBS5M4EFit4Ng2OoBifm04Z5qaf4OlObxMqsmi5H6TjrGRhwoV4wb8r8BgOAh5FNCo56bvKJCwAArpgmBwPAeH7jWQEOIYmhgZoiHEbRzQkKY2jBl83C5GKnihv2QA */
   initial: 'editing',
   context: {
-    date: getCurrentDateString(),
     isResponseWanted: false,
     errorMessages: {},
   },

--- a/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
@@ -130,6 +130,7 @@ export const FeedbackForm = ({ state, send }: FeedbackFormProps) => {
               value: date,
             })
           }
+          errorMessage={state.context?.errorMessages['date']?.[0]}
         />
 
         <TimeSelector

--- a/src/page-modules/contact/ticket-control/ticket-control-form-machine.ts
+++ b/src/page-modules/contact/ticket-control/ticket-control-form-machine.ts
@@ -2,7 +2,6 @@ import { assign, fromPromise, setup } from 'xstate';
 import { ticketControlFormEvents } from './events';
 import {
   convertFilesToBase64,
-  getCurrentDateString,
   setBankAccountStatusAndResetBankInformation,
   setLineAndResetStops,
   setTransportModeAndResetLineAndStops,
@@ -325,7 +324,6 @@ export const ticketControlFormMachine = setup({
   id: 'ticketControlForm',
   initial: 'editing',
   context: {
-    date: getCurrentDateString(),
     agreesFirstAgreement: false,
     agreesSecondAgreement: false,
     hasInternationalBankAccount: false,

--- a/src/page-modules/contact/travel-guarantee/forms/refundCarForm.tsx
+++ b/src/page-modules/contact/travel-guarantee/forms/refundCarForm.tsx
@@ -182,6 +182,7 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
               value: date,
             })
           }
+          errorMessage={state.context?.errorMessages['date']?.[0]}
         />
         <TimeSelector
           label={PageText.Contact.input.plannedDepartureTime.label}

--- a/src/page-modules/contact/travel-guarantee/forms/refundTaxiForm.tsx
+++ b/src/page-modules/contact/travel-guarantee/forms/refundTaxiForm.tsx
@@ -168,6 +168,7 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
               value: date,
             })
           }
+          errorMessage={state.context?.errorMessages['date']?.[0]}
         />
 
         <TimeSelector

--- a/src/page-modules/contact/travel-guarantee/travelGuaranteeFormMachine.ts
+++ b/src/page-modules/contact/travel-guarantee/travelGuaranteeFormMachine.ts
@@ -5,7 +5,6 @@ import { ReasonForTransportFailure } from './events';
 import { commonInputValidator, InputErrorMessages } from '../validation';
 import {
   convertFilesToBase64,
-  getCurrentDateString,
   setBankAccountStatusAndResetBankInformation,
   setLineAndResetStops,
   setTransportModeAndResetLineAndStops,
@@ -61,7 +60,7 @@ export type ContextProps = {
   line?: Line | undefined;
   fromStop?: Line['quays'][0] | undefined;
   toStop?: Line['quays'][0] | undefined;
-  date: string;
+  date?: string;
   plannedDepartureTime?: string;
   kilometersDriven?: string;
   fromAddress?: string;
@@ -293,7 +292,6 @@ export const fetchMachine = setup({
   context: {
     isIntialAgreementChecked: false,
     hasInternationalBankAccount: false,
-    date: getCurrentDateString(),
     errorMessages: {},
   },
   states: {

--- a/src/page-modules/contact/utils.ts
+++ b/src/page-modules/contact/utils.ts
@@ -34,9 +34,6 @@ export const convertFilesToBase64 = (
   return Promise.all(filePromises);
 };
 
-export const getCurrentDateString = (): string =>
-  new Date().toISOString().split('T')[0];
-
 export const setTransportModeAndResetLineAndStops = (
   context: any,
   transporMode: TransportModeType,


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/19523

### Background

Currently, the date is automatically set when reporting an incident. This results in several users sloppily specifying the correct date, which is again critical information. 

Date of an incident should be mandatory to provided when needed. The user must specify the date himself.


#### Illustrations
<details>
<summary>screenshots</summary>
<img width="1099" alt="Skjermbilde 2024-11-14 kl  12 53 28" src="https://github.com/user-attachments/assets/89853bd6-6c74-402a-b9f3-325b2073bc86">

</details>

### Proposed solution

- [x] Add error message property to DateSelector. 
- [x] Set `date` to `undefined` in the state machines.
