### PR TITLE
fix: remove property area from contact forms

### DIFF
--- a/src/page-modules/contact/means-of-transport/events.ts
+++ b/src/page-modules/contact/means-of-transport/events.ts
@@ -1,13 +1,10 @@
-import { TranslatedString } from '@atb/translations';
 import { commonEvents } from '../commoneEvents';
 import { Line } from '..';
 
-export type Area = { id: string; name: TranslatedString };
-
 const meansOfTransportSpecificFormEvents = {} as {
   type: 'ON_INPUT_CHANGE';
-  inputName: 'area' | 'formType' | 'isResponseWanted' | 'stop';
-  value: Area | string | boolean | Line['quays'][0] | undefined;
+  inputName: 'formType' | 'isResponseWanted' | 'stop';
+  value: string | boolean | Line['quays'][0] | undefined;
 };
 
 export const meansOfTransportFormEvents = {} as

--- a/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
@@ -45,28 +45,6 @@ export const DriverForm = ({ state, send }: DriverFormProps) => {
         </Typo.p>
 
         <Select
-          label={t(PageText.Contact.input.area.label).toString()}
-          value={state.context.area}
-          valueToId={(option) => option.id}
-          valueToText={(option) => t(option.name)}
-          onChange={(value) => {
-            if (!value) return;
-            send({
-              type: 'ON_INPUT_CHANGE',
-              inputName: 'area',
-              value: value,
-            });
-          }}
-          placeholder={t(PageText.Contact.input.area.optionLabel)}
-          options={PageText.Contact.input.area.options}
-          error={
-            state.context?.errorMessages['area']?.[0]
-              ? t(state.context?.errorMessages['area']?.[0])
-              : undefined
-          }
-        />
-
-        <Select
           label={t(PageText.Contact.input.transportMode.label)}
           value={state.context.transportMode || ''}
           onChange={(value) =>

--- a/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
@@ -44,28 +44,6 @@ export const InjuryForm = ({ state, send }: InjuryFormProps) => {
         </Typo.p>
 
         <Select
-          label={t(PageText.Contact.input.area.label).toString()}
-          value={state.context.area}
-          valueToId={(option) => option.id}
-          valueToText={(option) => t(option.name)}
-          onChange={(value) => {
-            if (!value) return;
-            send({
-              type: 'ON_INPUT_CHANGE',
-              inputName: 'area',
-              value: value,
-            });
-          }}
-          placeholder={t(PageText.Contact.input.area.optionLabel)}
-          options={PageText.Contact.input.area.options}
-          error={
-            state.context?.errorMessages['area']?.[0]
-              ? t(state.context?.errorMessages['area']?.[0])
-              : undefined
-          }
-        />
-
-        <Select
           label={t(PageText.Contact.input.transportMode.label)}
           value={state.context.transportMode || ''}
           onChange={(value) =>

--- a/src/page-modules/contact/means-of-transport/forms/serviceOfferingForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/serviceOfferingForm.tsx
@@ -47,28 +47,6 @@ export const ServiceOfferingForm = ({
         </Typo.p>
 
         <Select
-          label={t(PageText.Contact.input.area.label).toString()}
-          value={state.context.area}
-          valueToId={(option) => option.id}
-          valueToText={(option) => t(option.name)}
-          onChange={(value) => {
-            if (!value) return;
-            send({
-              type: 'ON_INPUT_CHANGE',
-              inputName: 'area',
-              value: value,
-            });
-          }}
-          placeholder={t(PageText.Contact.input.area.optionLabel)}
-          options={PageText.Contact.input.area.options}
-          error={
-            state.context?.errorMessages['area']?.[0]
-              ? t(state.context?.errorMessages['area']?.[0])
-              : undefined
-          }
-        />
-
-        <Select
           label={t(PageText.Contact.input.transportMode.label)}
           value={state.context.transportMode || ''}
           onChange={(value) =>

--- a/src/page-modules/contact/means-of-transport/means-of-transport-form-machine.ts
+++ b/src/page-modules/contact/means-of-transport/means-of-transport-form-machine.ts
@@ -7,7 +7,7 @@ import {
   setLineAndResetStops,
   setTransportModeAndResetLineAndStops,
 } from '../utils';
-import { Area, meansOfTransportFormEvents } from './events';
+import { meansOfTransportFormEvents } from './events';
 
 export enum FormType {
   Driver = 'driver',
@@ -20,7 +20,6 @@ export enum FormType {
 
 type submitInput = {
   formType?: string;
-  areaName?: string;
   transportMode?: string;
   lineName?: string;
   fromStopName?: string;
@@ -38,7 +37,6 @@ type submitInput = {
 
 export type ContextProps = {
   formType?: FormType;
-  area?: Area;
   transportMode?: TransportModeType;
   line?: Line;
   fromStop?: Line['quays'][0];
@@ -58,7 +56,6 @@ export type ContextProps = {
 const setInputToValidate = (context: ContextProps) => {
   const {
     formType,
-    area,
     transportMode,
     line,
     fromStop,
@@ -74,7 +71,6 @@ const setInputToValidate = (context: ContextProps) => {
   switch (formType) {
     case FormType.Driver:
       return {
-        area,
         transportMode,
         line,
         fromStop,
@@ -119,7 +115,6 @@ const setInputToValidate = (context: ContextProps) => {
 
     case FormType.ServiceOffering:
       return {
-        area,
         transportMode,
         line,
         feedback,
@@ -127,7 +122,6 @@ const setInputToValidate = (context: ContextProps) => {
 
     case FormType.Injury:
       return {
-        area,
         transportMode,
         line,
         fromStop,
@@ -194,7 +188,6 @@ export const meansOfTransportFormMachine = setup({
       async ({
         input: {
           formType,
-          areaName,
           transportMode,
           lineName,
           fromStopName,
@@ -220,7 +213,6 @@ export const meansOfTransportFormMachine = setup({
           method: 'POST',
           body: JSON.stringify({
             formType: formType,
-            area: areaName,
             transportMode: transportMode,
             line: lineName,
             fromStop: fromStopName,
@@ -288,7 +280,6 @@ export const meansOfTransportFormMachine = setup({
         input: ({ context }: { context: ContextProps }) => {
           return {
             formType: context.formType,
-            areaName: context.area?.name.no,
             transportMode: context.transportMode,
             lineName: context.line?.name,
             fromStopName: context.fromStop?.name,

--- a/src/page-modules/contact/validation/commonInputValidator.ts
+++ b/src/page-modules/contact/validation/commonInputValidator.ts
@@ -60,11 +60,6 @@ export const commonInputValidator = (context: any) => {
         PageText.Contact.input.bankInformation.SWIFT.errorMessages.empty,
     },
     {
-      inputName: 'area',
-      validCondition: context.area,
-      errorMessage: PageText.Contact.input.area.errorMessages.empty,
-    },
-    {
       inputName: 'transportMode',
       validCondition: context.transportMode,
       errorMessage: PageText.Contact.input.transportMode.errorMessages.empty,

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -1,4 +1,3 @@
-import { Area } from '@atb/page-modules/contact/means-of-transport/events';
 import {
   RefundReason,
   TicketType,
@@ -1390,79 +1389,6 @@ export const Contact = {
           'Feedback is missing',
           'Tilbakemelding manglar',
         ),
-      },
-    },
-    area: {
-      label: _('Område', 'Area', 'Område'),
-      optionLabel: _('Velg område', 'Select area', 'Vel område'),
-      options: [
-        {
-          id: 'rp1',
-          name: _(
-            'Ålesund, Giske, Sula (RP1)',
-            'Ålesund, Giske, Sula (RP1)',
-            'Ålesund, Giske, Sula (RP1)',
-          ),
-        },
-        {
-          id: 'rp2',
-          name: _(
-            'Kristiansund, Averøy, Aure, Smøla (RP2)',
-            'Kristiansund, Averøy, Aure, Smøla (RP2)',
-            'Kristiansund, Averøy, Aure, Smøla (RP2)',
-          ),
-        },
-        {
-          id: 'rp3',
-          name: _(
-            'Molde (unntatt Skåla), Gjemnes (RP3)',
-            'Molde (except Skåla), Gjemnes (RP3)',
-            'Molde (unntatt Skåla), Gjemnes (RP3)',
-          ),
-        },
-        {
-          id: 'rp4',
-          name: _(
-            'Sunnmøre nord (RP4)',
-            'Sunnmøre nord (RP4)',
-            'Sunnmøre nord (RP4)',
-          ),
-        },
-        {
-          id: 'rp5',
-          name: _(
-            'Sunnmøre sør (RP5)',
-            'Sunnmøre sør (RP5)',
-            'Sunnmøre sør (RP5)',
-          ),
-        },
-        {
-          id: 'rp6',
-          name: _(
-            'Sunndalsøra, Surnadal, Trondheim, Oppdal (RP6)',
-            'Sunndalsøra, Surnadal, Trondheim, Oppdal (RP6)',
-            'Sunndalsøra, Surnadal, Trondheim, Oppdal (RP6)',
-          ),
-        },
-        {
-          id: 'rp7',
-          name: _(
-            'Rauma, Vestnes, Skåla (RP7)',
-            'Rauma, Vestnes, Skåla (RP7)',
-            'Rauma, Vestnes, Skåla (RP7)',
-          ),
-        },
-        {
-          id: 'rp8',
-          name: _(
-            'Hustadvika, Midsund, Aukra (RP8)',
-            'Hustadvika, Midsund, Aukra (RP8)',
-            'Hustadvika, Midsund, Aukra (RP8)',
-          ),
-        },
-      ] as Area[],
-      errorMessages: {
-        empty: _('Område mangler', 'Area is missing', 'Område manglar'),
       },
     },
 


### PR DESCRIPTION
### Background
Remove the property `area` from all contact forms, as this property is redunat as the users already are providing information about line and stop place. 

### Conditions for FRAM
- [x] `Area` must be removed from `pureservice-connect` link: https://github.com/mrfylke/pureservice-connect, before merging this PR.  