### PR TITLE
fix: remove validation message when toggling between the input fields

### DIFF
--- a/src/page-modules/contact/utils.ts
+++ b/src/page-modules/contact/utils.ts
@@ -79,5 +79,9 @@ export const setBankAccountStatusAndResetBankInformation = (
     bankAccountNumber: undefined,
     IBAN: undefined,
     SWIFT: undefined,
+    errorMessages: {
+      ...context.errorMessages,
+      bankAccountNumber: [],
+    },
   };
 };


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/19546

### Background
Currently, the validation message for the `bankAccountNumber` input field does not disappear when toggling from highlighting the input field displaying `bankAccountNumber` to displaying the input fields for `SWIFT` and `IBAN`. The validation message should disappear to avoid confusion the users. 

#### Illustrations
<details>
<summary>video</summary>

https://github.com/user-attachments/assets/4790ddf0-d52e-4f33-a7fc-a0b87ec981ac




</details>

### Proposed solution
- [x] Remove the validation message when toggling between input fields for bank information.



