### PR TITLE
fix: update translations of date and time properties in ticket control state machine

### DIFF
--- a/src/page-modules/contact/ticket-control/events.ts
+++ b/src/page-modules/contact/ticket-control/events.ts
@@ -12,7 +12,9 @@ const ticketControlSpecificFormEvents = {} as {
     | 'isAppTicketStorageMode'
     | 'agreesFirstAgreement'
     | 'agreesSecondAgreement'
-    | 'hasInternationalBankAccount';
+    | 'hasInternationalBankAccount'
+    | 'dateOfTicketControl'
+    | 'timeOfTicketControl';
   value: string | boolean;
 };
 

--- a/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
@@ -121,30 +121,32 @@ export const FeedbackForm = ({ state, send }: FeedbackFormProps) => {
         />
 
         <DateSelector
-          label={PageText.Contact.input.date.label}
-          value={state.context.date}
-          onChange={(date) =>
+          label={PageText.Contact.input.date.ticketControl.label}
+          value={state.context.dateOfTicketControl}
+          onChange={(dateOfTicketControl: string) =>
             send({
               type: 'ON_INPUT_CHANGE',
-              inputName: 'date',
-              value: date,
-            })
-          }
-          errorMessage={state.context?.errorMessages['date']?.[0]}
-        />
-
-        <TimeSelector
-          label={PageText.Contact.input.plannedDepartureTime.label}
-          value={state.context.plannedDepartureTime || ''}
-          onChange={(time: string) =>
-            send({
-              type: 'ON_INPUT_CHANGE',
-              inputName: 'plannedDepartureTime',
-              value: time,
+              inputName: 'dateOfTicketControl',
+              value: dateOfTicketControl,
             })
           }
           errorMessage={
-            state.context?.errorMessages['plannedDepartureTime']?.[0]
+            state.context?.errorMessages['dateOfTicketControl']?.[0]
+          }
+        />
+
+        <TimeSelector
+          label={PageText.Contact.input.time.ticketControl.label}
+          value={state.context.timeOfTicketControl || ''}
+          onChange={(timeOfTicketControl: string) =>
+            send({
+              type: 'ON_INPUT_CHANGE',
+              inputName: 'timeOfTicketControl',
+              value: timeOfTicketControl,
+            })
+          }
+          errorMessage={
+            state.context?.errorMessages['timeOfTicketControl']?.[0]
           }
         />
       </SectionCard>

--- a/src/page-modules/contact/ticket-control/ticket-control-form-machine.ts
+++ b/src/page-modules/contact/ticket-control/ticket-control-form-machine.ts
@@ -42,8 +42,8 @@ type submitInput = {
   lineName?: string;
   fromStopName?: string;
   toStopName?: string;
-  date?: string;
-  plannedDepartureTime?: string;
+  dateOfTicketControl?: string;
+  timeOfTicketControl?: string;
 
   // PostponePayment
   invoiceNumber?: string;
@@ -81,8 +81,8 @@ export type ContextProps = {
   line?: Line | undefined;
   fromStop?: Line['quays'][0] | undefined;
   toStop?: Line['quays'][0] | undefined;
-  date?: string;
-  plannedDepartureTime?: string;
+  dateOfTicketControl?: string;
+  timeOfTicketControl?: string;
 
   // PostponePayment
   invoiceNumber?: string;
@@ -137,8 +137,8 @@ const setInputToValidate = (context: ContextProps) => {
     line,
     fromStop,
     toStop,
-    date,
-    plannedDepartureTime,
+    dateOfTicketControl,
+    timeOfTicketControl,
   } = context;
 
   switch (formType) {
@@ -167,8 +167,8 @@ const setInputToValidate = (context: ContextProps) => {
         line,
         fromStop,
         toStop,
-        date,
-        plannedDepartureTime,
+        dateOfTicketControl,
+        timeOfTicketControl,
         feedback,
         firstName,
         lastName,
@@ -270,8 +270,8 @@ export const ticketControlFormMachine = setup({
           lineName,
           fromStopName,
           toStopName,
-          date,
-          plannedDepartureTime,
+          dateOfTicketControl,
+          timeOfTicketControl,
           invoiceNumber,
         },
       }: {
@@ -304,8 +304,8 @@ export const ticketControlFormMachine = setup({
             line: lineName,
             fromStop: fromStopName,
             toStop: toStopName,
-            date: date,
-            plannedDepartureTime: plannedDepartureTime,
+            dateOfTicketControl: dateOfTicketControl,
+            timeOfTicketControl: timeOfTicketControl,
             invoiceNumber: invoiceNumber,
           }),
         })
@@ -386,8 +386,8 @@ export const ticketControlFormMachine = setup({
           lineName: context.line?.name,
           fromStopName: context.fromStop?.name,
           toStopName: context.toStop?.name,
-          date: context.date,
-          plannedDepartureTime: context.plannedDepartureTime,
+          dateOfTicketControl: context.dateOfTicketControl,
+          timeOfTicketControl: context.timeOfTicketControl,
           invoiceNumber: context.invoiceNumber,
         }),
 

--- a/src/page-modules/contact/validation/commonInputValidator.ts
+++ b/src/page-modules/contact/validation/commonInputValidator.ts
@@ -85,10 +85,22 @@ export const commonInputValidator = (context: any) => {
       errorMessage: PageText.Contact.input.date.errorMessages.empty,
     },
     {
+      inputName: 'dateOfTicketControl',
+      validCondition: context.dateOfTicketControl,
+      errorMessage:
+        PageText.Contact.input.date.ticketControl.errorMessages.empty,
+    },
+    {
       inputName: 'plannedDepartureTime',
       validCondition: context.plannedDepartureTime,
       errorMessage:
         PageText.Contact.input.plannedDepartureTime.errorMessages.empty,
+    },
+    {
+      inputName: 'timeOfTicketControl',
+      validCondition: context.timeOfTicketControl,
+      errorMessage:
+        PageText.Contact.input.time.ticketControl.errorMessages.empty,
     },
     {
       inputName: 'reasonForTransportFailure',

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -1223,14 +1223,14 @@ export const Contact = {
 
       ticketControl: {
         label: _(
-          'Dato billettkontroll ble gjennomført',
-          'Date ticket control was carried out',
-          'Dato billettkontroll blei gjennomført',
+          'Dato for billettkontrollen',
+          'Date for the ticket control',
+          'Dato for billettkontrollen',
         ),
         errorMessages: {
           empty: _(
             'Oppgi dato for når billettkontrollen ble gjennomført',
-            'Please provide the date when the ticket control was carried out.',
+            'Please provide the date for when the ticket control was carried out.',
             'Oppgi dato for når billettkontrollen blei gjennomført',
           ),
         },
@@ -1254,14 +1254,14 @@ export const Contact = {
     time: {
       ticketControl: {
         label: _(
-          'Tidspunkt billettkontroll ble gjennomført',
-          'Time ticket control was carried out',
-          'Tidspunkt billettkontroll blei gjennomført',
+          'Tidspunktet for billettkontrollen',
+          'The time of the ticket control',
+          'Tidspunktet for billettkontroll',
         ),
         errorMessages: {
           empty: _(
             'Oppgi tidspunkt for når billettkontrollen ble gjennomført',
-            'Please provide the time when the ticket control was carried out.',
+            'Please provide the time for when the ticket control was carried out.',
             'Oppgi tidspunktet for når billettkontrollen blei gjennomført',
           ),
         },

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -1224,7 +1224,7 @@ export const Contact = {
       ticketControl: {
         label: _(
           'Dato for billettkontrollen',
-          'Date for the ticket control',
+          'The date of the ticket control',
           'Dato for billettkontrollen',
         ),
         errorMessages: {

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -1220,6 +1220,21 @@ export const Contact = {
       errorMessages: {
         empty: _('Velg dato', 'Select date', 'Vel dato'),
       },
+
+      ticketControl: {
+        label: _(
+          'Dato billettkontroll ble gjennomført',
+          'Date ticket control was crried out',
+          'Dato billettkontroll blei gjennomført',
+        ),
+        errorMessages: {
+          empty: _(
+            'Oppgi dato for når billettkontrollen ble gjennomført',
+            'Please provide the date when the ticket control was carried out.',
+            'Oppgi dato for når billettkontrollen blei gjennomført',
+          ),
+        },
+      },
     },
     plannedDepartureTime: {
       label: _(
@@ -1235,6 +1250,24 @@ export const Contact = {
         ),
       },
     },
+
+    time: {
+      ticketControl: {
+        label: _(
+          'Tidspunkt billettkontroll ble gjennomført',
+          'Time ticket control was carried out',
+          'Tidspunkt billettkontroll blei gjennomført',
+        ),
+        errorMessages: {
+          empty: _(
+            'Oppgi tidspunkt for når billettkontrollen ble gjennomført',
+            'Please provide the time when the ticket control was carried out.',
+            'Oppgi tidspunktet for når billettkontrollen blei gjennomført',
+          ),
+        },
+      },
+    },
+
     reasonForTransportFailure: {
       label: _('Mulige valg', 'Options', 'Moglege val'),
       optionLabel: _('Velg årsak', 'Select reason', 'Vel åtsak'),

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -1224,7 +1224,7 @@ export const Contact = {
       ticketControl: {
         label: _(
           'Dato billettkontroll ble gjennomført',
-          'Date ticket control was crried out',
+          'Date ticket control was carried out',
           'Dato billettkontroll blei gjennomført',
         ),
         errorMessages: {


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/19548

### Background
Currently, the same labels are used for all date and time input fields in the contact form. Both labels can be formulated to be more specific, making it easier for the user to understand which date and which time should be given.

This PR updates the translations, and specifies the property names to be more descriptive. 

#### Illustrations
<details>
<summary>screenshots</summary>
<img width="1098" alt="Skjermbilde 2024-11-18 kl  13 32 00" src="https://github.com/user-attachments/assets/bfc4e9f3-ba21-4652-8615-47923182f770">


</details>

### Proposed solution
- Add the two new objects `date` and `time`  in `contact.ts`. These objects will contain translations which better describes the context of the forms they are being used in.   
- Specify property names in state machine to be more descriptive. 