### PR TITLE
fix: add condition to avoid runtime error

### DIFF
--- a/src/page-modules/contact/components/form/time-selector.tsx
+++ b/src/page-modules/contact/components/form/time-selector.tsx
@@ -30,7 +30,7 @@ export default function TimeSelector({
       <TimeField
         value={parsedValue}
         onChange={(change) => {
-          if (change === null) return;
+          if (!change) return;
           onChange(change.toString());
         }}
         hourCycle={24}

--- a/src/page-modules/contact/components/form/time-selector.tsx
+++ b/src/page-modules/contact/components/form/time-selector.tsx
@@ -29,7 +29,10 @@ export default function TimeSelector({
       <Label>{t(label)}</Label>
       <TimeField
         value={parsedValue}
-        onChange={(change) => onChange(change.toString())}
+        onChange={(change) => {
+          if (change === null) return;
+          onChange(change.toString());
+        }}
         hourCycle={24}
         shouldForceLeadingZeros
         className={style.timeSelector}


### PR DESCRIPTION
### What is wrong, and what is expected behavior?
A runtime error appears when updating the time using the `TimeSelector`. 

### How to replicate:
- First, enter a time. For example: `11:00`.
- Second, attempt updating the time på for `:00` by tapping the the delete button. 

### Illustration
<details>
<Summary>screenshots</Summary>
<img width="1071" alt="Skjermbilde 2024-11-18 kl  15 23 42" src="https://github.com/user-attachments/assets/cde2304b-a24f-4b67-a61d-1b450f623315">

</details>
