### PR TITLE
fix: make fromStop and toStop input fields optional in ticket control feedback form

### DIFF
--- a/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
@@ -13,7 +13,6 @@ import {
   Select,
   SearchableSelect,
   getLineOptions,
-  getStopOptions,
   DateSelector,
   TimeSelector,
 } from '../../components';
@@ -77,46 +76,6 @@ export const FeedbackForm = ({ state, send }: FeedbackFormProps) => {
           error={
             state.context?.errorMessages['line']?.[0] &&
             t(state.context?.errorMessages['line']?.[0])
-          }
-        />
-
-        <SearchableSelect
-          label={t(PageText.Contact.input.fromStop.label)}
-          value={state.context.fromStop}
-          placeholder={t(PageText.Contact.input.fromStop.optionLabel)}
-          isDisabled={!state.context.line}
-          options={getStopOptions(getQuaysByLine(state.context.line?.id ?? ''))}
-          onChange={(value) => {
-            send({
-              type: 'ON_INPUT_CHANGE',
-              inputName: 'fromStop',
-              value: value,
-            });
-          }}
-          error={
-            state.context?.errorMessages['fromStop']?.[0]
-              ? t(state.context?.errorMessages['fromStop']?.[0])
-              : undefined
-          }
-        />
-
-        <SearchableSelect
-          label={t(PageText.Contact.input.toStop.label)}
-          value={state.context.toStop}
-          placeholder={t(PageText.Contact.input.toStop.optionLabel)}
-          isDisabled={!state.context.line}
-          options={getStopOptions(getQuaysByLine(state.context.line?.id ?? ''))}
-          onChange={(value) => {
-            send({
-              type: 'ON_INPUT_CHANGE',
-              inputName: 'toStop',
-              value: value,
-            });
-          }}
-          error={
-            state.context?.errorMessages['toStop']?.[0]
-              ? t(state.context?.errorMessages['toStop']?.[0])
-              : undefined
           }
         />
 

--- a/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
@@ -13,6 +13,7 @@ import {
   Select,
   SearchableSelect,
   getLineOptions,
+  getStopOptions,
   DateSelector,
   TimeSelector,
 } from '../../components';
@@ -77,6 +78,36 @@ export const FeedbackForm = ({ state, send }: FeedbackFormProps) => {
             state.context?.errorMessages['line']?.[0] &&
             t(state.context?.errorMessages['line']?.[0])
           }
+        />
+
+        <SearchableSelect
+          label={t(PageText.Contact.input.fromStop.optionalLabel)}
+          value={state.context.fromStop}
+          placeholder={t(PageText.Contact.input.fromStop.optionLabel)}
+          isDisabled={!state.context.line}
+          options={getStopOptions(getQuaysByLine(state.context.line?.id ?? ''))}
+          onChange={(value) => {
+            send({
+              type: 'ON_INPUT_CHANGE',
+              inputName: 'fromStop',
+              value: value,
+            });
+          }}
+        />
+
+        <SearchableSelect
+          label={t(PageText.Contact.input.toStop.optionalLabel)}
+          value={state.context.toStop}
+          placeholder={t(PageText.Contact.input.toStop.optionLabel)}
+          isDisabled={!state.context.line}
+          options={getStopOptions(getQuaysByLine(state.context.line?.id ?? ''))}
+          onChange={(value) => {
+            send({
+              type: 'ON_INPUT_CHANGE',
+              inputName: 'toStop',
+              value: value,
+            });
+          }}
         />
 
         <DateSelector

--- a/src/page-modules/contact/ticket-control/ticket-control-form-machine.ts
+++ b/src/page-modules/contact/ticket-control/ticket-control-form-machine.ts
@@ -40,8 +40,6 @@ type submitInput = {
   // Feedback
   transportMode?: string;
   lineName?: string;
-  fromStopName?: string;
-  toStopName?: string;
   dateOfTicketControl?: string;
   timeOfTicketControl?: string;
 
@@ -79,8 +77,6 @@ export type ContextProps = {
   //Feedback
   transportMode?: TransportModeType | undefined;
   line?: Line | undefined;
-  fromStop?: Line['quays'][0] | undefined;
-  toStop?: Line['quays'][0] | undefined;
   dateOfTicketControl?: string;
   timeOfTicketControl?: string;
 
@@ -135,8 +131,6 @@ const setInputToValidate = (context: ContextProps) => {
     SWIFT,
     transportMode,
     line,
-    fromStop,
-    toStop,
     dateOfTicketControl,
     timeOfTicketControl,
   } = context;
@@ -165,8 +159,6 @@ const setInputToValidate = (context: ContextProps) => {
       return {
         transportMode,
         line,
-        fromStop,
-        toStop,
         dateOfTicketControl,
         timeOfTicketControl,
         feedback,
@@ -268,8 +260,6 @@ export const ticketControlFormMachine = setup({
           SWIFT,
           transportMode,
           lineName,
-          fromStopName,
-          toStopName,
           dateOfTicketControl,
           timeOfTicketControl,
           invoiceNumber,
@@ -302,8 +292,6 @@ export const ticketControlFormMachine = setup({
             attachments: base64EncodedAttachments,
             transportMode: transportMode,
             line: lineName,
-            fromStop: fromStopName,
-            toStop: toStopName,
             dateOfTicketControl: dateOfTicketControl,
             timeOfTicketControl: timeOfTicketControl,
             invoiceNumber: invoiceNumber,
@@ -384,8 +372,6 @@ export const ticketControlFormMachine = setup({
           SWIFT: context.SWIFT,
           transportMode: context.transportMode,
           lineName: context.line?.name,
-          fromStopName: context.fromStop?.name,
-          toStopName: context.toStop?.name,
           dateOfTicketControl: context.dateOfTicketControl,
           timeOfTicketControl: context.timeOfTicketControl,
           invoiceNumber: context.invoiceNumber,

--- a/src/page-modules/contact/ticket-control/ticket-control-form-machine.ts
+++ b/src/page-modules/contact/ticket-control/ticket-control-form-machine.ts
@@ -40,6 +40,8 @@ type submitInput = {
   // Feedback
   transportMode?: string;
   lineName?: string;
+  fromStopName?: string;
+  toStopName?: string;
   dateOfTicketControl?: string;
   timeOfTicketControl?: string;
 
@@ -77,6 +79,8 @@ export type ContextProps = {
   //Feedback
   transportMode?: TransportModeType | undefined;
   line?: Line | undefined;
+  fromStop?: Line['quays'][0] | undefined;
+  toStop?: Line['quays'][0] | undefined;
   dateOfTicketControl?: string;
   timeOfTicketControl?: string;
 
@@ -260,6 +264,8 @@ export const ticketControlFormMachine = setup({
           SWIFT,
           transportMode,
           lineName,
+          fromStopName,
+          toStopName,
           dateOfTicketControl,
           timeOfTicketControl,
           invoiceNumber,
@@ -292,6 +298,8 @@ export const ticketControlFormMachine = setup({
             attachments: base64EncodedAttachments,
             transportMode: transportMode,
             line: lineName,
+            fromStop: fromStopName,
+            toStop: toStopName,
             dateOfTicketControl: dateOfTicketControl,
             timeOfTicketControl: timeOfTicketControl,
             invoiceNumber: invoiceNumber,
@@ -372,6 +380,8 @@ export const ticketControlFormMachine = setup({
           SWIFT: context.SWIFT,
           transportMode: context.transportMode,
           lineName: context.line?.name,
+          fromStopName: context.fromStop?.name,
+          toStopName: context.toStop?.name,
           dateOfTicketControl: context.dateOfTicketControl,
           timeOfTicketControl: context.timeOfTicketControl,
           invoiceNumber: context.invoiceNumber,

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -879,6 +879,11 @@ export const Contact = {
 
     fromStop: {
       label: _('Fra holdeplass/kai', 'From stop/harbor', 'Frå haldeplass/kai'),
+      optionalLabel: _(
+        'Velg holdeplass/kai (valgfritt)',
+        'Select stop/harbor (optinal)',
+        'Vel haldeplass/kai (valfritt)',
+      ),
       optionLabel: _(
         'Velg holdeplass/kai',
         'Select stop/harbor',
@@ -895,6 +900,11 @@ export const Contact = {
 
     toStop: {
       label: _('Til holdeplass/kai', 'To stop/harbor', 'Til haldeplass/kai'),
+      optionalLabel: _(
+        'Velg holdeplass/kai (valgfritt)',
+        'Select stop/harbor (optinal)',
+        'Vel haldeplass/kai (valfritt)',
+      ),
       optionLabel: _(
         'Velg holdeplass/kai',
         'Select stop/harbor',


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/19559

### Background
Feedback from fram:

##### Billettkontroll
Ønsker ikke å kreve holdeplasser for billettkontroll skjema. Altså:
    - Må ha linje
    - Må ha tidspunkt
    - Ikke holdeplasser


#### Illustrations
<details>
<summary>screenshots</summary>

![Skjermbilde 2024-11-22 kl  12 54 24](https://github.com/user-attachments/assets/a77b15be-331f-4f0e-a627-b14eba578118)



</details>

### Proposed solution
Make `fromStop` and `toStop` input fields optional. 