### PR TITLE
fix: update attachments to be optional in app forms

### DIFF
--- a/src/page-modules/contact/ticketing/ticketingStateMachine.ts
+++ b/src/page-modules/contact/ticketing/ticketingStateMachine.ts
@@ -99,7 +99,6 @@ export type TicketingContextType = {
 const setInputsToValidate = (context: TicketingContextType) => {
   const {
     formType,
-    attachments,
     firstName,
     lastName,
     email,
@@ -124,7 +123,6 @@ const setInputsToValidate = (context: TicketingContextType) => {
   const commonAppFields = {
     formType,
     question,
-    attachments,
     firstName,
     lastName,
     email,


### PR DESCRIPTION
Remove attachments from inputs to validate, as attachments should optional to include.