### PR TITLE
fix: ensure that situation icons are only displayed during the validity period

### DIFF
--- a/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/index.tsx
@@ -6,7 +6,10 @@ import { formatTripDuration } from '@atb/utils/date';
 import { flatMap } from 'lodash';
 import { getNoticesForLeg } from './utils';
 import { RailReplacementBusMessage } from './rail-replacement-bus';
-import { SituationOrNoticeIcon } from '@atb/modules/situations';
+import {
+  isSituationValidAtDate,
+  SituationOrNoticeIcon,
+} from '@atb/modules/situations';
 import { isSubModeBoat } from '@atb/modules/transport-mode';
 import { ColorIcon } from '@atb/components/icon';
 
@@ -28,6 +31,9 @@ export function TripPatternHeader({
   );
 
   const startModeAndPlaceText = getStartModeAndPlaceText(tripPattern, t);
+  const situations = flatMap(tripPattern.legs, (leg) => leg.situations).filter(
+    isSituationValidAtDate(new Date()),
+  );
 
   return (
     <header className={style.header}>
@@ -52,7 +58,7 @@ export function TripPatternHeader({
       <RailReplacementBusMessage tripPattern={tripPattern} />
 
       <SituationOrNoticeIcon
-        situations={flatMap(tripPattern.legs, (leg) => leg.situations)}
+        situations={situations}
         notices={flatMap(tripPattern.legs, getNoticesForLeg)}
         accessibilityLabel={startModeAndPlaceText}
         cancellation={isCancelled}


### PR DESCRIPTION
### What is wrong, and what is expected behavior?
Currently, the situation icon is displayed when, even though the situation message it self is not displayed.  

### How to replicate:
<img width="1031" alt="Skjermbilde 2024-11-25 kl  13 05 42" src="https://github.com/user-attachments/assets/83a84720-0a5b-4649-83cc-791f7dda4e37">


#### App version: 
#### OS: 

### Illustration
<details>
<Summary>screenshots/video</Summary>

<img width="1069" alt="Skjermbilde 2024-11-25 kl  13 05 34" src="https://github.com/user-attachments/assets/76d0e630-27b9-4588-b499-a53df7cd9226">


</details>

### Solution
Use the function `isSituationValidAtDate(new Date())` to ensure that icon is only displayed for situation within the validity period.  
