### PR TITLE
fix: avoid opening new tab when clicking on link to contact form

### DIFF
--- a/src/layouts/shared/footer.tsx
+++ b/src/layouts/shared/footer.tsx
@@ -17,7 +17,7 @@ type SomeLink = {
   title: string;
 };
 
-const { urls, fylkeskommune } = getOrgData();
+const { orgId, urls, fylkeskommune } = getOrgData();
 
 export default function Footer({ withoutSettings = false }: FooterProps) {
   const { isDarkMode, toggleDarkmode } = useTheme();
@@ -92,7 +92,7 @@ export default function Footer({ withoutSettings = false }: FooterProps) {
                 <li>
                   <a
                     href={getConfigUrl(urls.supportUrl, language)}
-                    target="_blank"
+                    target={orgId === 'fram' ? undefined : '_blank'}
                     rel="noreferrer"
                   >
                     {t(

--- a/src/layouts/shared/footer.tsx
+++ b/src/layouts/shared/footer.tsx
@@ -17,7 +17,7 @@ type SomeLink = {
   title: string;
 };
 
-const { orgId, urls, fylkeskommune } = getOrgData();
+const { urls, fylkeskommune } = getOrgData();
 
 export default function Footer({ withoutSettings = false }: FooterProps) {
   const { isDarkMode, toggleDarkmode } = useTheme();
@@ -92,7 +92,11 @@ export default function Footer({ withoutSettings = false }: FooterProps) {
                 <li>
                   <a
                     href={getConfigUrl(urls.supportUrl, language)}
-                    target={orgId === 'fram' ? undefined : '_blank'}
+                    target={
+                      isExternalUrl(getConfigUrl(urls.supportUrl, language))
+                        ? '_blank'
+                        : undefined
+                    }
                     rel="noreferrer"
                   >
                     {t(
@@ -246,4 +250,14 @@ function LanguageSelections() {
       )}
     </>
   );
+}
+
+function isExternalUrl(url: string) {
+  try {
+    const currentHostname = window.location.hostname;
+    const urlHostname = new URL(url).hostname;
+    return urlHostname !== currentHostname;
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
Avoid opening a new TAB when clicking on the link in the footer to the new contact form.