### PR TITLE
fix: situations for assistant page 

### DIFF
--- a/src/page-modules/assistant/details/trip-section/index.tsx
+++ b/src/page-modules/assistant/details/trip-section/index.tsx
@@ -14,7 +14,6 @@ import WalkSection from './walk-section';
 import { ColorIcon } from '@atb/components/icon';
 import { MessageBox } from '@atb/components/message-box';
 import {
-  isSituationValidAtDate,
   SituationMessageBox,
   SituationOrNoticeIcon,
 } from '@atb/modules/situations';
@@ -147,16 +146,14 @@ export default function TripSection({
           </TripRow>
         )}
 
-        {leg.situations
-          .filter(isSituationValidAtDate(new Date()))
-          .map((situation) => (
-            <TripRow
-              key={situation.id}
-              rowLabel={<SituationOrNoticeIcon situation={situation} />}
-            >
-              <SituationMessageBox noStatusIcon situation={situation} />
-            </TripRow>
-          ))}
+        {leg.situations.map((situation) => (
+          <TripRow
+            key={situation.id}
+            rowLabel={<SituationOrNoticeIcon situation={situation} />}
+          >
+            <SituationMessageBox noStatusIcon situation={situation} />
+          </TripRow>
+        ))}
 
         {leg.notices.map(
           (notice) =>

--- a/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/index.tsx
@@ -6,10 +6,7 @@ import { formatTripDuration } from '@atb/utils/date';
 import { flatMap } from 'lodash';
 import { getNoticesForLeg } from './utils';
 import { RailReplacementBusMessage } from './rail-replacement-bus';
-import {
-  isSituationValidAtDate,
-  SituationOrNoticeIcon,
-} from '@atb/modules/situations';
+import { SituationOrNoticeIcon } from '@atb/modules/situations';
 import { isSubModeBoat } from '@atb/modules/transport-mode';
 import { ColorIcon } from '@atb/components/icon';
 
@@ -31,9 +28,6 @@ export function TripPatternHeader({
   );
 
   const startModeAndPlaceText = getStartModeAndPlaceText(tripPattern, t);
-  const situations = flatMap(tripPattern.legs, (leg) => leg.situations).filter(
-    isSituationValidAtDate(new Date()),
-  );
 
   return (
     <header className={style.header}>
@@ -58,7 +52,7 @@ export function TripPatternHeader({
       <RailReplacementBusMessage tripPattern={tripPattern} />
 
       <SituationOrNoticeIcon
-        situations={situations}
+        situations={flatMap(tripPattern.legs, (leg) => leg.situations)}
         notices={flatMap(tripPattern.legs, getNoticesForLeg)}
         accessibilityLabel={startModeAndPlaceText}
         cancellation={isCancelled}


### PR DESCRIPTION
Situations are not shown correctly on the assistant page. These changes should only be applied to the departure pages. 