### PR TITLE
fix: add a new exception to travelguarantee

### DIFF
--- a/src/page-modules/contact/travel-guarantee/index.tsx
+++ b/src/page-modules/contact/travel-guarantee/index.tsx
@@ -45,24 +45,22 @@ const TravelGuaranteeContent = () => {
           )}
         </Typo.p>
 
-        <Typo.p textType="body__primary">
-          {t(
-            PageText.Contact.travelGuarantee.agreement.travelGuaranteeExceptions
-              .minimumTimeToNextDeparture,
-          )}
-        </Typo.p>
-
-        <Typo.p textType="body__primary">
-          {t(
-            PageText.Contact.travelGuarantee.agreement.travelGuaranteeExceptions
-              .externalFactors,
-          )}
-        </Typo.p>
         <ul className={style.rules__list}>
-          {PageText.Contact.travelGuarantee.agreement.travelGuaranteeExceptions.examples.map(
-            (example: TranslatedString, index: number) => (
+          {PageText.Contact.travelGuarantee.agreement.travelGuaranteeExceptions.exceptions.map(
+            (exception, index) => (
               <li key={index}>
-                <Typo.p textType="body__primary">{t(example)}</Typo.p>
+                <Typo.p textType="body__primary">{t(exception.text)}</Typo.p>
+                {exception.examples.length > 0 && (
+                  <ul className={style.rules__list}>
+                    {exception.examples.map(
+                      (example: TranslatedString, exampleIndex: number) => (
+                        <li key={exampleIndex}>
+                          <Typo.p textType="body__primary">{t(example)}</Typo.p>
+                        </li>
+                      ),
+                    )}
+                  </ul>
+                )}
               </li>
             ),
           )}

--- a/src/page-modules/contact/travel-guarantee/index.tsx
+++ b/src/page-modules/contact/travel-guarantee/index.tsx
@@ -38,33 +38,37 @@ const TravelGuaranteeContent = () => {
           {t(PageText.Contact.travelGuarantee.agreement.ticketRefundText)}
         </Typo.p>
 
-        <Typo.p textType="heading__component">
-          {t(
-            PageText.Contact.travelGuarantee.agreement.travelGuaranteeExceptions
-              .label,
-          )}
-        </Typo.p>
+        <div>
+          <Typo.p textType="heading__component">
+            {t(
+              PageText.Contact.travelGuarantee.agreement
+                .travelGuaranteeExceptions.label,
+            )}
+          </Typo.p>
 
-        <ul className={style.rules__list}>
-          {PageText.Contact.travelGuarantee.agreement.travelGuaranteeExceptions.exceptions.map(
-            (exception, index) => (
-              <li key={index}>
-                <Typo.p textType="body__primary">{t(exception.text)}</Typo.p>
-                {exception.examples.length > 0 && (
-                  <ul className={style.rules__list}>
-                    {exception.examples.map(
-                      (example: TranslatedString, exampleIndex: number) => (
-                        <li key={exampleIndex}>
-                          <Typo.p textType="body__primary">{t(example)}</Typo.p>
-                        </li>
-                      ),
-                    )}
-                  </ul>
-                )}
-              </li>
-            ),
-          )}
-        </ul>
+          <ul className={style.rules__list}>
+            {PageText.Contact.travelGuarantee.agreement.travelGuaranteeExceptions.exceptions.map(
+              (exception, index) => (
+                <li key={index}>
+                  <Typo.p textType="body__primary">{t(exception.text)}</Typo.p>
+                  {exception.examples.length > 0 && (
+                    <ul className={style.rules__list}>
+                      {exception.examples.map(
+                        (example: TranslatedString, exampleIndex: number) => (
+                          <li key={exampleIndex}>
+                            <Typo.p textType="body__primary">
+                              {t(example)}
+                            </Typo.p>
+                          </li>
+                        ),
+                      )}
+                    </ul>
+                  )}
+                </li>
+              ),
+            )}
+          </ul>
+        </div>
 
         <Typo.p textType="body__primary">
           {t(

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -202,47 +202,61 @@ export const Contact = {
           'I kva tilfelle gjeld ikkje reisegarantien?',
         ),
 
-        minimumTimeToNextDeparture: _(
-          'Reisegarantien gjelder ikke dersom det er 20 minutter eller mindre til neste avgang i henhold til rutetabellen.',
-          'The travel guarantee does not apply if there are 20 minutes or less until the next departure according to the timetable.',
-          'Reisegarantien gjeld ikkje dersom det er 20 minutt eller mindre til neste avgang i følgje rutetabellen.',
-        ),
-
-        externalFactors: _(
-          'Reisegarantien gjelder heller ikke hvis forsinkelsen eller innstillingen skyldes forhold utenfor kontrollen til FRAM eller operatøren. Dette inkluderer situasjoner som (for eksempel):',
-          'The travel guarantee also does not apply if the delay or cancellation is due to circumstances beyond the control of FRAM or the operator. These are cases such as (for example):',
-          'Reisegarantien gjeld heller ikkje dersom forseinkinga eller innstillinga skjer på grunn av forhold utanfor kontrollen til FRAM eller operatøren. Dette er tilfelle som (for eksempel):',
-        ),
-
-        examples: [
-          _(
-            'offentlige påbud og forbud',
-            'public orders and prohibitions',
-            'offentlege påbod og forbod',
-          ),
-          _(
-            'streik og lignende',
-            'strikes and similar situations',
-            'streik og liknande',
-          ),
-          _('naturkatastrofer', 'natural disasters', 'naturkatastrofar'),
-          _(
-            'ekstraordinære værforhold',
-            'extraordinary weather conditions',
-            'ekstraordinære verforhold',
-          ),
-          _(
-            'vegarbeid eller uforutsette problemer med kjøreveien',
-            'roadworks or unforeseen issues with the road',
-            'vegarbeid eller uførutsette problem med køyrevegen',
-          ),
-          _(
-            'større arrangementer eller andre trafikale forhold som i stor grad rammer kollektivtrafikken',
-            'major events or other traffic conditions that significantly affect public transportation',
-            'større arrangement eller andre trafikale forhold som i stor grad rammar kollektivtrafikken',
-          ),
-          _('pandemi', 'pandemic', 'pandemi'),
+        exceptions: [
+          {
+            text: _(
+              'Reisegarantien gjelder ikke for fergene. Reisegarantien gjelder heller ikke for flybussen i Ålesund eller andre kommersielle busslinjer.',
+              'The travel guarantee does not apply to the ferries. The travel guarantee also does not apply to the airport bus in Ålesund or other commercial bus lines.',
+              'Reisegarantien gjeld ikkje for ferjene. Reisegarantien gjeld heller ikkje for flybussen i Ålesund eller andre kommersielle busslinjer.',
+            ),
+            examples: [],
+          },
+          {
+            text: _(
+              'Reisegarantien gjelder ikke dersom det er 20 minutter eller mindre til neste avgang i henhold til rutetabellen.',
+              'The travel guarantee does not apply if there are 20 minutes or less until the next departure according to the timetable.',
+              'Reisegarantien gjeld ikkje dersom det er 20 minutt eller mindre til neste avgang i følgje rutetabellen.',
+            ),
+            examples: [],
+          },
+          {
+            text: _(
+              'Reisegarantien gjelder heller ikke hvis forsinkelsen eller innstillingen skyldes forhold utenfor kontrollen til FRAM eller operatøren. Dette inkluderer situasjoner som (for eksempel):',
+              'The travel guarantee also does not apply if the delay or cancellation is due to circumstances beyond the control of FRAM or the operator. These are cases such as (for example):',
+              'Reisegarantien gjeld heller ikkje dersom forseinkinga eller innstillinga skjer på grunn av forhold utanfor kontrollen til FRAM eller operatøren. Dette er tilfelle som (for eksempel):',
+            ),
+            examples: [
+              _(
+                'offentlige påbud og forbud',
+                'public orders and prohibitions',
+                'offentlege påbod og forbod',
+              ),
+              _(
+                'streik og lignende',
+                'strikes and similar situations',
+                'streik og liknande',
+              ),
+              _('naturkatastrofer', 'natural disasters', 'naturkatastrofar'),
+              _(
+                'ekstraordinære værforhold',
+                'extraordinary weather conditions',
+                'ekstraordinære verforhold',
+              ),
+              _(
+                'vegarbeid eller uforutsette problemer med kjøreveien',
+                'roadworks or unforeseen issues with the road',
+                'vegarbeid eller uførutsette problem med køyrevegen',
+              ),
+              _(
+                'større arrangementer eller andre trafikale forhold som i stor grad rammer kollektivtrafikken',
+                'major events or other traffic conditions that significantly affect public transportation',
+                'større arrangement eller andre trafikale forhold som i stor grad rammar kollektivtrafikken',
+              ),
+              _('pandemi', 'pandemic', 'pandemi'),
+            ],
+          },
         ],
+
         exclusion: _(
           'Reisegarantien omfatter heller ikke tap som følge av forsinkelsen, som for eksempel mistet tannlegetime, jobbavtale, togavgang, fergeavgang eller flyavgang.',
           'The travel guarantee does not cover losses resulting from the delay, such as missed dental appointments, job agreements, train departures, ferry departures or flight departures.',


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/19617

### Background
###### Feedback from FRAM:
Etter overskriften «I hvilke tilfeller gjelder ikke reisegarantien», skal det settes inn denne setningen:
«Reisegarantien gjeld ikkje for ferjene. Reisegarantien gjeld heller ikke for flybussen i Ålesund eller andre kommersielle busslinjer.»


#### Illustrations
<details>
<summary>screenshots</summary>

<img width="1118" alt="Skjermbilde 2024-11-27 kl  11 54 33" src="https://github.com/user-attachments/assets/fecd72e0-1260-4ca6-a541-63af63dd724d">


</details>


### Proposed solution
- [x] Add a new exception to the travel guarantee page.
- [x] Display exceptions as bullet point list.




