### PR TITLE
style: remove excessive padding around list

### DIFF
--- a/src/page-modules/contact/contact.module.css
+++ b/src/page-modules/contact/contact.module.css
@@ -10,7 +10,6 @@
 }
 
 .rules__list {
-  padding: token('spacing.medium');
   padding-left: token('spacing.xLarge');
 }
 


### PR DESCRIPTION
This PR removes the padding from the css class `.rules_list`. This is tiny change, but in my opinion looks better.   

| Before  |  After  |   
|---|---|
| <img width="789" alt="Skjermbilde 2024-11-27 kl  12 03 59" src="https://github.com/user-attachments/assets/62de4216-619b-4b87-a4fd-c0f1f3d2f894"> | <img width="774" alt="Skjermbilde 2024-11-27 kl  12 04 12" src="https://github.com/user-attachments/assets/23ef72e2-24ad-4089-99ae-61d205375b5c"> | 
| <img width="822" alt="Skjermbilde 2024-11-27 kl  12 04 47" src="https://github.com/user-attachments/assets/55b62c49-7bfe-4322-a8dd-3f3c38943c9e"> | <img width="822" alt="Skjermbilde 2024-11-27 kl  12 04 36" src="https://github.com/user-attachments/assets/ce8a5c6e-3742-4cd8-9862-a552c098fa5d"> |
