### PR TITLE
chore: make radio button text more descriptive 

### DIFF
--- a/src/page-modules/contact/ticketing/forms/refund/otherTicketRefund.tsx
+++ b/src/page-modules/contact/ticketing/forms/refund/otherTicketRefund.tsx
@@ -1,5 +1,5 @@
 import { PageText, useTranslation } from '@atb/translations';
-import { ticketingFormEvents } from '../../events';
+import { ticketingFormEvents, TicketType } from '../../events';
 import { TicketingContextType } from '../../ticketingStateMachine';
 import { Typo } from '@atb/components/typography';
 import {
@@ -28,8 +28,8 @@ const RefundSection = ({ state, send }: RefundSectionProps) => {
       <Select
         label={t(PageText.Contact.input.refundReason.label)}
         value={state.context.ticketType}
-        valueToId={(option) => option.id}
-        valueToText={(option) => t(option.name)}
+        valueToId={(option: TicketType) => option.id}
+        valueToText={(option: TicketType) => t(option.name)}
         onChange={(value) => {
           if (!value) return;
           send({

--- a/src/page-modules/contact/travel-guarantee/forms/refundCarForm.tsx
+++ b/src/page-modules/contact/travel-guarantee/forms/refundCarForm.tsx
@@ -2,7 +2,10 @@ import { PageText, useTranslation } from '@atb/translations';
 import { useLines } from '../../lines/use-lines';
 import { TransportModeType } from '../../types';
 import { Line } from '../..';
-import { TravelGuaranteeFormEvents } from '../events';
+import {
+  ReasonForTransportFailure,
+  TravelGuaranteeFormEvents,
+} from '../events';
 import { ContextProps } from '../travelGuaranteeFormMachine';
 import {
   SectionCard,
@@ -208,7 +211,7 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
             send({
               type: 'ON_INPUT_CHANGE',
               inputName: 'reasonForTransportFailure',
-              value: value,
+              value: value as ReasonForTransportFailure,
             });
           }}
           placeholder={t(
@@ -224,8 +227,8 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
                 )
               : undefined
           }
-          valueToId={(option) => option.id}
-          valueToText={(option) => t(option.name)}
+          valueToId={(option: ReasonForTransportFailure) => option.id}
+          valueToText={(option: ReasonForTransportFailure) => t(option.name)}
         />
       </SectionCard>
 

--- a/src/page-modules/contact/travel-guarantee/forms/refundTaxiForm.tsx
+++ b/src/page-modules/contact/travel-guarantee/forms/refundTaxiForm.tsx
@@ -2,7 +2,10 @@ import { PageText, useTranslation } from '@atb/translations';
 import { useLines } from '../../lines/use-lines';
 import { TransportModeType } from '../../types';
 import { Line } from '../..';
-import { TravelGuaranteeFormEvents } from '../events';
+import {
+  ReasonForTransportFailure,
+  TravelGuaranteeFormEvents,
+} from '../events';
 import { ContextProps } from '../travelGuaranteeFormMachine';
 import { Typo } from '@atb/components/typography';
 import {
@@ -195,7 +198,7 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
             send({
               type: 'ON_INPUT_CHANGE',
               inputName: 'reasonForTransportFailure',
-              value: value,
+              value: value as ReasonForTransportFailure,
             });
           }}
           placeholder={t(
@@ -211,8 +214,8 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
                 )
               : undefined
           }
-          valueToId={(option) => option.id}
-          valueToText={(option) => t(option.name)}
+          valueToId={(option: ReasonForTransportFailure) => option.id}
+          valueToText={(option: ReasonForTransportFailure) => t(option.name)}
         />
       </SectionCard>
       <SectionCard title={t(PageText.Contact.input.feedback.optionalTitle)}>

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -4,8 +4,9 @@ import {
 } from '@atb/page-modules/contact/ticketing/events';
 import { ReasonForTransportFailure } from '@atb/page-modules/contact/travel-guarantee/events';
 import { translation as _ } from '@atb/translations/commons';
+import { orgSpecificTranslations } from '../utils';
 
-export const Contact = {
+const ContactInternal = {
   contactPageLayout: {
     title: _(
       'Hva kan vi hjelpe deg med?',
@@ -52,7 +53,7 @@ export const Contact = {
         ),
 
         app: {
-          title: _('App', 'App', 'App'),
+          title: _('Mobilapp', 'Mobile App', 'Mobilapp'),
         },
       },
 
@@ -1433,3 +1434,21 @@ export const Contact = {
     },
   },
 };
+
+export const Contact = orgSpecificTranslations(ContactInternal, {
+  fram: {
+    ticketControl: {
+      feeComplaint: {
+        ticketStorage: {
+          app: {
+            title: _(
+              'Mobilapp (f.eks. FRAM, Entur)',
+              'Mobile App (e.g., FRAM, Entur)',
+              'Mobilapp (f.eks. FRAM, Entur)',
+            ),
+          },
+        },
+      },
+    },
+  },
+});

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -53,7 +53,7 @@ const ContactInternal = {
         ),
 
         app: {
-          title: _('Mobilapp', 'Mobile App', 'Mobilapp'),
+          title: _('Mobilapp', 'Mobile app', 'Mobilapp'),
         },
       },
 
@@ -1443,7 +1443,7 @@ export const Contact = orgSpecificTranslations(ContactInternal, {
           app: {
             title: _(
               'Mobilapp (f.eks. FRAM, Entur)',
-              'Mobile App (e.g., FRAM, Entur)',
+              'Mobile app (e.g. FRAM, Entur)',
               'Mobilapp (f.eks. FRAM, Entur)',
             ),
           },


### PR DESCRIPTION
Close https://github.com/AtB-AS/kundevendt/issues/19625#issue-2704445305

### Background
Currently in the contact form, `App` or `Travelcard` are the only available options for when asking the user to specify where his ticket is stored.  `App` is too vague and can lead tho misunderstandings. A better solution would be to display the name of the app, or a list of names if the ticket can be stored on several apps. 

#### Illustrations
<details>
<summary>screenshots</summary>

<img width="1007" alt="Skjermbilde 2024-11-29 kl  10 53 06" src="https://github.com/user-attachments/assets/b465197e-1075-4b49-ae8c-c14dc9cec275">


</details>

### Proposed solution
Change  the radio button text from `App` to the app name(s)  where the ticket can be found.  
 