### PR TITLE
fix: ensure case-insensitive matching of selected IDs in custom selector

### DIFF
--- a/src/page-modules/contact/components/form/select.tsx
+++ b/src/page-modules/contact/components/form/select.tsx
@@ -39,7 +39,9 @@ export default function CustomeSelect<T>({
   const showError = !!error;
 
   const findItemFromOptions = (key: string) =>
-    options.find((option) => valueToId(option) === key.toLowerCase());
+    options.find(
+      (option) => valueToId(option).toLowerCase() === key.toLowerCase(),
+    );
 
   const onChangeInternal = (key: Key | null) => {
     if (key === null) return;


### PR DESCRIPTION
 Add toLowerCase() to avoid undefined values in case of upper case letters being used in the ids.