### PR TITLE
fix: fix cors for reverse endpoint

### DIFF
--- a/src/pages/api/departures/reverse.ts
+++ b/src/pages/api/departures/reverse.ts
@@ -31,5 +31,18 @@ export default handlerWithDepartureClient<ReverseApiReturnType>(
     },
   },
   // @TODO FIX THIS!
-  ['https://frammr.no', /\.frammr.no$/],
+  [
+    'https://frammr.no',
+    /\.frammr.no$/,
+    'https://reisnordland.no',
+    /\.reisnordland.no$/,
+    'https://reisnordland.com',
+    /\.reisnordland.com$/,
+    'https://svipper.no',
+    /\.svipper.no$/,
+    'https://vkt.no',
+    /\.vkt.no$/,
+    'https://farte.no',
+    /\.farte.no$/,
+  ],
 );


### PR DESCRIPTION
Reused the same CORS origins that are used for auto-complete. This might be the reason for CORS error for geolocation.
