### PR TITLE
feat: add refund reason to appTicketRefund form

### DIFF
--- a/src/page-modules/contact/refund/forms/refund-ticket/appTicketRefund.tsx
+++ b/src/page-modules/contact/refund/forms/refund-ticket/appTicketRefund.tsx
@@ -1,7 +1,8 @@
 import { PageText, useTranslation } from '@atb/translations';
-import { SectionCard, Input } from '../../../components';
+import { SectionCard, Input, Textarea, FileInput } from '../../../components';
 import { RefundContextProps } from '../../refundFormMachine';
 import { RefundFormEvents } from '../../events';
+import { Typo } from '@atb/components/typography';
 
 type AppTicketRefundProps = {
   state: { context: RefundContextProps };
@@ -53,6 +54,36 @@ export const AppTicketRefund = ({ state, send }: AppTicketRefundProps) => {
               (bulletPoint) => t(bulletPoint),
             ),
         }}
+      />
+
+      <Typo.p textType="body__primary">
+        {t(PageText.Contact.input.refundReason.question)}
+      </Typo.p>
+
+      <Textarea
+        value={state.context.refundReason || ''}
+        onChange={(e) =>
+          send({
+            type: 'ON_INPUT_CHANGE',
+            inputName: 'refundReason',
+            value: e.target.value,
+          })
+        }
+        error={
+          state.context.errorMessages['refundReason']?.[0] &&
+          t(state.context.errorMessages['refundReason']?.[0]).toString()
+        }
+      />
+      <FileInput
+        name="attachments"
+        onChange={(files) => {
+          send({
+            type: 'ON_INPUT_CHANGE',
+            inputName: 'attachments',
+            value: files,
+          });
+        }}
+        label={t(PageText.Contact.input.feedback.attachment)}
       />
     </SectionCard>
   );

--- a/src/page-modules/contact/refund/refundFormMachine.ts
+++ b/src/page-modules/contact/refund/refundFormMachine.ts
@@ -196,6 +196,7 @@ const setInputToValidate = (context: RefundContextProps) => {
         formType,
         customerNumber,
         orderId,
+        refundReason,
       };
 
     case FormType.OtherTicketRefund:


### PR DESCRIPTION
Close https://github.com/AtB-AS/kundevendt/issues/19703

### Background
Utvid skjema med et tesktfelt for å beskrive hvorfor man ønsker refusjon for billettkjøpet. 

#### Illustrations
<details>
<summary>screenshots/video/figma</summary>

<img width="1015" alt="Skjermbilde 2025-01-08 kl  13 38 49" src="https://github.com/user-attachments/assets/b9d6b3bb-8dc2-4037-9989-8d8119ed2087" />

</details>

#### Proposed solution
- [x] Add text field to specify the refund reason + the option to upload attachments.  

