### PR TITLE
feat: force Farte light theme

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# What ORG to activate (nfk | atb | fram | troms)
+# What ORG to activate (nfk | atb | fram | troms | vkt | farte)
 NEXT_PUBLIC_PLANNER_ORG_ID=atb
 
 # Specifies what environment to build locally (dev | staging | prod)

--- a/orgs/farte.json
+++ b/orgs/farte.json
@@ -9,7 +9,8 @@
   "fylkeskommune": {
     "logoSrc": "/telemark_fylkeskommune.svg",
     "logoSrcDark": "/telemark_fylkeskommune.svg",
-    "name": "Telemark fylkeskommune"
+    "name": "Telemark fylkeskommune",
+    "forceTheme": "light"
   },
 
   "urls": {

--- a/orgs/schema-validation.json
+++ b/orgs/schema-validation.json
@@ -19,6 +19,10 @@
             },
             "replaceTitleWithLogoInHeader": {
               "type": "boolean"
+            },
+            "forceTheme": {
+              "type": "string",
+              "enum": ["light", "dark"]
             }
           },
           "required": ["name", "logoSrc", "logoSrcDark"],

--- a/src/layouts/shared/footer.tsx
+++ b/src/layouts/shared/footer.tsx
@@ -41,6 +41,8 @@ export default function Footer({ withoutSettings = false }: FooterProps) {
     },
   ].filter(Boolean) as SomeLink[];
 
+  const isForcingTheme = fylkeskommune?.forceTheme !== undefined;
+
   return (
     <footer className={style.footer}>
       <div className={style.footer__content}>
@@ -117,28 +119,33 @@ export default function Footer({ withoutSettings = false }: FooterProps) {
 
               <ul className={style.footer__linkList}>
                 <LanguageSelections />
-                <li>
-                  <button
-                    className={style.buttonLink}
-                    onClick={() => toggleDarkmode(!isDarkMode)}
-                  >
-                    {isDarkMode
-                      ? t(
-                          ModuleText.Layout.base.footer.sections.settings
-                            .toggleLightMode,
-                        )
-                      : t(
-                          ModuleText.Layout.base.footer.sections.settings
-                            .toggleDarkMode,
-                        )}
-                  </button>
-                </li>
+                {!isForcingTheme && (
+                  <li>
+                    <button
+                      className={style.buttonLink}
+                      onClick={() => toggleDarkmode(!isDarkMode)}
+                    >
+                      {isDarkMode
+                        ? t(
+                            ModuleText.Layout.base.footer.sections.settings
+                              .toggleLightMode,
+                          )
+                        : t(
+                            ModuleText.Layout.base.footer.sections.settings
+                              .toggleDarkMode,
+                          )}
+                    </button>
+                  </li>
+                )}
               </ul>
 
               <p className={style.footer__cookieWarning}>
                 {t(
-                  ModuleText.Layout.base.footer.sections.settings
-                    .cookiesWarning,
+                  !isForcingTheme
+                    ? ModuleText.Layout.base.footer.sections.settings
+                        .cookiesWarning
+                    : ModuleText.Layout.base.footer.sections.settings
+                        .languageCookiesWarning,
                 )}
               </p>
             </section>

--- a/src/modules/org-data/index.tsx
+++ b/src/modules/org-data/index.tsx
@@ -28,6 +28,7 @@ export type OrgData = {
     logoSrc: string;
     logoSrcDark: string;
     replaceTitleWithLogoInHeader?: boolean;
+    forceTheme?: 'light' | 'dark';
   };
 
   urls: {

--- a/src/modules/theme/index.ts
+++ b/src/modules/theme/index.ts
@@ -1,6 +1,6 @@
 import { createThemesFor, ThemeVariant } from '@atb-as/theme';
 import { useDarkmodeCookie } from '@atb/modules/cookies';
-import { currentOrg, WEBSHOP_ORGS } from '@atb/modules/org-data';
+import { currentOrg, getOrgData, WEBSHOP_ORGS } from '@atb/modules/org-data';
 import { useEffect } from 'react';
 
 export type {
@@ -42,6 +42,10 @@ export function useTheme() {
 
 export function useDarkMode(): [boolean, (value: boolean) => void] {
   const [enabledState, setEnabledState] = useDarkmodeCookie();
+  const forceTheme = getOrgData().fylkeskommune?.forceTheme;
+  if (forceTheme) {
+    return [forceTheme == 'dark', () => {}];
+  }
   // If enabledState is defined use it, otherwise fallback to prefersDarkMode.
   // This allows user to override OS level setting on our website.
   const enabled = enabledState ?? false;

--- a/src/translations/modules/layout.ts
+++ b/src/translations/modules/layout.ts
@@ -62,7 +62,7 @@ export const LayoutInternal = {
           ),
           cookiesWarning: _(
             '* Overstyring av språk og utseende krever bruk av cookies.',
-            '* Overriding language and appearance require cookies.',
+            '* Overriding language and appearance requires cookies.',
             '* Overstyring av språk og utsjånad krev bruk av cookies.',
           ),
         },

--- a/src/translations/modules/layout.ts
+++ b/src/translations/modules/layout.ts
@@ -65,6 +65,11 @@ export const LayoutInternal = {
             '* Overriding language and appearance requires cookies.',
             '* Overstyring av språk og utsjånad krev bruk av cookies.',
           ),
+          languageCookiesWarning: _(
+            '* Overstyring av språk krever bruk av cookies.',
+            '* Overriding language requires cookies.',
+            '* Overstyring av språk krev bruk av cookies.',
+          ),
         },
       },
       bottomLinks: {


### PR DESCRIPTION
Adds an optional `forceTheme` option to `OrgData`, which disables dark theme toggling and forces the specified theme.

This is useful for organizations without a dark theme (or light theme), like Farte.

Without `"forceTheme"` in `farte.json`:

<img width="343" alt="image" src="https://github.com/user-attachments/assets/2c50791f-f39e-4811-8583-9b99db307754" />

With `"forceTheme": "light"` in `farte.json`:

<img width="343" alt="image" src="https://github.com/user-attachments/assets/691b6041-dc05-44c2-9d94-47b8935494d9" />

