### PR TITLE
fix: specify post body size limit for contact form api  

### DIFF
--- a/src/pages/api/contact/contact-api-config.ts
+++ b/src/pages/api/contact/contact-api-config.ts
@@ -1,0 +1,7 @@
+export const defaultConfig = {
+  api: {
+    bodyParser: {
+      sizeLimit: '50mb',
+    },
+  },
+};

--- a/src/pages/api/contact/means-of-transport.ts
+++ b/src/pages/api/contact/means-of-transport.ts
@@ -2,6 +2,11 @@ import { tryResult } from '@atb/modules/api-server';
 import { handlerWithContactFormClient } from '@atb/page-modules/contact/server';
 import { ContactApiReturnType } from '@atb/page-modules/contact/server/types';
 import { NextApiRequest, NextApiResponse } from 'next';
+import { defaultConfig } from './contact-api-config';
+
+export const config = {
+  ...defaultConfig,
+};
 
 export default handlerWithContactFormClient<ContactApiReturnType>({
   async POST(req: NextApiRequest, res: NextApiResponse, { client, ok }) {

--- a/src/pages/api/contact/refund.ts
+++ b/src/pages/api/contact/refund.ts
@@ -2,6 +2,11 @@ import { tryResult } from '@atb/modules/api-server';
 import { handlerWithContactFormClient } from '@atb/page-modules/contact/server';
 import { ContactApiReturnType } from '@atb/page-modules/contact/server/types';
 import { NextApiRequest, NextApiResponse } from 'next';
+import { defaultConfig } from './contact-api-config';
+
+export const config = {
+  ...defaultConfig,
+};
 
 export default handlerWithContactFormClient<ContactApiReturnType>({
   async POST(req: NextApiRequest, res: NextApiResponse, { client, ok }) {

--- a/src/pages/api/contact/ticket-control.ts
+++ b/src/pages/api/contact/ticket-control.ts
@@ -2,6 +2,11 @@ import { tryResult } from '@atb/modules/api-server';
 import { handlerWithContactFormClient } from '@atb/page-modules/contact/server';
 import { ContactApiReturnType } from '@atb/page-modules/contact/server/types';
 import { NextApiRequest, NextApiResponse } from 'next';
+import { defaultConfig } from './contact-api-config';
+
+export const config = {
+  ...defaultConfig,
+};
 
 export default handlerWithContactFormClient<ContactApiReturnType>({
   async POST(req: NextApiRequest, res: NextApiResponse, { client, ok }) {

--- a/src/pages/api/contact/ticketing.ts
+++ b/src/pages/api/contact/ticketing.ts
@@ -2,6 +2,11 @@ import { tryResult } from '@atb/modules/api-server';
 import { handlerWithContactFormClient } from '@atb/page-modules/contact/server';
 import { ContactApiReturnType } from '@atb/page-modules/contact/server/types';
 import { NextApiRequest, NextApiResponse } from 'next';
+import { defaultConfig } from './contact-api-config';
+
+export const config = {
+  ...defaultConfig,
+};
 
 export default handlerWithContactFormClient<ContactApiReturnType>({
   async POST(req: NextApiRequest, res: NextApiResponse, { client, ok }) {


### PR DESCRIPTION
Close https://github.com/AtB-AS/kundevendt/issues/19769

### What is wrong, and what is expected behavior?
When posting a form 1MB or larger, the status code 413 appears. This is due to NEXT default body size limit which is set to 1MB. When posting forms with attachments, the size of the body can easily exceed 1MB. When this happens, the screen start to buffer.

### Proposed solution
- [x] Specify the body size limit to `50mb`, the same limit set in `pureservice-connect`.