### PR TITLE
feat: quay public code prefix

### DIFF
--- a/src/page-modules/assistant/details/index.tsx
+++ b/src/page-modules/assistant/details/index.tsx
@@ -95,6 +95,7 @@ export function AssistantDetails({ tripPattern }: AssistantDetailsProps) {
             interchangeDetails={getInterchangeDetails(
               tripPattern.legs,
               leg.interchangeTo?.toServiceJourney.id,
+              t
             )}
             legWaitDetails={getLegWaitDetails(leg, tripPattern.legs[index + 1])}
           />

--- a/src/page-modules/assistant/details/trip-section/index.tsx
+++ b/src/page-modules/assistant/details/trip-section/index.tsx
@@ -100,6 +100,7 @@ export default function TripSection({
           >
             <Typo.p textType="body__primary">
               {getPlaceName(
+                t,
                 leg.fromPlace.name,
                 leg.fromPlace.quay?.name,
                 leg.fromPlace.quay?.publicCode,
@@ -213,6 +214,7 @@ export default function TripSection({
           >
             <Typo.p textType="body__primary">
               {getPlaceName(
+                t,
                 leg.toPlace.name,
                 leg.toPlace.quay?.name,
                 leg.toPlace.quay?.publicCode,

--- a/src/page-modules/assistant/details/trip-section/interchange-section.tsx
+++ b/src/page-modules/assistant/details/trip-section/interchange-section.tsx
@@ -4,7 +4,7 @@ import { MonoIcon } from '@atb/components/icon';
 import { MessageBox } from '@atb/components/message-box';
 import { TripPatternWithDetails } from '../../server/journey-planner/validators';
 import { getPlaceName } from '../utils';
-import { PageText, useTranslation } from '@atb/translations';
+import { PageText, TranslateFunction, useTranslation } from '@atb/translations';
 
 import style from './trip-section.module.css';
 import { secondsToDuration } from '@atb/utils/date';
@@ -96,6 +96,7 @@ function useInterchangeTextTranslation({
 export function getInterchangeDetails(
   legs: TripPatternWithDetails['legs'],
   id: string | undefined,
+  t: TranslateFunction,
 ): InterchangeDetails | undefined {
   if (!id) return undefined;
   const interchangeLeg = legs.find(
@@ -106,6 +107,7 @@ export function getInterchangeDetails(
     return {
       publicCode: interchangeLeg.line.publicCode,
       fromPlace: getPlaceName(
+        t,
         interchangeLeg.fromPlace.name,
         interchangeLeg.fromPlace.quay?.name,
         interchangeLeg.fromPlace.quay?.publicCode,

--- a/src/page-modules/assistant/details/utils.ts
+++ b/src/page-modules/assistant/details/utils.ts
@@ -1,19 +1,23 @@
 import { fromCETToLocalTime } from '@atb/utils/date';
 import { parseTripQueryString } from '../server/journey-planner';
+import { TranslateFunction } from '@atb/translations';
+import { Assistant } from '@atb/translations/pages';
 
-export function formatQuayName(quayName?: string, publicCode?: string | null) {
+export function formatQuayName(t: TranslateFunction, quayName?: string, publicCode?: string | null) {
   if (!quayName) return;
   if (!publicCode) return quayName;
-  return `${quayName} ${publicCode}`;
+  const prefix = t(Assistant.details.quayPublicCodePrefix);
+  return `${quayName}${prefix ? prefix : ' '}${publicCode}`;
 }
 
 export function getPlaceName(
+  t: TranslateFunction,
   placeName?: string,
   quayName?: string,
   publicCode?: string | null,
 ): string {
   const fallback = placeName ?? '';
-  return quayName ? formatQuayName(quayName, publicCode) ?? fallback : fallback;
+  return quayName ? formatQuayName(t, quayName, publicCode) ?? fallback : fallback;
 }
 
 export function formatLineName(

--- a/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/__tests__/trip-pattern-header.test.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/__tests__/trip-pattern-header.test.tsx
@@ -73,31 +73,70 @@ describe('trip pattern header', function () {
   });
 
   it('should get quay name from quay', () => {
-    const quayName = getQuayName({
-      publicCode: '',
-      name: 'Quay',
-      id: 'NSR:Quay:1',
-      situations: [],
+    const Test = function () {
+      const { t } = useTranslation();
+      const quayName = getQuayName({
+        publicCode: '',
+        name: 'Quay',
+        id: 'NSR:Quay:1',
+        situations: [],
+      }, t);
+      return <div>{quayName}</div>;
+    };
+
+    customRender(<Test />, {
+      providerProps: {
+        initialCookies: {
+          darkmode: false,
+          language: 'no',
+        },
+      },
     });
 
-    expect(quayName).toBe('Quay');
+    expect(screen.getByText('Quay')).toBeInTheDocument();
   });
 
   it('should get quay name with public code from quay', () => {
-    const quayName = getQuayName({
-      publicCode: '1',
-      name: 'Quay',
-      id: 'NSR:Quay:1',
-      situations: [],
+    const Test = function () {
+      const { t } = useTranslation();
+      const quayName = getQuayName({
+        publicCode: '1',
+        name: 'Quay',
+        id: 'NSR:Quay:1',
+        situations: [],
+      }, t);
+      return <div>{quayName}</div>;
+    };
+
+    customRender(<Test />, {
+      providerProps: {
+        initialCookies: {
+          darkmode: false,
+          language: 'no',
+        },
+      },
     });
 
-    expect(quayName).toBe('Quay 1');
+    expect(screen.getByText('Quay 1')).toBeInTheDocument();
   });
 
   it('should get quay name from trip', () => {
-    const quayName = getQuayName(tripPatternFixture.legs[0].fromPlace.quay);
+    const Test = function () {
+      const { t } = useTranslation();
+      const quayName = getQuayName(tripPatternFixture.legs[0].fromPlace.quay, t);
+      return <div>{quayName}</div>;
+    };
 
-    expect(quayName).toBe('From 1');
+    customRender(<Test />, {
+      providerProps: {
+        initialCookies: {
+          darkmode: false,
+          language: 'no',
+        },
+      },
+    });
+
+    expect(screen.getByText('From 1')).toBeInTheDocument();
   });
 
   it('should get start mode and start place from trip', () => {

--- a/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/index.tsx
@@ -9,6 +9,7 @@ import { RailReplacementBusMessage } from './rail-replacement-bus';
 import { SituationOrNoticeIcon } from '@atb/modules/situations';
 import { isSubModeBoat } from '@atb/modules/transport-mode';
 import { ColorIcon } from '@atb/components/icon';
+import { Assistant } from '@atb/translations/pages';
 
 type TripPatternHeaderProps = {
   tripPattern: TripPattern;
@@ -70,9 +71,9 @@ export function getStartModeAndPlaceText(
 
   if (tripPattern.legs[0].mode === 'foot' && tripPattern.legs[1]) {
     startLeg = tripPattern.legs[1];
-    tmpStartName = getQuayName(startLeg.fromPlace.quay);
+    tmpStartName = getQuayName(startLeg.fromPlace.quay, t);
   } else if (tripPattern.legs[0].mode !== 'foot') {
-    tmpStartName = getQuayName(startLeg.fromPlace.quay);
+    tmpStartName = getQuayName(startLeg.fromPlace.quay, t);
   }
 
   const startName: string =
@@ -117,8 +118,12 @@ export function getStartModeAndPlaceText(
   }
 }
 
-export function getQuayName(quay: Quay | null): string | null {
+export function getQuayName(
+  quay: Quay | null,
+  t: TranslateFunction,
+): string | null {
   if (!quay) return null;
   if (!quay.publicCode) return quay.name;
-  return `${quay.name} ${quay.publicCode}`;
+  const prefix = t(Assistant.trip.tripPattern.quayPublicCodePrefix);
+  return `${quay.name}${prefix ? prefix : ' '}${quay.publicCode}`;
 }

--- a/src/page-modules/assistant/trip/trip-pattern/utils.ts
+++ b/src/page-modules/assistant/trip/trip-pattern/utils.ts
@@ -30,7 +30,7 @@ export const tripSummary = (
   let startText = '';
 
   if (tripPattern.legs[0]?.mode === 'foot' && tripPattern.legs[1]) {
-    const quayName = getQuayName(tripPattern.legs[1]?.fromPlace.quay);
+    const quayName = getQuayName(tripPattern.legs[1]?.fromPlace.quay, t);
 
     {
       quayName
@@ -43,7 +43,7 @@ export const tripSummary = (
         : undefined;
     }
   } else {
-    const quayName = getQuayName(tripPattern.legs[0]?.fromPlace.quay);
+    const quayName = getQuayName(tripPattern.legs[0]?.fromPlace.quay, t);
     if (quayName) {
       startText = t(
         PageText.Assistant.trip.tripSummary.header.title(

--- a/src/page-modules/departures/details/estimated-call-rows.tsx
+++ b/src/page-modules/departures/details/estimated-call-rows.tsx
@@ -133,6 +133,7 @@ type EstimatedCallRowProps = {
   collapseButton: JSX.Element | null;
   situations: Situation[];
 };
+
 function EstimatedCallRow({
   call,
   mode,
@@ -171,7 +172,7 @@ function EstimatedCallRow({
         href={`/departures/${call.quay.stopPlace.id}`}
       >
         <Typo.p textType="body__primary">
-          {formatQuayName(call.quay.name, call.quay.publicCode)}
+          {formatQuayName(t, call.quay.name, call.quay.publicCode)}
         </Typo.p>
         {!call.forAlighting && !call.metadata.isStartOfServiceJourney && (
           <Typo.p textType="body__secondary" className={style.boardingInfo}>

--- a/src/page-modules/departures/details/utils.ts
+++ b/src/page-modules/departures/details/utils.ts
@@ -1,5 +1,7 @@
 import { ServiceJourneyData } from '../server/journey-planner/validators';
 import { EstimatedCallMetadata, EstimatedCallWithMetadata } from '../types';
+import { TranslateFunction } from '@atb/translations';
+import { Departures } from '@atb/translations/pages';
 
 export function addMetadataToEstimatedCalls(
   estimatedCalls: ServiceJourneyData['estimatedCalls'][0][],
@@ -58,8 +60,13 @@ export function getSituationsToShowForCall(
   );
 }
 
-export function formatQuayName(quayName?: string, publicCode?: string | null) {
+export function formatQuayName(
+  t: TranslateFunction,
+  quayName?: string,
+  publicCode?: string | null,
+) {
   if (!quayName) return;
   if (!publicCode) return quayName;
-  return `${quayName} ${publicCode}`;
+  const prefix = t(Departures.details.quayPublicCodePrefix);
+  return `${quayName}${prefix ? prefix : ' '}${publicCode}`;
 }

--- a/src/page-modules/departures/stop-place/index.tsx
+++ b/src/page-modules/departures/stop-place/index.tsx
@@ -29,13 +29,17 @@ import { nextDepartures } from '../client';
 import style from './stop-place.module.css';
 import { formatDestinationDisplay } from '../utils';
 import { useTheme } from '@atb/modules/theme';
+import { formatQuayName } from '@atb/page-modules/departures/details/utils';
 
 export type StopPlaceProps = {
   departures: DepartureData;
 };
+
 export function StopPlace({ departures }: StopPlaceProps) {
   const { t } = useTranslation();
-  const { color: {interactive}} = useTheme();
+  const {
+    color: { interactive },
+  } = useTheme();
   const router = useRouter();
   const [isHoveringRefreshButton, setIsHoveringRefreshButton] = useState(false);
 
@@ -135,9 +139,7 @@ export function EstimatedCallList({ quay }: EstimatedCallListProps) {
             className={style.textColor__secondary}
             textType="body__secondary--bold"
           >
-            {quay.publicCode
-              ? [quay.name, quay.publicCode].join(' ')
-              : quay.name}
+            {formatQuayName(t, quay.name, quay.publicCode)}
           </Typo.h3>
           {quay.description && (
             <Typo.span

--- a/src/translations/dictionary.ts
+++ b/src/translations/dictionary.ts
@@ -57,7 +57,7 @@ const dictionary = {
   readMore: _('Les mer', 'Read more', `Les meir`),
   close: _('Lukk', 'Close', 'Lukk'),
   listConcatWord: _('og', 'and', 'og'),
-  via: _('via', 'via', 'via'),
+  via: _('via', 'via', 'via')
 };
 
 export default orgSpecificTranslations(dictionary, {

--- a/src/translations/pages/assistant.ts
+++ b/src/translations/pages/assistant.ts
@@ -106,6 +106,7 @@ const AssistantInternal = {
           _(`Fra ${place}`, `From ${place}`, `Frå ${place}`),
         unknownPlace: _('ukjent', 'unknown', 'ukjend'),
       },
+      quayPublicCodePrefix: _('', '', ''),
       details: _('Detaljer', 'Details', 'Detaljar'),
       hasSituationsTip: _(
         'Denne reisen har driftsmeldinger. Se detaljer for mer info',
@@ -353,6 +354,7 @@ const AssistantInternal = {
           `${duration} reisetid`,
         ),
     },
+    quayPublicCodePrefix: _('', '', ''),
     mapSection: {
       travelTime: (time: string) =>
         _(
@@ -527,4 +529,14 @@ export const Assistant = orgSpecificTranslations(AssistantInternal, {
       },
     },
   },
+  vkt: {
+    details: {
+      quayPublicCodePrefix: _(' - Spor ', ' - Track ', ' - Spor '),
+    },
+    trip: {
+      tripPattern: {
+        quayPublicCodePrefix: _(' - Spor ', ' - Track ', ' - Spor '),
+      }
+    }
+  }
 });

--- a/src/translations/pages/departures.ts
+++ b/src/translations/pages/departures.ts
@@ -1,6 +1,7 @@
 import { translation as _ } from '@atb/translations/commons';
+import { orgSpecificTranslations } from '@atb/translations/utils';
 
-export const Departures = {
+const DeparturesInternal = {
   title: _('Finn avganger', 'Find departures', 'Finn avgangar'),
   titleAddress: (place: string) =>
     _(`Stopp nært ${place}`, `Stops near ${place}`, `Stopp nær ${place}`),
@@ -117,6 +118,7 @@ export const Departures = {
       'Back to travel suggestion',
       'Tilbake til reiseforslag',
     ),
+    quayPublicCodePrefix: _('', '', ''),
     lastPassedStop: (stopPlaceName: string, time: string) =>
       _(
         `Passerte ${stopPlaceName} kl. ${time}`,
@@ -156,3 +158,11 @@ export const Departures = {
     },
   },
 };
+
+export const Departures = orgSpecificTranslations(DeparturesInternal, {
+  vkt: {
+    details: {
+      quayPublicCodePrefix: _(' - Spor ', ' - Track ', ' - Spor '),
+    },
+  },
+});


### PR DESCRIPTION
VKT requested a prefix for quay public codes, similar to entur.no

> entur.no
>
> <img width="214" alt="image" src="https://github.com/user-attachments/assets/0f62f1b1-13fb-4b81-be58-426cb57eecc1" />

#### Before
<img height="150" alt="image" src="https://github.com/user-attachments/assets/59215e87-7c9e-4789-9e3e-1220c2621774" />


#### After
<img height="150" alt="image" src="https://github.com/user-attachments/assets/bbbed195-2f1b-4535-a716-b13dfe3426c8" />


