### PR TITLE
fix: update config for contact api endpoints 

### DIFF
--- a/src/pages/api/contact/contact-api-config.ts
+++ b/src/pages/api/contact/contact-api-config.ts
@@ -1,7 +1,0 @@
-export const defaultConfig = {
-  api: {
-    bodyParser: {
-      sizeLimit: '50mb',
-    },
-  },
-};

--- a/src/pages/api/contact/means-of-transport.ts
+++ b/src/pages/api/contact/means-of-transport.ts
@@ -2,10 +2,13 @@ import { tryResult } from '@atb/modules/api-server';
 import { handlerWithContactFormClient } from '@atb/page-modules/contact/server';
 import { ContactApiReturnType } from '@atb/page-modules/contact/server/types';
 import { NextApiRequest, NextApiResponse } from 'next';
-import { defaultConfig } from './contact-api-config';
 
 export const config = {
-  ...defaultConfig,
+  api: {
+    bodyParser: {
+      sizeLimit: '50mb',
+    },
+  },
 };
 
 export default handlerWithContactFormClient<ContactApiReturnType>({

--- a/src/pages/api/contact/refund.ts
+++ b/src/pages/api/contact/refund.ts
@@ -2,10 +2,13 @@ import { tryResult } from '@atb/modules/api-server';
 import { handlerWithContactFormClient } from '@atb/page-modules/contact/server';
 import { ContactApiReturnType } from '@atb/page-modules/contact/server/types';
 import { NextApiRequest, NextApiResponse } from 'next';
-import { defaultConfig } from './contact-api-config';
 
 export const config = {
-  ...defaultConfig,
+  api: {
+    bodyParser: {
+      sizeLimit: '50mb',
+    },
+  },
 };
 
 export default handlerWithContactFormClient<ContactApiReturnType>({

--- a/src/pages/api/contact/ticket-control.ts
+++ b/src/pages/api/contact/ticket-control.ts
@@ -2,10 +2,13 @@ import { tryResult } from '@atb/modules/api-server';
 import { handlerWithContactFormClient } from '@atb/page-modules/contact/server';
 import { ContactApiReturnType } from '@atb/page-modules/contact/server/types';
 import { NextApiRequest, NextApiResponse } from 'next';
-import { defaultConfig } from './contact-api-config';
 
 export const config = {
-  ...defaultConfig,
+  api: {
+    bodyParser: {
+      sizeLimit: '50mb',
+    },
+  },
 };
 
 export default handlerWithContactFormClient<ContactApiReturnType>({

--- a/src/pages/api/contact/ticketing.ts
+++ b/src/pages/api/contact/ticketing.ts
@@ -2,12 +2,14 @@ import { tryResult } from '@atb/modules/api-server';
 import { handlerWithContactFormClient } from '@atb/page-modules/contact/server';
 import { ContactApiReturnType } from '@atb/page-modules/contact/server/types';
 import { NextApiRequest, NextApiResponse } from 'next';
-import { defaultConfig } from './contact-api-config';
 
 export const config = {
-  ...defaultConfig,
+  api: {
+    bodyParser: {
+      sizeLimit: '50mb',
+    },
+  },
 };
-
 export default handlerWithContactFormClient<ContactApiReturnType>({
   async POST(req: NextApiRequest, res: NextApiResponse, { client, ok }) {
     return tryResult(req, res, async () => {


### PR DESCRIPTION
Define body size limit in all contact form endpoints, as NEXT does not support import of config.

<img width="2011" alt="Skjermbilde 2025-01-16 kl  13 47 45" src="https://github.com/user-attachments/assets/6d086852-0637-4bae-afbf-30bad5504c52" />
