### PR TITLE
fix: disallow robots in non-production

### DIFF
--- a/next-sitemap.js
+++ b/next-sitemap.js
@@ -21,8 +21,11 @@ module.exports = {
   generateIndexSitemap: false,
   sitemapSize: 7000,
   generateRobotsTxt: true,
-  robosTxtOptions: {
-    policies: [{ userAgent: '*', allow: '/' }],
+  robotsTxtOptions: {
+    policies:
+      environment === 'production'
+        ? [{ userAgent: '*', allow: '/' }]
+        : [{ userAgent: '*', disallow: '/' }],
   },
 
   // Adds path as it doesn't support dynamic routes.


### PR DESCRIPTION
Updated `robots.txt` generator to use `Disallow` for non-`production` environments, i.e. `staging` and `dev`.


Mainly to avoid this situation:

![image](https://github.com/user-attachments/assets/e0078d33-150d-44a7-82f5-a62d7cbe1cce)
