### PR TITLE
feat: add border around search dropdown

### DIFF
--- a/src/components/search/search.module.css
+++ b/src/components/search/search.module.css
@@ -51,6 +51,7 @@
   width: 100%;
   background-color: token('color.background.neutral.0.background');
   border-radius: 0.75rem;
+  border: token('border.width.slim') solid token('color.background.neutral.3.background');
   position: absolute;
   top: calc(100% + token('spacing.xSmall'));
   overflow: hidden;


### PR DESCRIPTION
Adds a tiny border around the search dropdown, which was missing in https://github.com/AtB-AS/kundevendt/issues/20062

![Screenshot 2025-03-18 at 10 24 43](https://github.com/user-attachments/assets/de0bffeb-8d4b-4b38-bffd-4a449adead1c)
