### PR TITLE
feat: use autocomplete data instead of reverse geocoder for trip search and departure

### DIFF
--- a/src/components/map/map-header.tsx
+++ b/src/components/map/map-header.tsx
@@ -64,13 +64,13 @@ export function MapHeader({
         <div className={style.header__buttons}>
           <ButtonLink
             mode="interactive_0"
-            href={`/assistant?fromLat=${position.lat}&fromLon=${position.lon}&fromLayer=${layer}`}
+            href={`/assistant?fromName=${name}&fromLat=${position.lat}&fromLon=${position.lon}&fromLayer=${layer}`}
             title={t(ComponentText.Map.button.travelFrom)}
             className={style.header__button}
           />
           <ButtonLink
             mode="interactive_0"
-            href={`/assistant?toLat=${position.lat}&toLon=${position.lon}&toLayer=${layer}`}
+            href={`/assistant?toName=${name}&toLat=${position.lat}&toLon=${position.lon}&toLayer=${layer}`}
             title={t(ComponentText.Map.button.travelTo)}
             className={style.header__button}
           />

--- a/src/page-modules/assistant/__tests__/assistant.test.tsx
+++ b/src/page-modules/assistant/__tests__/assistant.test.tsx
@@ -66,12 +66,12 @@ describe('assistant page', function () {
       async nonTransitTrips() {
         return nonTransitTripResult;
       },
-      async autocomplete() {
-        return {} as any;
+      async autocomplete(query, focus) {
+        if (query === 'Strindheim') return [fromFeature];
+        else return [toFeature];
       },
-      async reverse(lat, lon, layers) {
-        if (layers === 'address') return fromFeature;
-        else return toFeature;
+      async reverse() {
+        return {} as any;
       },
       async singleTrip() {
         return {} as any;
@@ -86,10 +86,12 @@ describe('assistant page', function () {
       params: {},
       query: {
         fromId: '638651',
+        fromName: 'Strindheim',
         fromLon: 10.4560389,
         fromLat: 63.4266611,
         fromLayer: 'address',
         toId: 'NSR:StopPlace:43984',
+        toName: 'Byåsen skole',
         toLon: 10.358037,
         toLat: 63.398886,
         toLayer: 'venue',
@@ -103,6 +105,7 @@ describe('assistant page', function () {
       ...context,
     } as any);
 
+    console.log(result);
     (await expectProps(result)).toMatchObject<AssistantContentProps>({
       tripQuery: {
         from: fromFeature,
@@ -312,12 +315,12 @@ describe('assistant page', function () {
       async nonTransitTrips() {
         return nonTransitTripResult;
       },
-      async autocomplete() {
-        return {} as any;
+      async autocomplete(query, focus) {
+        if (query === 'Strindheim') return [fromFeature];
+        else return [toFeature];
       },
-      async reverse(lat, lon, layers) {
-        if (layers === 'address') return fromFeature;
-        else return toFeature;
+      async reverse() {
+        return {} as any;
       },
       async singleTrip() {
         return {} as any;
@@ -332,10 +335,12 @@ describe('assistant page', function () {
       params: {},
       query: {
         fromId: '638651',
+        fromName: 'Strindheim',
         fromLon: 10.4560389,
         fromLat: 63.4266611,
         fromLayer: 'address',
         toId: 'NSR:StopPlace:43984',
+        toName: 'Byåsen skole',
         toLon: 10.358037,
         toLat: 63.398886,
         toLayer: 'venue',

--- a/src/page-modules/assistant/details/utils.ts
+++ b/src/page-modules/assistant/details/utils.ts
@@ -3,7 +3,11 @@ import { parseTripQueryString } from '../server/journey-planner';
 import { TranslateFunction } from '@atb/translations';
 import { Assistant } from '@atb/translations/pages';
 
-export function formatQuayName(t: TranslateFunction, quayName?: string, publicCode?: string | null) {
+export function formatQuayName(
+  t: TranslateFunction,
+  quayName?: string,
+  publicCode?: string | null,
+) {
   if (!quayName) return;
   if (!publicCode) return quayName;
   const prefix = t(Assistant.details.quayPublicCodePrefix);
@@ -17,7 +21,9 @@ export function getPlaceName(
   publicCode?: string | null,
 ): string {
   const fallback = placeName ?? '';
-  return quayName ? formatQuayName(t, quayName, publicCode) ?? fallback : fallback;
+  return quayName
+    ? (formatQuayName(t, quayName, publicCode) ?? fallback)
+    : fallback;
 }
 
 export function formatLineName(
@@ -45,6 +51,8 @@ export function tripQueryStringToQueryParams(
   if (
     !from ||
     !to ||
+    !from.name ||
+    !to.name ||
     !from.coordinates ||
     !to.coordinates ||
     !from.place ||
@@ -64,10 +72,12 @@ export function tripQueryStringToQueryParams(
     searchMode,
     searchTime,
     fromId: from.place,
+    fromName: from.name,
     fromLon: String(from.coordinates.longitude),
     fromLat: String(from.coordinates.latitude),
     fromLayer,
     toId: to.place,
+    toName: to.name,
     toLon: String(to.coordinates.longitude),
     toLat: String(to.coordinates.latitude),
     toLayer,

--- a/src/page-modules/assistant/trip-query-fetcher.ts
+++ b/src/page-modules/assistant/trip-query-fetcher.ts
@@ -30,14 +30,7 @@ export async function fetchFromToTripQuery(
         lat: tripQuery.fromLat,
         lon: tripQuery.fromLon,
       })
-      .catch((err) => {
-        console.log(err);
-        throw err;
-      })
-      .then((result) => {
-        console.log('fromP', JSON.stringify(result[0]));
-        return result[0];
-      });
+      .then((result) => result[0]);
   }
 
   if (hasToLatLon(tripQuery)) {
@@ -46,10 +39,7 @@ export async function fetchFromToTripQuery(
         lat: tripQuery.toLat,
         lon: tripQuery.toLon,
       })
-      .then((result) => {
-        console.log('toP', JSON.stringify(result[0]));
-        return result[0];
-      });
+      .then((result) => result[0]);
   }
 
   if (hasVia(tripQuery)) {
@@ -58,10 +48,7 @@ export async function fetchFromToTripQuery(
         lat: tripQuery.viaLat,
         lon: tripQuery.viaLon,
       })
-      .then((result) => {
-        console.log('viaP', JSON.stringify(result[0]));
-        return result[0];
-      });
+      .then((result) => result[0]);
   }
 
   const [from, to, via] = await Promise.all([fromP, toP, viaP]);

--- a/src/page-modules/assistant/trip-query-fetcher.ts
+++ b/src/page-modules/assistant/trip-query-fetcher.ts
@@ -25,23 +25,43 @@ export async function fetchFromToTripQuery(
   let viaP: Promise<GeocoderFeature | undefined> | undefined = undefined;
 
   if (!fromP && hasFromLatLon(tripQuery)) {
-    fromP = client.reverse(
-      tripQuery.fromLat,
-      tripQuery.fromLon,
-      tripQuery.fromLayer,
-    );
+    fromP = client
+      .autocomplete(tripQuery.fromName, {
+        lat: tripQuery.fromLat,
+        lon: tripQuery.fromLon,
+      })
+      .catch((err) => {
+        console.log(err);
+        throw err;
+      })
+      .then((result) => {
+        console.log('fromP', JSON.stringify(result[0]));
+        return result[0];
+      });
   }
 
   if (hasToLatLon(tripQuery)) {
-    toP = client.reverse(tripQuery.toLat, tripQuery.toLon, tripQuery.toLayer);
+    toP = client
+      .autocomplete(tripQuery.toName, {
+        lat: tripQuery.toLat,
+        lon: tripQuery.toLon,
+      })
+      .then((result) => {
+        console.log('toP', JSON.stringify(result[0]));
+        return result[0];
+      });
   }
 
   if (hasVia(tripQuery)) {
-    viaP = client.reverse(
-      tripQuery.viaLat,
-      tripQuery.viaLon,
-      tripQuery.viaLayer,
-    );
+    viaP = client
+      .autocomplete(tripQuery.viaName, {
+        lat: tripQuery.viaLat,
+        lon: tripQuery.viaLon,
+      })
+      .then((result) => {
+        console.log('viaP', JSON.stringify(result[0]));
+        return result[0];
+      });
   }
 
   const [from, to, via] = await Promise.all([fromP, toP, viaP]);
@@ -59,8 +79,11 @@ export async function fetchFromToTripQuery(
 
 function hasFromLatLon(
   query: TripQuery | undefined,
-): query is Required<Pick<TripQuery, 'fromLat' | 'fromLayer' | 'fromLon'>> {
+): query is Required<
+  Pick<TripQuery, 'fromLat' | 'fromLayer' | 'fromLon' | 'fromName'>
+> {
   return (
+    query?.fromName !== undefined &&
     query?.fromLon !== undefined &&
     query?.fromLat !== undefined &&
     query?.fromLayer !== undefined
@@ -68,8 +91,11 @@ function hasFromLatLon(
 }
 function hasToLatLon(
   query: TripQuery | undefined,
-): query is Required<Pick<TripQuery, 'toLat' | 'toLayer' | 'toLon'>> {
+): query is Required<
+  Pick<TripQuery, 'toLat' | 'toLayer' | 'toLon' | 'toName'>
+> {
   return (
+    query?.toName !== undefined &&
     query?.toLon !== undefined &&
     query?.toLat !== undefined &&
     query?.toLayer !== undefined
@@ -78,8 +104,11 @@ function hasToLatLon(
 
 function hasVia(
   query: TripQuery | undefined,
-): query is Required<Pick<TripQuery, 'viaLat' | 'viaLayer' | 'viaLon'>> {
+): query is Required<
+  Pick<TripQuery, 'viaLat' | 'viaLayer' | 'viaLon' | 'viaName'>
+> {
   return (
+    query?.viaName !== undefined &&
     query?.viaLon !== undefined &&
     query?.viaLat !== undefined &&
     query?.viaLayer !== undefined

--- a/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/__tests__/trip-pattern-header.test.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/__tests__/trip-pattern-header.test.tsx
@@ -2,7 +2,11 @@ import { cleanup, render, screen } from '@testing-library/react';
 import mockRouter from 'next-router-mock';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createDynamicRouteParser } from 'next-router-mock/dynamic-routes';
-import { getQuayName, getStartModeAndPlaceText, TripPatternHeader } from '..';
+import {
+  getQuayOrPlaceName,
+  getStartModeAndPlaceText,
+  TripPatternHeader,
+} from '..';
 import { tripPatternFixture } from './trip-pattern.fixture';
 import {
   AppCookiesProvider,
@@ -75,13 +79,17 @@ describe('trip pattern header', function () {
   it('should get quay name from quay', () => {
     const Test = function () {
       const { t } = useTranslation();
-      const quayName = getQuayName({
-        publicCode: '',
-        name: 'Quay',
-        description: null,
-        id: 'NSR:Quay:1',
-        situations: [],
-      }, t);
+      const quayName = getQuayOrPlaceName(
+        {
+          publicCode: '',
+          name: 'Quay',
+          description: null,
+          id: 'NSR:Quay:1',
+          situations: [],
+        },
+        'PlaceName',
+        t,
+      );
       return <div>{quayName}</div>;
     };
 
@@ -100,13 +108,17 @@ describe('trip pattern header', function () {
   it('should get quay name with public code from quay', () => {
     const Test = function () {
       const { t } = useTranslation();
-      const quayName = getQuayName({
-        publicCode: '1',
-        name: 'Quay',
-        description: null,
-        id: 'NSR:Quay:1',
-        situations: [],
-      }, t);
+      const quayName = getQuayOrPlaceName(
+        {
+          publicCode: '1',
+          name: 'Quay',
+          description: null,
+          id: 'NSR:Quay:1',
+          situations: [],
+        },
+        'PlaceName',
+        t,
+      );
       return <div>{quayName}</div>;
     };
 
@@ -125,7 +137,11 @@ describe('trip pattern header', function () {
   it('should get quay name from trip', () => {
     const Test = function () {
       const { t } = useTranslation();
-      const quayName = getQuayName(tripPatternFixture.legs[0].fromPlace.quay, t);
+      const quayName = getQuayOrPlaceName(
+        tripPatternFixture.legs[0].fromPlace.quay,
+        tripPatternFixture.legs[0].fromPlace.name,
+        t,
+      );
       return <div>{quayName}</div>;
     };
 
@@ -139,6 +155,29 @@ describe('trip pattern header', function () {
     });
 
     expect(screen.getByText('From 1')).toBeInTheDocument();
+  });
+
+  it('should use place name if quay is not available from trip', () => {
+    const Test = function () {
+      const { t } = useTranslation();
+      const quayName = getQuayOrPlaceName(
+        null,
+        tripPatternFixture.legs[0].fromPlace.name,
+        t,
+      );
+      return <div>{quayName}</div>;
+    };
+
+    customRender(<Test />, {
+      providerProps: {
+        initialCookies: {
+          darkmode: false,
+          language: 'no',
+        },
+      },
+    });
+
+    expect(screen.getByText('FromPlaceName')).toBeInTheDocument();
   });
 
   it('should get start mode and start place from trip', () => {

--- a/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/__tests__/trip-pattern.fixture.ts
+++ b/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/__tests__/trip-pattern.fixture.ts
@@ -25,7 +25,7 @@ export const tripPatternFixture: TripPattern = {
       },
       situations: [],
       fromPlace: {
-        name: 'From',
+        name: 'FromPlaceName',
         quay: {
           publicCode: '1',
           name: 'From',

--- a/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/index.tsx
@@ -71,9 +71,17 @@ export function getStartModeAndPlaceText(
 
   if (tripPattern.legs[0].mode === 'foot' && tripPattern.legs[1]) {
     startLeg = tripPattern.legs[1];
-    tmpStartName = getQuayName(startLeg.fromPlace.quay, t);
+    tmpStartName = getQuayOrPlaceName(
+      startLeg.fromPlace.quay,
+      startLeg.fromPlace.name,
+      t,
+    );
   } else if (tripPattern.legs[0].mode !== 'foot') {
-    tmpStartName = getQuayName(startLeg.fromPlace.quay, t);
+    tmpStartName = getQuayOrPlaceName(
+      startLeg.fromPlace.quay,
+      startLeg.fromPlace.name,
+      t,
+    );
   }
 
   const startName: string =
@@ -118,11 +126,12 @@ export function getStartModeAndPlaceText(
   }
 }
 
-export function getQuayName(
+export function getQuayOrPlaceName(
   quay: Quay | null,
+  name: string | null,
   t: TranslateFunction,
 ): string | null {
-  if (!quay) return null;
+  if (!quay) return name;
   if (!quay.publicCode) return quay.name;
   const prefix = t(Assistant.trip.tripPattern.quayPublicCodePrefix);
   return `${quay.name}${prefix ? prefix : ' '}${quay.publicCode}`;

--- a/src/page-modules/assistant/trip/trip-pattern/utils.ts
+++ b/src/page-modules/assistant/trip/trip-pattern/utils.ts
@@ -4,7 +4,7 @@ import {
   secondsBetween,
 } from '@atb/utils/date';
 import { Leg, TripPattern } from '../../server/journey-planner/validators';
-import { getQuayName } from './trip-pattern-header';
+import { getQuayOrPlaceName } from './trip-pattern-header';
 import { Language, TranslateFunction, PageText } from '@atb/translations';
 import dictionary from '@atb/translations/dictionary';
 import { screenReaderPause } from '@atb/components/typography/utils';
@@ -30,7 +30,11 @@ export const tripSummary = (
   let startText = '';
 
   if (tripPattern.legs[0]?.mode === 'foot' && tripPattern.legs[1]) {
-    const quayName = getQuayName(tripPattern.legs[1]?.fromPlace.quay, t);
+    const quayName = getQuayOrPlaceName(
+      tripPattern.legs[1]?.fromPlace.quay,
+      tripPattern.legs[1]?.fromPlace.name,
+      t,
+    );
 
     {
       quayName
@@ -43,7 +47,11 @@ export const tripSummary = (
         : undefined;
     }
   } else {
-    const quayName = getQuayName(tripPattern.legs[0]?.fromPlace.quay, t);
+    const quayName = getQuayOrPlaceName(
+      tripPattern.legs[0]?.fromPlace.quay,
+      tripPattern.legs[0]?.fromPlace.name,
+      t,
+    );
     if (quayName) {
       startText = t(
         PageText.Assistant.trip.tripSummary.header.title(

--- a/src/page-modules/assistant/types.ts
+++ b/src/page-modules/assistant/types.ts
@@ -29,10 +29,12 @@ export type FromToTripQuery = {
 
 export const TripQuerySchema = z.object({
   fromId: z.string().optional(),
+  fromName: z.string().optional(),
   fromLon: z.number().optional(),
   fromLat: z.number().optional(),
   fromLayer: z.union([z.literal('address'), z.literal('venue')]).optional(),
   toId: z.string().optional(),
+  toName: z.string().optional(),
   toLon: z.number().optional(),
   toLat: z.number().optional(),
   toLayer: z.union([z.literal('address'), z.literal('venue')]).optional(),
@@ -41,6 +43,7 @@ export const TripQuerySchema = z.object({
   searchTime: z.number().optional(),
   cursor: z.string().optional(),
   viaId: z.string().optional(),
+  viaName: z.string().optional(),
   viaLon: z.number().optional(),
   viaLat: z.number().optional(),
   viaLayer: z.union([z.literal('address'), z.literal('venue')]).optional(),

--- a/src/page-modules/assistant/utils.ts
+++ b/src/page-modules/assistant/utils.ts
@@ -31,6 +31,7 @@ function featuresToFromToQuery(
   if (from) {
     ret = {
       fromId: from.id,
+      fromName: from.name,
       fromLon: from.geometry.coordinates[0],
       fromLat: from.geometry.coordinates[1],
       fromLayer: from.layer,
@@ -41,6 +42,7 @@ function featuresToFromToQuery(
     ret = {
       ...ret,
       toId: to.id,
+      toName: to.name,
       toLon: to.geometry.coordinates[0],
       toLat: to.geometry.coordinates[1],
       toLayer: to.layer,
@@ -51,6 +53,7 @@ function featuresToFromToQuery(
     ret = {
       ...ret,
       viaId: via.id,
+      viaName: via.name,
       viaLon: via.geometry.coordinates[0],
       viaLat: via.geometry.coordinates[1],
       viaLayer: via.layer,

--- a/src/page-modules/departures/fetch-departure-query.ts
+++ b/src/page-modules/departures/fetch-departure-query.ts
@@ -32,7 +32,14 @@ export async function fetchFromDepartureQuery(
       lon: parseFloat(query.lon.toString()),
     };
 
-    const from = await client.reverse(position.lat, position.lon, 'address');
+    const from = await client
+      .autocomplete(query.name, {
+        lat: position.lat,
+        lon: position.lon,
+      })
+      .then((result) => {
+        return result[0];
+      });
 
     return {
       isAddress: true,

--- a/src/page-modules/departures/utils.ts
+++ b/src/page-modules/departures/utils.ts
@@ -23,12 +23,14 @@ export function createFromQuery(tripQuery: FromDepartureQuery): {
 
   if (tripQuery.from) {
     const [lon, lat] = tripQuery.from.geometry.coordinates;
+    const name = tripQuery.from.name;
     return {
       pathname: '/departures',
       query: {
         ...searchTimeQuery,
         lon,
         lat,
+        name,
       },
     };
   }


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/20033

Switched the reverse geocoder into autocomplete to allow same behavior with the app. Trip search and departure now should no longer converts "Prinsens Gate 39" into "Quality Hotel Augustin".

https://github.com/user-attachments/assets/9ef26594-88ba-4e76-8f5f-f3a16fa052f1