### PR TITLE
fix: remove line name validation

### DIFF
--- a/src/page-modules/assistant/line-filter/index.tsx
+++ b/src/page-modules/assistant/line-filter/index.tsx
@@ -16,25 +16,12 @@ export default function LineFilter({ filterState, onChange }: LineFilterProps) {
 
   const { authorityId } = getOrgData();
 
-  const { data, error, isLoading } = useSWR(
-    `api/assistant/lines/${authorityId}`,
-    swrFetcher,
-  );
-  const [validationError, setValidationError] =
-    useState<LabeledInputProps['validationError']>();
+  const { data } = useSWR(`api/assistant/lines/${authorityId}`, swrFetcher);
   const [localFilterState, setLocalFilterState] = useState('');
-  const [publicCodeLineMap, setPublicCodeLineMap] =
-    useState<Map<string, string[]>>();
 
   const onChangeWrapper = (event: ChangeEvent<HTMLInputElement>) => {
     const input = event.target.value;
     setLocalFilterState(input);
-    setValidationError(undefined);
-
-    if (!isValidFilter(input)) {
-      setValidationError(t(PageText.Assistant.search.lineFilter.error));
-      return;
-    }
 
     if (!input) {
       onChange(null);
@@ -78,10 +65,8 @@ export default function LineFilter({ filterState, onChange }: LineFilterProps) {
           PageText.Assistant.search.lineFilter.lineSearch.placeholder,
         )}
         type="text"
-        pattern="[0-9, ]*"
         value={localFilterState}
         onChange={onChangeWrapper}
-        validationError={validationError}
       />
 
       <Typo.p textType="body__tertiary" className={style.infoText}>
@@ -89,10 +74,4 @@ export default function LineFilter({ filterState, onChange }: LineFilterProps) {
       </Typo.p>
     </div>
   );
-}
-
-function isValidFilter(filter: string): boolean {
-  return filter.split(',').every((line) => {
-    return !isNaN(Number(line.trim()));
-  });
 }

--- a/src/translations/pages/assistant.ts
+++ b/src/translations/pages/assistant.ts
@@ -49,11 +49,6 @@ const AssistantInternal = {
         'I travel with line',
         'Eg reiser med linje',
       ),
-      error: _(
-        'Linje må være tall eller liste av tall (f.eks. 2, 10)',
-        'Line must be a number or list of numbers (e.g. 2, 10)',
-        'Linje må vere tal eller liste av tal (t.d. 2, 10)',
-      ),
       lineSearch: {
         label: _('Linje', 'Line', 'Linje'),
         placeholder: _('linjenummer', 'line number', 'linjenummer'),
@@ -480,12 +475,6 @@ export const Assistant = orgSpecificTranslations(AssistantInternal, {
   nfk: {
     search: {
       lineFilter: {
-        error: _(
-          'Linje må være tall eller liste av tall (f.eks. 100, 200)',
-          'Line must be a number or list of numbers (e.g. 100, 200)',
-          'Linje må vere tal eller liste av tal (t.d. 100, 200)',
-        ),
-
         example: _(
           'Eksempel: 100, 200, 300',
           'Example: 100, 200, 300',
@@ -506,12 +495,6 @@ export const Assistant = orgSpecificTranslations(AssistantInternal, {
   fram: {
     search: {
       lineFilter: {
-        error: _(
-          'Linje må være tall eller liste av tall (f.eks. 905, 902)',
-          'Line must be a number or list of numbers (e.g. 905, 902)',
-          'Linje må vere tal eller liste av tal (t.d. 905, 902)',
-        ),
-
         example: _(
           'Eksempel: 905, 902, 901',
           'Example: 905, 902, 901',
@@ -532,12 +515,6 @@ export const Assistant = orgSpecificTranslations(AssistantInternal, {
   farte: {
     search: {
       lineFilter: {
-        error: _(
-          'Linje må være kombinasjon av bokstav og tall, eller en liste av disse (f.eks. R1, P5, 601)',
-          'Line must be a combination of letters and numbers, or a list of these (e.g. R1, P5, 601)',
-          'Linje må vera kombinasjon av bokstav og tal, eller ei liste av desse (t.d. R1, P5, 601)',
-        ),
-
         example: _(
           'Eksempel: R1, P5, 601',
           'Example: R1, P5, 601',
@@ -558,12 +535,6 @@ export const Assistant = orgSpecificTranslations(AssistantInternal, {
   vkt: {
     search: {
       lineFilter: {
-        error: _(
-          'Linje må være kombinasjon av bokstav og tall, eller en liste av disse (f.eks. 03, 100, 113B)',
-          'Line must be a combination of letters and numbers, or a list of these (e.g. 03, 100, 113B)',
-          'Linje må vera kombinasjon av bokstav og tal, eller ei liste av desse (t.d. 03, 100, 113B)',
-        ),
-
         example: _(
           'Eksempel: 03, 100, 113B',
           'Example: 03, 100, 113B',
@@ -584,7 +555,7 @@ export const Assistant = orgSpecificTranslations(AssistantInternal, {
     trip: {
       tripPattern: {
         quayPublicCodePrefix: _(' - Spor ', ' - Track ', ' - Spor '),
-      }
-    }
-  }
+      },
+    },
+  },
 });

--- a/src/translations/pages/assistant.ts
+++ b/src/translations/pages/assistant.ts
@@ -54,6 +54,12 @@ const AssistantInternal = {
         placeholder: _('linjenummer', 'line number', 'linjenummer'),
       },
       example: _('Eksempel: 2, 10', 'Example: 2, 10', 'Eksempel: 2, 10'),
+      unknownLines: (lines: string[]) =>
+        _(
+          `Vi finner ikke linje ${lines.join(', ')}`,
+          `We couldn't find line ${lines.join(', ')}`,
+          `Vi finn ikkje linje ${lines.join(', ')}`,
+        ),
     },
     buttons: {
       find: {

--- a/src/utils/presence.ts
+++ b/src/utils/presence.ts
@@ -1,0 +1,4 @@
+export const isDefined = <T>(value: T): value is NonNullable<T> =>
+  value !== undefined && value !== null;
+
+export const isTruthy = <T>(value: T): value is NonNullable<T> => !!value;


### PR DESCRIPTION
Line public codes doesn't have to be numbers, and can in theory include any text. In the case of Farte, "R1, P5, 601" is given as an example, which doesn't work with the current validation logic.

This PR instead gives feedback to the user which lines weren't found, and makes the input validation more forgiving: Both spaces and commas are treated as separators, so both `10, 2` and `10 2` are valid filters. 

![Screenshot 2025-03-26 at 09 25 39](https://github.com/user-attachments/assets/d6fa87c1-6705-4475-821b-bed07f76505d)

fixes https://github.com/AtB-AS/kundevendt/issues/20311