### PR TITLE
feat: add checkbox for showing only stop places on trip search

### DIFF
--- a/src/components/checkbox/checkbox.module.css
+++ b/src/components/checkbox/checkbox.module.css
@@ -11,6 +11,7 @@
   padding: token('spacing.xSmall');
   border-radius: token('border.radius.small');
 }
+
 .checkbox:not(.checkbox--readonly) {
   background-color: token('color.interactive.2.default.background');
   color: token('color.interactive.2.default.foreground.primary');
@@ -28,6 +29,29 @@
   color: token('color.interactive.2.disabled.foreground.primary');
 }
 .checkbox:not(.checkbox--readonly):focus-within {
+  outline: 0;
+  box-shadow: inset 0 0 0 token('border.width.slim')
+    token('color.interactive.2.outline.background');
+}
+
+.checkbox:not(.checkbox--readonly):is(.checkbox--transparent) {
+  background-color: transparent;
+  color: token('color.interactive.0.default.foreground.primary');
+}
+.checkbox:not(.checkbox--readonly):is(.checkbox--transparent):hover {
+  background-color: transparent;
+  color: token('color.interactive.0.hover.foreground.primary');
+}
+.checkbox:not(.checkbox--readonly):is(.checkbox--transparent):active {
+  background-color: transparent;
+  color: token('color.interactive.0.default.foreground.primary');
+}
+.checkbox:not(.checkbox--readonly):is(.checkbox--transparent):disabled {
+  background-color: transparent;
+  color: token('color.interactive.0.disabled.foreground.primary');
+}
+.checkbox:not(.checkbox--readonly):is(.checkbox--transparent):focus-within {
+  background-color: transparent;
   outline: 0;
   box-shadow: inset 0 0 0 token('border.width.slim')
     token('color.interactive.2.outline.background');

--- a/src/components/checkbox/checkbox.module.css
+++ b/src/components/checkbox/checkbox.module.css
@@ -1,0 +1,78 @@
+@value typo-body__secondary from "@atb/theme/typography.module.css";
+@value typo-body__primary from "@atb/theme/typography.module.css";
+
+/* Checkbox */
+.checkbox {
+  display: block;
+  transition:
+    border 150ms ease-in-out,
+    background-color 100ms ease;
+  cursor: pointer;
+  padding: token('spacing.xSmall');
+  border-radius: token('border.radius.small');
+}
+.checkbox:not(.checkbox--readonly) {
+  background-color: token('color.interactive.2.default.background');
+  color: token('color.interactive.2.default.foreground.primary');
+}
+.checkbox:not(.checkbox--readonly):hover {
+  background-color: token('color.interactive.2.hover.background');
+  color: token('color.interactive.2.hover.foreground.primary');
+}
+.checkbox:not(.checkbox--readonly):active {
+  background-color: token('color.interactive.2.active.background');
+  color: token('color.interactive.2.active.foreground.primary');
+}
+.checkbox:not(.checkbox--readonly):disabled {
+  background-color: token('color.interactive.2.disabled.background');
+  color: token('color.interactive.2.disabled.foreground.primary');
+}
+.checkbox:not(.checkbox--readonly):focus-within {
+  outline: 0;
+  box-shadow: inset 0 0 0 token('border.width.slim')
+    token('color.interactive.2.outline.background');
+}
+
+.checkbox--disabled {
+  cursor: not-allowed;
+}
+.checkbox--disabled > * {
+  opacity: 0.2;
+}
+.checkbox--error {
+  border-color: token('color.status.error.primary.background');
+}
+.checkbox__checkbox {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+}
+.checkbox__checkbox:focus {
+  outline: 0;
+}
+.checkbox__checkbox[readonly] {
+  color: token('color.foreground.dynamic.secondary');
+}
+:global(.dark) .checkbox__checkbox::-webkit-calendar-picker-indicator {
+  filter: invert(1);
+}
+
+.checkbox__content {
+  display: flex;
+  gap: token('spacing.medium');
+}
+.checkbox__label {
+  flex: 1;
+}
+.checkbox__description {
+  flex: 1;
+  opacity: 0.6;
+  margin-top: token('spacing.small');
+  composes: typo-body__secondary from '@atb/theme/typography.module.css';
+}
+.checkbox__checkbox:not(:checked) + .checkbox__icon {
+  border: token('border.width.slim') solid
+    token('color.foreground.dynamic.primary');
+  border-radius: token('border.radius.small');
+}

--- a/src/components/checkbox/checkbox.module.css
+++ b/src/components/checkbox/checkbox.module.css
@@ -8,7 +8,7 @@
     border 150ms ease-in-out,
     background-color 100ms ease;
   cursor: pointer;
-  padding: token('spacing.xSmall');
+  padding: token('spacing.medium');
   border-radius: token('border.radius.small');
 }
 
@@ -33,30 +33,11 @@
   box-shadow: inset 0 0 0 token('border.width.slim')
     token('color.interactive.2.outline.background');
 }
-
-.checkbox:not(.checkbox--readonly):is(.checkbox--transparent) {
-  background-color: transparent;
-  color: token('color.interactive.0.default.foreground.primary');
+.checkbox--expand {
+  display: flex;
+  flex: 1;
+  flex-grow: 1;
 }
-.checkbox:not(.checkbox--readonly):is(.checkbox--transparent):hover {
-  background-color: transparent;
-  color: token('color.interactive.0.hover.foreground.primary');
-}
-.checkbox:not(.checkbox--readonly):is(.checkbox--transparent):active {
-  background-color: transparent;
-  color: token('color.interactive.0.default.foreground.primary');
-}
-.checkbox:not(.checkbox--readonly):is(.checkbox--transparent):disabled {
-  background-color: transparent;
-  color: token('color.interactive.0.disabled.foreground.primary');
-}
-.checkbox:not(.checkbox--readonly):is(.checkbox--transparent):focus-within {
-  background-color: transparent;
-  outline: 0;
-  box-shadow: inset 0 0 0 token('border.width.slim')
-    token('color.interactive.2.outline.background');
-}
-
 .checkbox--disabled {
   cursor: not-allowed;
 }

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -55,7 +55,9 @@ export default function Checkbox({
         <ColorIcon icon={icon} className={style.checkbox__icon} role="none" />
         <dl>
           <dt className={style.checkbox__label}>{label}</dt>
-          <dd className={style.checkbox__description}>{description}</dd>
+          {description && (
+            <dd className={style.checkbox__description}>{description}</dd>
+          )}
         </dl>
       </span>
       {!!error && <ErrorMessage message={error} />}

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -12,7 +12,7 @@ export type CheckboxProps = {
   label: string;
   description?: string;
   checked?: boolean;
-  transparent?: boolean;
+  expand?: boolean;
   onClick?: () => void;
 };
 
@@ -24,7 +24,7 @@ export default function Checkbox({
   label,
   description,
   checked = false,
-  transparent = false,
+  expand = false,
   onClick,
 }: CheckboxProps) {
   const id = useId();
@@ -34,7 +34,7 @@ export default function Checkbox({
     [style['checkbox--error']]: !!error,
     [style['checkbox--disabled']]: disabled,
     [style['checkbox--readonly']]: readonly,
-    [style['checkbox--transparent']]: transparent,
+    [style['checkbox--expand']]: expand,
   });
 
   const icon = checked ? 'input/CheckboxChecked' : 'input/CheckboxUnchecked';

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -1,8 +1,8 @@
 import { andIf } from '@atb/utils/css';
-import style from './form.module.css';
+import style from './checkbox.module.css';
 import { useId } from 'react';
 import { ColorIcon } from '@atb/components/icon';
-import ErrorMessage from './error-message';
+import { ErrorMessage } from '../error-message';
 
 export type CheckboxProps = {
   onChange: (checked: boolean) => void;

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -12,6 +12,7 @@ export type CheckboxProps = {
   label: string;
   description?: string;
   checked?: boolean;
+  transparent?: boolean;
   onClick?: () => void;
 };
 
@@ -23,6 +24,7 @@ export default function Checkbox({
   label,
   description,
   checked = false,
+  transparent = false,
   onClick,
 }: CheckboxProps) {
   const id = useId();
@@ -32,6 +34,7 @@ export default function Checkbox({
     [style['checkbox--error']]: !!error,
     [style['checkbox--disabled']]: disabled,
     [style['checkbox--readonly']]: readonly,
+    [style['checkbox--transparent']]: transparent,
   });
 
   const icon = checked ? 'input/CheckboxChecked' : 'input/CheckboxUnchecked';

--- a/src/components/checkbox/index.ts
+++ b/src/components/checkbox/index.ts
@@ -1,0 +1,2 @@
+export { default as Checkbox } from './checkbox';
+export type { CheckboxProps } from './checkbox';

--- a/src/components/error-message/error-message.module.css
+++ b/src/components/error-message/error-message.module.css
@@ -1,0 +1,6 @@
+/* error message */
+
+.errorMessage {
+  display: flex;
+  gap: token('spacing.small');
+}

--- a/src/components/error-message/error-message.tsx
+++ b/src/components/error-message/error-message.tsx
@@ -1,6 +1,6 @@
 import { Typo } from '@atb/components/typography';
 import { ColorIcon } from '@atb/components/icon';
-import style from './form.module.css';
+import style from './error-message.module.css';
 
 export type ErrorMessageProps = {
   message: string;

--- a/src/components/error-message/index.ts
+++ b/src/components/error-message/index.ts
@@ -1,0 +1,2 @@
+export { default as ErrorMessage } from './error-message';
+export type { ErrorMessageProps } from './error-message';

--- a/src/components/search/__tests__/search.test.tsx
+++ b/src/components/search/__tests__/search.test.tsx
@@ -59,6 +59,7 @@ const customRender = (ui: React.ReactNode, renderOptions?: RenderOptions) => {
       value={{
         fallback: {
           '/api/departures/autocomplete?q=test&onlyStopPlaces=false': result,
+          '/api/departures/autocomplete?q=test&onlyStopPlaces=true': result,
         },
       }}
     >

--- a/src/components/search/__tests__/search.test.tsx
+++ b/src/components/search/__tests__/search.test.tsx
@@ -58,7 +58,7 @@ const customRender = (ui: React.ReactNode, renderOptions?: RenderOptions) => {
     <SWRConfig
       value={{
         fallback: {
-          '/api/departures/autocomplete?q=test': result,
+          '/api/departures/autocomplete?q=test&onlyStopPlaces=false': result,
         },
       }}
     >

--- a/src/components/search/search.module.css
+++ b/src/components/search/search.module.css
@@ -51,7 +51,8 @@
   width: 100%;
   background-color: token('color.background.neutral.0.background');
   border-radius: 0.75rem;
-  border: token('border.width.slim') solid token('color.background.neutral.3.background');
+  border: token('border.width.slim') solid
+    token('color.background.neutral.3.background');
   position: absolute;
   top: calc(100% + token('spacing.xSmall'));
   overflow: hidden;
@@ -62,6 +63,13 @@
 }
 .menu:empty {
   display: none;
+}
+
+.stopPlaceCheckbox {
+  display: flex;
+  align-items: center;
+  padding: token('spacing.xSmall');
+  cursor: pointer;
 }
 
 .item {
@@ -83,7 +91,8 @@
 .itemHighlighted {
   color: token('color.interactive.2.hover.foreground.primary');
   background-color: token('color.interactive.2.hover.background');
-  outline: token('border.width.medium') solid token('color.interactive.2.outline.background');
+  outline: token('border.width.medium') solid
+    token('color.interactive.2.outline.background');
   border-radius: token('border.radius.small');
 }
 

--- a/src/components/search/search.tsx
+++ b/src/components/search/search.tsx
@@ -38,7 +38,10 @@ export default function Search({
 }: SearchProps) {
   const [query, setQuery] = useState('');
   const [focus, setFocus] = useState(false);
-  const [onlyStopPlaces, setOnlyStopPlaces] = useState<boolean>(true);
+  const [onlyStopPlaces, setOnlyStopPlaces] = useLocalStorage<boolean>(
+    'onlyStopPlaces',
+    true,
+  );
   const { data } = useAutocomplete(
     query,
     autocompleteFocusPoint,

--- a/src/components/search/search.tsx
+++ b/src/components/search/search.tsx
@@ -34,7 +34,7 @@ export default function Search({
   initialFeature,
   selectedItem,
   autocompleteFocusPoint,
-  onlyStopPlaces,
+  onlyStopPlaces = false,
   testID,
 }: SearchProps) {
   const [query, setQuery] = useState('');

--- a/src/components/search/search.tsx
+++ b/src/components/search/search.tsx
@@ -6,11 +6,12 @@ import VenueIcon from '@atb/components/venue-icon';
 import { andIf } from '@atb/utils/css';
 import { GeocoderFeature } from '@atb/page-modules/departures';
 import { logSpecificEvent } from '@atb/modules/firebase';
-import { ComponentText, useTranslation } from '@atb/translations';
+import { ComponentText, PageText, useTranslation } from '@atb/translations';
 import useLocalStorage from '@atb/utils/use-localstorage';
 import { useGeolocation } from './use-geolocation';
 import { MonoIcon } from '../icon';
 import { LoadingIcon } from '../loading';
+import { Checkbox } from '../checkbox';
 
 type SearchProps = {
   label: string;
@@ -21,7 +22,6 @@ type SearchProps = {
   initialFeature?: GeocoderFeature;
   selectedItem?: GeocoderFeature;
   autocompleteFocusPoint?: GeocoderFeature;
-  onlyStopPlaces?: boolean;
   testID?: string;
 };
 
@@ -34,11 +34,11 @@ export default function Search({
   initialFeature,
   selectedItem,
   autocompleteFocusPoint,
-  onlyStopPlaces = false,
   testID,
 }: SearchProps) {
   const [query, setQuery] = useState('');
   const [focus, setFocus] = useState(false);
+  const [onlyStopPlaces, setOnlyStopPlaces] = useState<boolean>(true);
   const { data } = useAutocomplete(
     query,
     autocompleteFocusPoint,
@@ -142,6 +142,18 @@ export default function Search({
           {button ?? null}
 
           <ul className={style.menu} {...getMenuProps()}>
+            {isOpen && inputValue !== '' && (
+              <li className={style.item}>
+                <Checkbox
+                  label={t(PageText.Assistant.search.onlyStopPlacesCheckbox)}
+                  checked={onlyStopPlaces}
+                  onChange={(checked) => {
+                    setOnlyStopPlaces(checked);
+                  }}
+                  expand={true}
+                />
+              </li>
+            )}
             {isOpen &&
               inputValue !== '' &&
               data?.map((item, index) => (

--- a/src/components/search/search.tsx
+++ b/src/components/search/search.tsx
@@ -146,7 +146,7 @@ export default function Search({
 
           <ul className={style.menu} {...getMenuProps()}>
             {isOpen && inputValue !== '' && (
-              <li className={style.item}>
+              <li className={style.stopPlaceCheckbox}>
                 <Checkbox
                   label={t(PageText.Assistant.search.onlyStopPlacesCheckbox)}
                   checked={onlyStopPlaces}

--- a/src/components/search/search.tsx
+++ b/src/components/search/search.tsx
@@ -21,6 +21,7 @@ type SearchProps = {
   initialFeature?: GeocoderFeature;
   selectedItem?: GeocoderFeature;
   autocompleteFocusPoint?: GeocoderFeature;
+  onlyStopPlaces?: boolean;
   testID?: string;
 };
 
@@ -33,11 +34,16 @@ export default function Search({
   initialFeature,
   selectedItem,
   autocompleteFocusPoint,
+  onlyStopPlaces,
   testID,
 }: SearchProps) {
   const [query, setQuery] = useState('');
   const [focus, setFocus] = useState(false);
-  const { data } = useAutocomplete(query, autocompleteFocusPoint);
+  const { data } = useAutocomplete(
+    query,
+    autocompleteFocusPoint,
+    onlyStopPlaces,
+  );
   const { t } = useTranslation();
   const [recentFeatureSearches, setRecentFeatureSearches] = useLocalStorage<
     GeocoderFeature[]

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -33,7 +33,6 @@ import {
   GlobalMessageContextEnum,
   GlobalMessages,
 } from '@atb/modules/global-messages';
-import { Checkbox } from '@atb/components/checkbox';
 
 export type AssistantLayoutProps = PropsWithChildren<{
   tripQuery: FromToTripQuery;
@@ -51,7 +50,6 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
   const [isPerformingSearchNavigation, setIsPerformingSearchNavigation] =
     useState(false);
   const [geolocationError, setGeolocationError] = useState<string | null>(null);
-  const [onlyStopPlaces, setOnlyStopPlaces] = useState<boolean>(true);
 
   // Loading the transport mode filter data here instead of in the component
   // avoids the data loading when the filter is mounted which causes the
@@ -157,7 +155,6 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
               placeholder={t(PageText.Assistant.search.input.placeholder)}
               onChange={onFromSelected}
               selectedItem={tripQuery.from ?? undefined}
-              onlyStopPlaces={onlyStopPlaces}
               testID="searchFrom"
               onGeolocationError={setGeolocationError}
             />
@@ -175,7 +172,6 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
                 />
               }
               autocompleteFocusPoint={tripQuery.from ?? undefined}
-              onlyStopPlaces={onlyStopPlaces}
               onGeolocationError={setGeolocationError}
             />
           </div>
@@ -193,14 +189,6 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
               <MessageBox type="warning" message={geolocationError} />
             </div>
           )}
-          <Checkbox
-            label={t(PageText.Assistant.search.onlyStopPlacesCheckbox)}
-            checked={onlyStopPlaces}
-            onChange={(checked) => {
-              setOnlyStopPlaces(checked);
-            }}
-            transparent={true}
-          />
         </motion.div>
         <AnimatePresence initial={false}>
           {showAlternatives && (

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -157,6 +157,7 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
               placeholder={t(PageText.Assistant.search.input.placeholder)}
               onChange={onFromSelected}
               selectedItem={tripQuery.from ?? undefined}
+              onlyStopPlaces={onlyStopPlaces}
               testID="searchFrom"
               onGeolocationError={setGeolocationError}
             />
@@ -174,6 +175,7 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
                 />
               }
               autocompleteFocusPoint={tripQuery.from ?? undefined}
+              onlyStopPlaces={onlyStopPlaces}
               onGeolocationError={setGeolocationError}
             />
           </div>

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -33,6 +33,7 @@ import {
   GlobalMessageContextEnum,
   GlobalMessages,
 } from '@atb/modules/global-messages';
+import { Checkbox } from '@atb/components/checkbox';
 
 export type AssistantLayoutProps = PropsWithChildren<{
   tripQuery: FromToTripQuery;
@@ -50,6 +51,7 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
   const [isPerformingSearchNavigation, setIsPerformingSearchNavigation] =
     useState(false);
   const [geolocationError, setGeolocationError] = useState<string | null>(null);
+  const [onlyStopPlaces, setOnlyStopPlaces] = useState<boolean>(true);
 
   // Loading the transport mode filter data here instead of in the component
   // avoids the data loading when the filter is mounted which causes the
@@ -189,6 +191,14 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
               <MessageBox type="warning" message={geolocationError} />
             </div>
           )}
+          <Checkbox
+            label={t(PageText.Assistant.search.onlyStopPlacesCheckbox)}
+            checked={onlyStopPlaces}
+            onChange={(checked) => {
+              setOnlyStopPlaces(checked);
+            }}
+            transparent={true}
+          />
         </motion.div>
         <AnimatePresence initial={false}>
           {showAlternatives && (

--- a/src/page-modules/contact/components/form/date-selector.tsx
+++ b/src/page-modules/contact/components/form/date-selector.tsx
@@ -1,3 +1,4 @@
+import { ErrorMessage } from '@atb/components/error-message';
 import style from './form.module.css';
 import { MonoIcon } from '@atb/components/icon';
 import { TranslatedString, useTranslation } from '@atb/translations';
@@ -16,7 +17,6 @@ import {
   Label,
   Popover,
 } from 'react-aria-components';
-import ErrorMessage from './error-message';
 
 export type DateSelectorProps = {
   label: TranslatedString;

--- a/src/page-modules/contact/components/form/file-input.tsx
+++ b/src/page-modules/contact/components/form/file-input.tsx
@@ -5,7 +5,7 @@ import { Button } from '@atb/components/button';
 import { MonoIcon } from '@atb/components/icon';
 import { PageText, TranslatedString, useTranslation } from '@atb/translations';
 import { useTheme } from '@atb/modules/theme';
-import ErrorMessage from './error-message';
+import { ErrorMessage } from '@atb/components/error-message';
 
 export type FileInputProps = {
   label: string;
@@ -23,7 +23,9 @@ export default function FileInput({
 }: FileInputProps) {
   const { t } = useTranslation();
   const id = useId();
-  const { color: {background} } = useTheme();
+  const {
+    color: { background },
+  } = useTheme();
   const [files, setFiles] = useState<File[]>([]);
 
   const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {

--- a/src/page-modules/contact/components/form/form.module.css
+++ b/src/page-modules/contact/components/form/form.module.css
@@ -28,7 +28,8 @@
 
   padding: token('spacing.small');
 
-  border: token('border.width.slim') solid token('color.foreground.dynamic.primary');
+  border: token('border.width.slim') solid
+    token('color.foreground.dynamic.primary');
   border-radius: token('border.radius.small');
   width: 100%;
 }
@@ -82,7 +83,8 @@
   height: 1.25rem;
   width: 1.25rem;
   --padding: 2px;
-  border: token('border.width.slim') solid token('color.foreground.dynamic.primary');
+  border: token('border.width.slim') solid
+    token('color.foreground.dynamic.primary');
   padding: var(--padding);
   margin-right: token('spacing.medium');
 }
@@ -150,84 +152,10 @@
   color: token('color.interactive.2.hover.foreground.primary');
 }
 
-/* Checkbox */
-.checkbox {
-  display: block;
-  transition:
-    border 150ms ease-in-out,
-    background-color 100ms ease;
-  cursor: pointer;
-  padding: token('spacing.xSmall');
-  border-radius: token('border.radius.small');
-}
-.checkbox:not(.checkbox--readonly) {
-  background-color: token('color.interactive.2.default.background');
-  color: token('color.interactive.2.default.foreground.primary');
-}
-.checkbox:not(.checkbox--readonly):hover {
-  background-color: token('color.interactive.2.hover.background');
-  color: token('color.interactive.2.hover.foreground.primary');
-}
-.checkbox:not(.checkbox--readonly):active {
-  background-color: token('color.interactive.2.active.background');
-  color: token('color.interactive.2.active.foreground.primary');
-}
-.checkbox:not(.checkbox--readonly):disabled {
-  background-color: token('color.interactive.2.disabled.background');
-  color: token('color.interactive.2.disabled.foreground.primary');
-}
-.checkbox:not(.checkbox--readonly):focus-within {
-  outline: 0;
-  box-shadow: inset 0 0 0 token('border.width.slim')
-    token('color.interactive.2.outline.background');
-}
-
-.checkbox--disabled {
-  cursor: not-allowed;
-}
-.checkbox--disabled > * {
-  opacity: 0.2;
-}
-.checkbox--error {
-  border-color: token('color.status.error.primary.background');
-}
-.checkbox__checkbox {
-  position: absolute;
-  opacity: 0;
-  width: 1px;
-  height: 1px;
-}
-.checkbox__checkbox:focus {
-  outline: 0;
-}
-.checkbox__checkbox[readonly] {
-  color: token('color.foreground.dynamic.secondary');
-}
-:global(.dark) .checkbox__checkbox::-webkit-calendar-picker-indicator {
-  filter: invert(1);
-}
-
-.checkbox__content {
-  display: flex;
-  gap: token('spacing.medium');
-}
-.checkbox__label {
-  flex: 1;
-}
-.checkbox__description {
-  flex: 1;
-  opacity: 0.6;
-  margin-top: token('spacing.small');
-  composes: typo-body__secondary from '@atb/theme/typography.module.css';
-}
-.checkbox__checkbox:not(:checked) + .checkbox__icon {
-  border: token('border.width.slim') solid token('color.foreground.dynamic.primary');
-  border-radius: token('border.radius.small');
-}
-
 /* textare */
 .textarea {
-  border: token('border.width.slim') solid token('color.foreground.dynamic.primary');
+  border: token('border.width.slim') solid
+    token('color.foreground.dynamic.primary');
   border-radius: token('border.radius.small');
 
   padding: token('spacing.small');
@@ -242,13 +170,6 @@
     --baseTypo-body__primary-letterSpacing,
     0.03125rem
   ) !important;
-}
-
-/* error message */
-
-.errorMessage {
-  display: flex;
-  gap: token('spacing.small');
 }
 
 /** file input */
@@ -273,7 +194,8 @@
   background-color: token('color.background.neutral.1.background');
   color: token('color.foreground.dynamic.primary');
   padding: token('spacing.small');
-  border: token('border.width.slim') solid token('color.foreground.dynamic.primary');
+  border: token('border.width.slim') solid
+    token('color.foreground.dynamic.primary');
   border-radius: token('border.radius.small');
   cursor: pointer;
 }
@@ -368,7 +290,8 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  border: token('border.width.slim') solid token('color.foreground.dynamic.primary');
+  border: token('border.width.slim') solid
+    token('color.foreground.dynamic.primary');
   border-radius: token('border.radius.small');
 }
 
@@ -418,7 +341,8 @@
   overflow: auto;
   max-height: 16rem;
   width: var(--trigger-width);
-  border: token('border.width.slim') solid token('color.foreground.dynamic.primary');
+  border: token('border.width.slim') solid
+    token('color.foreground.dynamic.primary');
   border-radius: token('border.radius.small');
   color: token('color.background.neutral.0.foreground.primary');
   background: token('color.background.neutral.0.background');
@@ -503,7 +427,8 @@
   color: token('color.foreground.dynamic.primary');
   background-color: transparent;
   border-radius: token('border.radius.small');
-  border: token('border.width.slim') solid token('color.foreground.dynamic.primary');
+  border: token('border.width.slim') solid
+    token('color.foreground.dynamic.primary');
 }
 
 .select__button:disabled {
@@ -626,7 +551,8 @@
   padding: token('spacing.medium');
   color: token('color.background.neutral.0.foreground.primary');
   border-radius: token('border.radius.small');
-  border: token('border.width.slim') solid token('color.foreground.dynamic.primary');
+  border: token('border.width.slim') solid
+    token('color.foreground.dynamic.primary');
 }
 
 .dateSelector input[type='date']:focus,

--- a/src/page-modules/contact/components/form/index.ts
+++ b/src/page-modules/contact/components/form/index.ts
@@ -1,5 +1,3 @@
-export { default as Checkbox } from './checkbox';
-export { default as ErrorMessage } from './error-message';
 export { default as FileInput } from './file-input';
 export { default as Input } from './input';
 export { default as Radio } from './radio';

--- a/src/page-modules/contact/components/form/input.tsx
+++ b/src/page-modules/contact/components/form/input.tsx
@@ -3,10 +3,10 @@ import { ChangeEvent, useState } from 'react';
 import { PageText, TranslatedString, useTranslation } from '@atb/translations';
 import { andIf } from '@atb/utils/css';
 import { Typo } from '@atb/components/typography';
-import ErrorMessage from './error-message';
 import { MonoIcon } from '@atb/components/icon';
 import { Button } from '@atb/components/button';
 import DescriptionModal from './description-modal';
+import { ErrorMessage } from '@atb/components/error-message';
 
 type InputProps = {
   label: string;

--- a/src/page-modules/contact/components/form/searchable-select/searchable-select.tsx
+++ b/src/page-modules/contact/components/form/searchable-select/searchable-select.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import { MonoIcon } from '@atb/components/icon';
-import ErrorMessage from '../error-message';
 import style from '../form.module.css';
 import { andIf } from '@atb/utils/css';
 import {
@@ -14,6 +13,7 @@ import {
   Popover,
   Group,
 } from 'react-aria-components';
+import { ErrorMessage } from '@atb/components/error-message';
 
 export type Option<T> = { id: string; name: string; value: T };
 export type SearchableSelectProps<T> = {

--- a/src/page-modules/contact/components/form/select.tsx
+++ b/src/page-modules/contact/components/form/select.tsx
@@ -1,5 +1,4 @@
 import { useId } from 'react';
-import ErrorMessage from './error-message';
 import { MonoIcon } from '@atb/components/icon';
 import style from './form.module.css';
 import {
@@ -11,6 +10,7 @@ import {
   Popover,
   Select,
 } from 'react-aria-components';
+import { ErrorMessage } from '@atb/components/error-message';
 
 export type SelectProps<T> = {
   label?: string;

--- a/src/page-modules/contact/components/form/textarea.tsx
+++ b/src/page-modules/contact/components/form/textarea.tsx
@@ -1,5 +1,5 @@
+import { ErrorMessage } from '@atb/components/error-message';
 import style from './form.module.css';
-import ErrorMessage from './error-message';
 
 export type CheckboxProps = {
   onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;

--- a/src/page-modules/contact/components/form/time-selector.tsx
+++ b/src/page-modules/contact/components/form/time-selector.tsx
@@ -1,7 +1,7 @@
+import { ErrorMessage } from '@atb/components/error-message';
 import style from './form.module.css';
 import { TranslatedString, useTranslation } from '@atb/translations';
 import { parseTime } from '@internationalized/date';
-import ErrorMessage from './error-message';
 import {
   DateInput,
   DateSegment,

--- a/src/page-modules/contact/components/index.tsx
+++ b/src/page-modules/contact/components/index.tsx
@@ -1,6 +1,4 @@
 export {
-  Checkbox,
-  ErrorMessage,
   FileInput,
   Input,
   Radio,

--- a/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
@@ -11,13 +11,13 @@ import {
   Input,
   FileInput,
   Textarea,
-  Checkbox,
   SearchableSelect,
   getLineOptions,
   getStopOptions,
   DateSelector,
   TimeSelector,
 } from '../../components';
+import { Checkbox } from '@atb/components/checkbox';
 
 type TransportationFormProps = {
   state: { context: MeansOfTransportContextProps };

--- a/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/index.tsx
+++ b/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/index.tsx
@@ -6,15 +6,12 @@ import {
   refundStateMachine,
 } from '../../refundFormMachine';
 import { RefundFormEvents } from '../../events';
-import {
-  Checkbox,
-  SectionCard,
-  Radio,
-} from '@atb/page-modules/contact/components';
+import { SectionCard, Radio } from '@atb/page-modules/contact/components';
 import { Typo } from '@atb/components/typography';
 import Link from 'next/link';
 import RefundTaxiForm from './refundTaxiForm';
 import RefundCarForm from './refundCarForm';
+import { Checkbox } from '@atb/components/checkbox';
 
 type RefundAndTravelGuaranteeFormsProps = {
   state: StateFrom<typeof refundStateMachine>;

--- a/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundCarForm.tsx
+++ b/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundCarForm.tsx
@@ -8,7 +8,6 @@ import {
   SectionCard,
   Input,
   Select,
-  Checkbox,
   Textarea,
   FileInput,
   SearchableSelect,
@@ -17,6 +16,7 @@ import {
   DateSelector,
   TimeSelector,
 } from '../../../components';
+import { Checkbox } from '@atb/components/checkbox';
 
 type RefundCarFormProps = {
   state: { context: RefundContextProps };

--- a/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundTaxiForm.tsx
+++ b/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundTaxiForm.tsx
@@ -9,7 +9,6 @@ import {
   SectionCard,
   Input,
   Select,
-  Checkbox,
   Textarea,
   FileInput,
   SearchableSelect,
@@ -18,6 +17,7 @@ import {
   DateSelector,
   TimeSelector,
 } from '../../../components';
+import { Checkbox } from '@atb/components/checkbox';
 
 type RefundTaxiFormProps = {
   state: { context: RefundContextProps };

--- a/src/page-modules/contact/refund/forms/refund-ticket/index.tsx
+++ b/src/page-modules/contact/refund/forms/refund-ticket/index.tsx
@@ -2,12 +2,13 @@ import style from '../../..//contact.module.css';
 import { StateFrom } from 'xstate';
 import { PageText, TranslatedString, useTranslation } from '@atb/translations';
 import { Typo } from '@atb/components/typography';
-import { SectionCard, Radio, Checkbox } from '../../../components';
+import { SectionCard, Radio } from '../../../components';
 import AppTicketRefund from './appTicketRefund';
 import Link from 'next/link';
 import { refundStateMachine, RefundTicketForm } from '../../refundFormMachine';
 import { RefundFormEvents } from '../../events';
 import OtherTicketRefund from './otherTicketRefund';
+import { Checkbox } from '@atb/components/checkbox';
 
 type RefundTicketFormsProps = {
   state: StateFrom<typeof refundStateMachine>;

--- a/src/page-modules/contact/refund/forms/refund-ticket/otherTicketRefund.tsx
+++ b/src/page-modules/contact/refund/forms/refund-ticket/otherTicketRefund.tsx
@@ -4,13 +4,13 @@ import { Typo } from '@atb/components/typography';
 import {
   SectionCard,
   Input,
-  Checkbox,
   Select,
   Textarea,
   FileInput,
   Radio,
 } from '../../../components';
 import { RefundContextProps } from '../../refundFormMachine';
+import { Checkbox } from '@atb/components/checkbox';
 
 type OtherTicketRefundProps = {
   state: { context: RefundContextProps };

--- a/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
@@ -6,11 +6,11 @@ import { ticketControlFormEvents } from '../events';
 import {
   Input,
   SectionCard,
-  Checkbox,
   Radio,
   Textarea,
   FileInput,
 } from '../../components';
+import { Checkbox } from '@atb/components/checkbox';
 
 type FeeComplaintFormProps = {
   state: { context: TicketControlContextProps };

--- a/src/page-modules/departures/client/geocoder/index.ts
+++ b/src/page-modules/departures/client/geocoder/index.ts
@@ -11,6 +11,7 @@ const DEBOUNCE_TIME_AUTOCOMPLETE_IN_MS = 300;
 export function useAutocomplete(
   q: string,
   autocompleteFocusPoint?: GeocoderFeature,
+  onlyStopPlaces?: boolean,
 ) {
   const debouncedQuery = useDebounce(q, DEBOUNCE_TIME_AUTOCOMPLETE_IN_MS);
 
@@ -18,9 +19,11 @@ export function useAutocomplete(
     ? `&lat=${autocompleteFocusPoint.geometry.coordinates[0]}&lon=${autocompleteFocusPoint.geometry.coordinates[1]}`
     : '';
 
+  const layerQuery = `&onlyStopPlaces=${onlyStopPlaces}`;
+
   return useSWR<AutocompleteApiReturnType>(
     debouncedQuery !== ''
-      ? `/api/departures/autocomplete?q=${debouncedQuery}${focusQuery}`
+      ? `/api/departures/autocomplete?q=${debouncedQuery}${focusQuery}${layerQuery}`
       : null,
     swrFetcher,
     {

--- a/src/page-modules/departures/server/geocoder/index.ts
+++ b/src/page-modules/departures/server/geocoder/index.ts
@@ -14,6 +14,7 @@ export type GeocoderApi = {
       lat: number;
       lon: number;
     },
+    onlyStopPlaces?: boolean,
   ): Promise<GeocoderFeature[]>;
   reverse(
     lat: number,
@@ -26,10 +27,11 @@ export function createGeocoderApi(
   request: HttpRequester<'http-entur'>,
 ): GeocoderApi {
   return {
-    async autocomplete(query, focus) {
+    async autocomplete(query, focus, onlyStopPlaces) {
       const focusQuery = await createFocusQuery(focus);
+      const venueQuery = onlyStopPlaces ? ['venue'] : ['venue', 'address'];
       const result = await request(
-        `/geocoder/v1/autocomplete?text=${query}&${focusQuery}&size=10&lang=no&multiModal=child`,
+        `/geocoder/v1/autocomplete?text=${query}&${focusQuery}&size=10&lang=no&multiModal=child&layers=${venueQuery}`,
       );
 
       const parsed = geocoderRootSchema.safeParse(await result.json());

--- a/src/pages/api/departures/autocomplete.ts
+++ b/src/pages/api/departures/autocomplete.ts
@@ -12,8 +12,17 @@ export default handlerWithDepartureClient<AutocompleteApiReturnType>(
       const query = z.string().safeParse(req.query.q);
       const lat = z.string().optional().safeParse(req.query.lat);
       const lon = z.string().optional().safeParse(req.query.lon);
+      const onlyStopPlaces = z
+        .string()
+        .optional()
+        .safeParse(req.query.onlyStopPlaces);
 
-      if (!query.success || !lat.success || !lon.success) {
+      if (
+        !query.success ||
+        !lat.success ||
+        !lon.success ||
+        !onlyStopPlaces.success
+      ) {
         return errorResultAsJson(
           res,
           constants.HTTP_STATUS_BAD_REQUEST,
@@ -36,7 +45,13 @@ export default handlerWithDepartureClient<AutocompleteApiReturnType>(
       }
 
       return tryResult(req, res, async () => {
-        return ok(await client.autocomplete(String(query.data), focus));
+        return ok(
+          await client.autocomplete(
+            String(query.data),
+            focus,
+            onlyStopPlaces.data === 'true',
+          ),
+        );
       });
     },
   },

--- a/src/translations/pages/assistant.ts
+++ b/src/translations/pages/assistant.ts
@@ -70,6 +70,11 @@ const AssistantInternal = {
         less: _('Færre valg', 'Less choices', 'Færre val'),
       },
     },
+    onlyStopPlacesCheckbox: _(
+      'Vis kun holdeplasser',
+      'Show only stop places',
+      'Vis berre haldeplassar',
+    ),
   },
   trip: {
     resultsFound: _(


### PR DESCRIPTION
Part of https://github.com/AtB-AS/kundevendt/issues/20334

One of the most-requested feature on from the kundeservice team feedback. This will add a checkbox that is similar to the one found in the app, where the search autocomplete will only show stop places if the checkbox is checked.

This is a very rough implementation and lots of improvement might be found in the CSS. (I'm super noob in CSS ✌🏼 ).

- We already have checkbox component from the `contact form` which FRAM uses.
- I extracted that checkbox component (and error-message component) to generic use component.
- Added the checkbox to the search box (top of the list) and modified the css part so it allows expanding the clickable area.
- Modified the API implementation to show only stop places.

https://github.com/user-attachments/assets/8500eaa7-f630-4990-b0c6-e02b4049efb4


### Acceptance Criteria
- [ ] Checkbox appears inside the list when user types something into the search bar
- [ ] Checkbox doesn't show when there are nothing in the search bar
- [ ] Checking the checkbox shows only stop places
- [ ] Unchecking the checkbox shows all results
- [ ] Checkbox can be selected using arrow keys on keyboard
- [ ] While selected, the checkbox can be toggled by using the enter key on keyboard
- [ ] If an item other than the checkbox are selected, the enter key should close the list and use the selected value as the selected item.  