### PR TITLE
feat: extend contact form with selector to specify which platform the ticket was purchases through

### DIFF
--- a/src/page-modules/contact/refund/events.ts
+++ b/src/page-modules/contact/refund/events.ts
@@ -5,6 +5,8 @@ import {
   RefundAndTravelGuarantee,
   RefundTicketForm,
 } from './refundFormMachine';
+import { TransportModeType } from '../types';
+import { Line } from '..';
 
 export type ReasonForTransportFailure = { id: string; name: TranslatedString };
 export type TicketType = { id: string; name: TranslatedString };
@@ -24,12 +26,34 @@ const RefundSpecificFormEvents = {} as
         | 'ticketType'
         | 'travelCardNumber'
         | 'refundReason'
+        | 'firstName'
+        | 'lastName'
+        | 'address'
+        | 'postalCode'
+        | 'city'
+        | 'email'
+        | 'phoneNumber'
+        | 'bankAccountNumber'
+        | 'IBAN'
+        | 'SWIFT'
+        | 'fromStop'
+        | 'toStop'
+        | 'date'
+        | 'plannedDepartureTime'
+        | 'feedback'
+        | 'attachments'
         | 'isInitialAgreementChecked'
         | 'hasInternationalBankAccount'
         | 'showInputTravelCardNumber';
-      value: string | boolean | ReasonForTransportFailure | TicketType;
+      value:
+        | string
+        | boolean
+        | ReasonForTransportFailure
+        | TicketType
+        | Line['quays'][0]
+        | File[]
+        | undefined;
     }
-  | { type: 'SET_STATE_SUBMITTED'; stateSubmitted: string | undefined }
   | {
       type: 'SELECT_FORM_CATEGORY';
       formCategory: FormCategory;
@@ -43,9 +67,16 @@ const RefundSpecificFormEvents = {} as
       refundAndTravelGuarantee: RefundAndTravelGuarantee;
     }
   | {
+      type: 'ON_TRANSPORTMODE_CHANGE';
+      value: TransportModeType;
+    }
+  | {
+      type: 'ON_LINE_CHANGE';
+      value: Line | undefined;
+    }
+  | {
+  | {
       type: 'SUBMIT';
     };
 
-export const RefundFormEvents = {} as
-  | typeof RefundSpecificFormEvents
-  | typeof commonEvents;
+export const RefundFormEvents = {} as typeof RefundSpecificFormEvents;

--- a/src/page-modules/contact/refund/events.ts
+++ b/src/page-modules/contact/refund/events.ts
@@ -1,11 +1,10 @@
 import { TranslatedString } from '@atb/translations';
-import { commonEvents } from '../commoneEvents';
 import {
   FormCategory,
   RefundAndTravelGuarantee,
   RefundTicketForm,
 } from './refundFormMachine';
-import { TransportModeType } from '../types';
+import { PurchasePlatformType, TransportModeType } from '../types';
 import { Line } from '..';
 
 export type ReasonForTransportFailure = { id: string; name: TranslatedString };
@@ -75,6 +74,9 @@ const RefundSpecificFormEvents = {} as
       value: Line | undefined;
     }
   | {
+      type: 'ON_PURCHASE_PLATFORM_CHANGE';
+      value: PurchasePlatformType | undefined;
+    }
   | {
       type: 'SUBMIT';
     };

--- a/src/page-modules/contact/refund/forms/refund-ticket/appTicketRefund.tsx
+++ b/src/page-modules/contact/refund/forms/refund-ticket/appTicketRefund.tsx
@@ -1,8 +1,15 @@
 import { PageText, useTranslation } from '@atb/translations';
-import { SectionCard, Input, Textarea, FileInput } from '../../../components';
 import { RefundContextProps } from '../../refundFormMachine';
 import { RefundFormEvents } from '../../events';
 import { Typo } from '@atb/components/typography';
+import { PurchasePlatformType, TransportModeType } from '../../../types';
+import {
+  SectionCard,
+  Input,
+  Textarea,
+  FileInput,
+  Select,
+} from '../../../components';
 
 type AppTicketRefundProps = {
   state: { context: RefundContextProps };
@@ -54,6 +61,32 @@ export const AppTicketRefund = ({ state, send }: AppTicketRefundProps) => {
               (bulletPoint) => t(bulletPoint),
             ),
         }}
+      />
+
+      <Select
+        label={t(PageText.Contact.input.purchasePlatform.label)}
+        value={state.context.purchasePlatform || ''}
+        onChange={(value) =>
+          send({
+            type: 'ON_PURCHASE_PLATFORM_CHANGE',
+            value: value as PurchasePlatformType,
+          })
+        }
+        error={
+          state.context?.errorMessages['purchasePlatform']?.[0]
+            ? t(state.context?.errorMessages['purchasePlatform']?.[0])
+            : undefined
+        }
+        valueToId={(val: string) => val}
+        valueToText={(val: string) =>
+          t(
+            PageText.Contact.input.purchasePlatform.platforms[
+              val as PurchasePlatformType
+            ],
+          )
+        }
+        options={['enturApp', 'enturWeb', 'framApp', 'framWeb']}
+        placeholder={t(PageText.Contact.input.purchasePlatform.optionLabel)}
       />
 
       <Typo.p textType="body__primary">

--- a/src/page-modules/contact/refund/refundFormMachine.ts
+++ b/src/page-modules/contact/refund/refundFormMachine.ts
@@ -1,4 +1,4 @@
-import { TransportModeType } from '../types';
+import { PurchasePlatformType, TransportModeType } from '../types';
 import { assign, fromPromise, setup } from 'xstate';
 import { Line } from '../server/journey-planner/validators';
 import { ReasonForTransportFailure, TicketType } from './events';
@@ -63,6 +63,7 @@ type SubmitInput = {
   ticketType?: string;
   travelCardNumber?: string;
   refundReason?: string;
+  purchasePlatform?: string;
 };
 
 export type RefundContextProps = {
@@ -95,6 +96,7 @@ export type RefundContextProps = {
   ticketType?: TicketType;
   travelCardNumber?: string;
   refundReason?: string;
+  purchasePlatform?: PurchasePlatformType | undefined;
 
   isInitialAgreementChecked: boolean;
   hasInternationalBankAccount: boolean;
@@ -155,6 +157,7 @@ const setInputToValidate = (context: RefundContextProps) => {
     ticketType,
     travelCardNumber,
     refundReason,
+    purchasePlatform,
     showInputTravelCardNumber,
   } = context;
 
@@ -199,6 +202,7 @@ const setInputToValidate = (context: RefundContextProps) => {
         customerNumber,
         orderId,
         refundReason,
+        purchasePlatform,
       };
 
     case FormType.OtherTicketRefund:
@@ -318,7 +322,20 @@ export const refundStateMachine = setup({
         return setLineAndResetStops(context, event.value);
       return context;
     }),
+
+    onPurchasePlatformChange: assign(({ context, event }) => {
+      if (event.type === 'ON_PURCHASE_PLATFORM_CHANGE')
+        return {
+          ...context,
+          purchasePlatform: event.value,
+          errorMessages: {
+            ...context.errorMessages,
+          },
+        };
+      return context;
+    }),
   },
+
   actors: {
     submit: fromPromise(async ({ input }: { input: SubmitInput }) => {
       const base64EncodedAttachments = await convertFilesToBase64(
@@ -360,6 +377,10 @@ export const refundStateMachine = setup({
 
     ON_LINE_CHANGE: {
       actions: 'onLineChange',
+    },
+
+    ON_PURCHASE_PLATFORM_CHANGE: {
+      actions: 'onPurchasePlatformChange',
     },
 
     SELECT_FORM_CATEGORY: {
@@ -535,6 +556,7 @@ export const refundStateMachine = setup({
           ticketType: context?.ticketType?.name.no,
           travelCardNumber: context?.travelCardNumber,
           refundReason: context?.refundReason,
+          purchasePlatform: context?.purchasePlatform,
         }),
 
         onDone: {

--- a/src/page-modules/contact/refund/refundFormMachine.ts
+++ b/src/page-modules/contact/refund/refundFormMachine.ts
@@ -289,7 +289,7 @@ export const refundStateMachine = setup({
           return setFormTypeAndInitialContext(context, value as FormType);
 
         if (inputName === 'isInitialAgreementChecked')
-          return setInitialAgreementAndFormType(context, value);
+          return setInitialAgreementAndFormType(context, value as boolean);
 
         if (inputName === 'hasInternationalBankAccount') {
           return setBankAccountStatusAndResetBankInformation(

--- a/src/page-modules/contact/types.ts
+++ b/src/page-modules/contact/types.ts
@@ -1,1 +1,6 @@
 export type TransportModeType = 'bus' | 'expressboat' | 'ferry';
+export type PurchasePlatformType =
+  | 'framApp'
+  | 'enturApp'
+  | 'framWeb'
+  | 'enturWeb';

--- a/src/page-modules/contact/validation/commonInputValidator.ts
+++ b/src/page-modules/contact/validation/commonInputValidator.ts
@@ -191,6 +191,11 @@ export const commonInputValidator = (context: any) => {
       validCondition: context.ticketType,
       errorMessage: PageText.Contact.input.ticketType.errorMessages.empty,
     },
+    {
+      inputName: 'purchasePlatform',
+      validCondition: context.purchasePlatform,
+      errorMessage: PageText.Contact.input.ticketType.errorMessages.empty,
+    },
   ];
 
   // Iterate over each field and apply validation

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -741,16 +741,16 @@ const ContactInternal = {
       },
       appTicketRefund: {
         label: _(
-          'Billett kjøpt i FRAM-appen (alle billettyper) ',
-          'Ticket purchased in the FRAM app (all ticket types)',
-          'Billett kjøpt i FRAM-appen (alle billettypar) ',
+          'Billett kjøpt i app eller nettbutikk',
+          'Ticket purchased in an app or webshop',
+          'Billett kjøpt i app eller nettbutikk',
         ),
       },
       otherTicketRefund: {
         label: _(
-          'Billett på reisekort eller kjøpt i nettbutikken, om bord eller på trafikkterminal',
-          'Ticket on travel card or purchased in the webshop, on board or at the terminal',
-          'Billett på reisekort eller kjøpt i nettbutikken, om bord eller på trafikkterminal',
+          'Billett kjøpt om bord eller på trafikkterminal',
+          'Ticket purchased onboard or at a terminal',
+          'Billett kjøpt om bord eller på trafikkterminal',
         ),
       },
     },

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -969,6 +969,28 @@ const ContactInternal = {
       },
     },
 
+    purchasePlatform: {
+      label: _('Kjøpsplattform', 'Purchase platform', 'Kjøpsplattform'),
+      optionLabel: _(
+        'Velg app eller nettbutikk billetten ble kjøpt i',
+        'Select the app or webshop where the ticket was purchased',
+        'Vel app eller nettbutikk der billetten vart kjøpt',
+      ),
+      platforms: {
+        enturApp: _('Entur-appen', 'Entur app', 'Entur-appen'),
+        framApp: _('FRAM-appen', 'FRAM app', 'FRAM-appen'),
+        enturWeb: _('Entur nettbutikk', 'Entur webshop', 'Entur nettbutikk'),
+        framWeb: _('FRAM nettbutikk', 'FRAM webshop', 'FRAM nettbutikk'),
+      },
+      errorMessages: {
+        empty: _(
+          'Velg app eller nettbutikk',
+          'Select app or webshop',
+          'Vel app eller nettbutikk',
+        ),
+      },
+    },
+
     line: {
       label: _('Linje', 'Line', 'Linje'),
       optionLabel: _('Velg linje', 'Choose line', 'Vel linje'),


### PR DESCRIPTION
- [x] extend contact form with selector to specify which platform the ticket was purchases through.
- [x] update translations of refund ticket form groups.
- [x] cleanup of refund form events.

<img width="831" alt="Skjermbilde 2025-04-11 kl  16 09 02" src="https://github.com/user-attachments/assets/56386262-0c0b-4c53-8bc8-7a4e55587a44" />

    