### PR TITLE
feat: add message to inform users to not include personal information

### DIFF
--- a/src/page-modules/contact/layouts/contact-page-layout.tsx
+++ b/src/page-modules/contact/layouts/contact-page-layout.tsx
@@ -122,6 +122,13 @@ function ContactPageLayout({ children }: ContactPageLayoutProps) {
         </div>
       </div>
       {children}
+      {selectedContactPage && (
+        <div className={style.privacyAndTerms}>
+          <Typo.p textType="body__secondary--bold">
+            {t(PageText.Contact.contactPageLayout.privacyAndTerms)}
+          </Typo.p>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/page-modules/contact/layouts/layout.module.css
+++ b/src/page-modules/contact/layouts/layout.module.css
@@ -78,3 +78,13 @@
     display: block;
   }
 }
+
+.privacyAndTerms {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: token('spacing.large');
+  margin: token('spacing.xLarge');
+  padding-bottom: 0;
+  margin-bottom: 0;
+}

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -18,6 +18,11 @@ const ContactInternal = {
       'Tilbake til reisesøk',
     ),
     placeholder: _('Velg et skjema', 'Select a form', 'Vel eit skjema'),
+    privacyAndTerms: _(
+      'Vi ber om de personopplysningene vi trenger for å behandle saken din. Du skal derfor ikke legge inn personopplysninger i fritekstfeltene. Personopplysninger er alle opplysninger som kan knytest til en fysisk person, eller bidra til å identifisere en fysisk person.',
+      'We ask for the personal information we need to process your case. You should therefore not enter personal information in the free text field. Personal information is all information that can be linked to a physical person, or help to identify a physical person.',
+      'Vi ber om dei personopplysningane vi treng for å behandle saka di. Du skal derfor ikkje legge inn personopplysningar i fritekstfelta. Personopplysningar er alle opplysningar som kan knytast til ein fysisk person, eller bidra til å identifisere ein fysisk person.',
+    ),
   },
 
   ticketControl: {


### PR DESCRIPTION
Include message telling users not to provide personal information unless asked after in the contact form. Visible to all forms. 


<img width="956" alt="Skjermbilde 2025-04-28 kl  10 48 51" src="https://github.com/user-attachments/assets/4810e115-6628-43b7-b1c8-3bf037cdf92a" />
