### PR TITLE
feat: extend validation bank account number in contact form

### DIFF
--- a/src/page-modules/contact/components/form/form.module.css
+++ b/src/page-modules/contact/components/form/form.module.css
@@ -47,6 +47,10 @@
   cursor: not-allowed;
 }
 
+.input:disabled::placeholder {
+  color: token('color.foreground.dynamic.disabled');
+}
+
 .input:focus-within {
   outline: 0;
   box-shadow: inset 0 0 0 token('border.width.slim')

--- a/src/page-modules/contact/components/form/input.tsx
+++ b/src/page-modules/contact/components/form/input.tsx
@@ -29,6 +29,7 @@ export const Input = ({
   modalContent,
   disabled,
   onChange,
+  placeholder,
 }: InputProps) => {
   const { t } = useTranslation();
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -79,6 +80,7 @@ export const Input = ({
         value={value}
         disabled={disabled}
         onChange={onChange}
+        placeholder={placeholder}
       />
       {errorMessage && <ErrorMessage message={t(errorMessage)} />}
 

--- a/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundCarForm.tsx
+++ b/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundCarForm.tsx
@@ -363,7 +363,11 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
           label={t(
             PageText.Contact.input.bankInformation.bankAccountNumber.label,
           )}
-          type="number"
+          placeholder={t(
+            PageText.Contact.input.bankInformation.bankAccountNumber
+              .placeholder,
+          )}
+          type="text"
           name="bankAccountNumber"
           value={state.context.bankAccountNumber || ''}
           disabled={state.context.hasInternationalBankAccount}

--- a/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundTaxiForm.tsx
+++ b/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundTaxiForm.tsx
@@ -350,7 +350,11 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
           label={t(
             PageText.Contact.input.bankInformation.bankAccountNumber.label,
           )}
-          type="number"
+          placeholder={t(
+            PageText.Contact.input.bankInformation.bankAccountNumber
+              .placeholder,
+          )}
+          type="text"
           name="bankAccountNumber"
           value={state.context.bankAccountNumber || ''}
           disabled={state.context.hasInternationalBankAccount}

--- a/src/page-modules/contact/refund/forms/refund-ticket/otherTicketRefund.tsx
+++ b/src/page-modules/contact/refund/forms/refund-ticket/otherTicketRefund.tsx
@@ -301,7 +301,10 @@ const AboutYouSection = ({ state, send }: AboutYouSectionProps) => {
         label={t(
           PageText.Contact.input.bankInformation.bankAccountNumber.label,
         )}
-        type="number"
+        placeholder={t(
+          PageText.Contact.input.bankInformation.bankAccountNumber.placeholder,
+        )}
+        type="text"
         name="bankAccountNumber"
         value={state.context.bankAccountNumber || ''}
         disabled={state.context.hasInternationalBankAccount}

--- a/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
@@ -351,7 +351,11 @@ const FormContent = ({ state, send }: FormProps) => {
           label={t(
             PageText.Contact.input.bankInformation.bankAccountNumber.label,
           )}
-          type="number"
+          placeholder={t(
+            PageText.Contact.input.bankInformation.bankAccountNumber
+              .placeholder,
+          )}
+          type="text"
           name="bankAccountNumber"
           value={state.context.bankAccountNumber || ''}
           disabled={state.context.hasInternationalBankAccount}

--- a/src/page-modules/contact/validation/validationRules.ts
+++ b/src/page-modules/contact/validation/validationRules.ts
@@ -5,9 +5,22 @@ const removeWhitespace = (value: string): string => value.replace(/\s+/g, '');
 const isNotEmptyOrUndefined = (value: string | undefined): boolean =>
   value !== undefined && removeWhitespace(value) !== '';
 
+const isDigitsOnly = (value: string): boolean => /^\d+$/.test(value);
+
 const hasExpectedLength =
   (expectedLength: number) => (value: string | undefined) =>
     value?.length === expectedLength;
+
+const isValidBankAccount = (value: string): boolean => {
+  if (value.includes('.')) {
+    if (value[4] !== '.' && value[8] !== '.') return false;
+  }
+
+  const cleaned = removeWhitespace(value.replace(/\./g, ''));
+
+  if (!isDigitsOnly(cleaned)) return false;
+  return hasExpectedLength(11)(cleaned);
+};
 
 type ValidationRule = {
   validate: (value: any) => boolean;
@@ -69,6 +82,12 @@ const rulesBankAccountNumber: ValidationRule[] = [
     errorMessage:
       PageText.Contact.input.bankInformation.bankAccountNumber.errorMessages
         .empty,
+  },
+  {
+    validate: isValidBankAccount,
+    errorMessage:
+      PageText.Contact.input.bankInformation.bankAccountNumber.errorMessages
+        .invalidFormat,
   },
 ];
 
@@ -160,7 +179,11 @@ const rulesFeeNumber: ValidationRule[] = [
   },
   {
     validate: hasExpectedLength(4),
-    errorMessage: PageText.Contact.input.feeNumber.errorMessages.notFourDigits,
+    errorMessage: PageText.Contact.input.feeNumber.errorMessages.invalidFormat,
+  },
+  {
+    validate: isDigitsOnly,
+    errorMessage: PageText.Contact.input.feeNumber.errorMessages.invalidFormat,
   },
 ];
 

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -1210,7 +1210,7 @@ const ContactInternal = {
           'Fyll ut gebyrnummeret ditt',
         ),
         invalidFormat: _(
-          'Ugyldig format. Ggebyrnummeret består av fire siffer',
+          'Ugyldig format. Gebyrnummeret består av fire siffer',
           'Invalid format. The fee number consists of four digits',
           'Ugyldig format. Gebyrnummeret består av fire siffer',
         ),

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -913,11 +913,17 @@ const ContactInternal = {
     bankInformation: {
       bankAccountNumber: {
         label: _('Bankkontonummer', 'Bank account number', 'Bankkontonummer'),
+        placeholder: _('xxxx.xx.xxxxx', 'xxxx.xx.xxxxx', 'xxxx.xx.xxxxx'),
         errorMessages: {
           empty: _(
             'Vennligst fyll ut ditt bankkontonummer',
             'Please provide your bank account number',
             'Vennligst fyll ut ditt bankkontonummer',
+          ),
+          invalidFormat: _(
+            'Ugyldig bankkontonummer. Skriv inn et gyldig nummer med 11 siffer.',
+            'Invalid bank account number. Please enter a valid 11-digit number.',
+            'Ugyldig bankkontonummer. Skriv inn eit gyldig nummer med 11 siffer.',
           ),
         },
       },
@@ -1203,10 +1209,10 @@ const ContactInternal = {
           'Enter your fee number',
           'Fyll ut gebyrnummeret ditt',
         ),
-        notFourDigits: _(
-          'Gebyrnummeret består av fire siffer',
-          'The fee number consists of four digits',
-          'Gebyrnummeret består av fire siffer',
+        invalidFormat: _(
+          'Ugyldig format. Ggebyrnummeret består av fire siffer',
+          'Invalid format. The fee number consists of four digits',
+          'Ugyldig format. Gebyrnummeret består av fire siffer',
         ),
       },
     },


### PR DESCRIPTION
Extend validation bank account number in contact form

<img width="881" alt="Skjermbilde 2025-04-28 kl  13 44 46" src="https://github.com/user-attachments/assets/f9cc3d1f-2390-4da6-a290-f9dc28bf8545" />

<img width="871" alt="Skjermbilde 2025-04-28 kl  13 44 11" src="https://github.com/user-attachments/assets/2035d83b-7dd7-4408-b06f-a3697967b278" />
