### PR TITLE
Widget in its more natural habitat

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ NEXT_PUBLIC_PLANNER_ORG_ID=atb yarn build:widget
 
 This will place asset inside `public/widget/<VERSION>` which will be reachable
 through `http://localhost:3000/widget/` or
-`http://localhost:3000/widget/fullscreen/<VERSION>`.
+`http://localhost:3000/widget/fullscreen/<VERSION>` (omitting the version will
+default to the most recent one).
 
 During development you can watch for changes:
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ NEXT_PUBLIC_PLANNER_ORG_ID=atb yarn build:widget
 ```
 
 This will place asset inside `public/widget/<VERSION>` which will be reachable
-through `http://localhost:3000/widget/<VERSION>`.
+through `http://localhost:3000/widget/` or
+`http://localhost:3000/widget/fullscreen/<VERSION>`.
 
 During development you can watch for changes:
 

--- a/src/modules/cookies/cookies-context.tsx
+++ b/src/modules/cookies/cookies-context.tsx
@@ -34,7 +34,7 @@ export type AppCookiesProviderProps = PropsWithChildren<{
 
 export function AppCookiesProvider({
   children,
-  initialCookies,
+  initialCookies = { darkmode: false, language: 'no' },
 }: AppCookiesProviderProps) {
   const language = useCookie<string>(
     LANGUAGE_COOKIE_NAME,

--- a/src/modules/cookies/cookies-context.tsx
+++ b/src/modules/cookies/cookies-context.tsx
@@ -34,7 +34,7 @@ export type AppCookiesProviderProps = PropsWithChildren<{
 
 export function AppCookiesProvider({
   children,
-  initialCookies = { darkmode: false, language: 'no' },
+  initialCookies,
 }: AppCookiesProviderProps) {
   const language = useCookie<string>(
     LANGUAGE_COOKIE_NAME,

--- a/src/pages/widget/fullscreen/[[...version]].tsx
+++ b/src/pages/widget/fullscreen/[[...version]].tsx
@@ -1,0 +1,117 @@
+import { useEffect, useRef, useState } from 'react';
+import DefaultLayout from '@atb/layouts/default';
+import { type WithGlobalData } from '@atb/layouts/global-data';
+import type { NextPage } from 'next';
+import Head from 'next/head';
+import { useRouter } from 'next/router';
+import type { createWidget, PlannerWebOutput } from '@atb/widget/widget';
+import { compressToEncodedURIComponent } from 'lz-string';
+import { useTheme } from '@atb/modules/theme';
+
+const currentOrg = process.env.NEXT_PUBLIC_PLANNER_ORG_ID;
+
+if (!currentOrg) {
+  throw new Error('Missing env NEXT_PUBLIC_PLANNER_ORG_ID');
+}
+
+const compressedOrgId = compressToEncodedURIComponent(currentOrg);
+
+declare global {
+  interface Window {
+    PlannerWeb: {
+      createWidget: typeof createWidget;
+    };
+  }
+}
+
+const WidgetPage: NextPage<WithGlobalData<{}>> = ({ ...props }) => {
+  const currentUrlBase = 'http://localhost:3000';
+
+  const router = useRouter();
+  const [isLoaded, setLoaded] = useState(false);
+  const [html, setHtml] = useState('');
+  const lib = useRef<PlannerWebOutput | null>(null);
+
+  const theme = useTheme();
+
+  useEffect(() => {
+    if (!router.isReady) return; // Wait for the router to be ready
+
+    const { version: versionParam } = router.query; // Access the id from the query
+    const version = Array.isArray(versionParam)
+      ? versionParam[0]
+      : versionParam; // Handle dynamic routes
+
+    if (version) {
+      setLoaded(false); // Reset the loading state
+      const scriptUrl = `${currentUrlBase}/widget/${compressedOrgId}/${version}/planner-web.umd.js`;
+
+      const loadWidget = () => {
+        if (window.PlannerWeb?.createWidget) {
+          lib.current = window.PlannerWeb.createWidget({
+            urlBase: currentUrlBase,
+            language: 'nb',
+          });
+
+          setHtml(lib.current.output);
+          setLoaded(true);
+        } else {
+          console.error('PlannerWeb.createWidget is not defined');
+        }
+      };
+
+      // Dynamically load the script if not already loaded
+      const existingScript = document.querySelector(
+        `script[src="${scriptUrl}"]`,
+      );
+      if (!existingScript) {
+        const script = document.createElement('script');
+        script.src = scriptUrl;
+        script.async = true;
+        script.onload = loadWidget;
+        document.body.appendChild(script);
+      } else {
+        loadWidget();
+      }
+    }
+  }, [router.isReady, router.query]);
+
+  useEffect(() => {
+    if (html) {
+      lib.current?.init();
+    }
+  }, [html]);
+
+  return (
+    <DefaultLayout {...props}>
+      <Head>
+        <link
+          rel="stylesheet"
+          href={`${currentUrlBase}/widget/${compressedOrgId}/${router.query.version?.[0]}/planner-web.css`}
+        />
+        <style>
+          {`
+          .wrapper {
+            background: ${theme.color.background.accent[0].background};
+            display: flex;
+            justify-content: center;
+            padding: 20px 0;
+          }
+          .widget {
+            max-width: 1140px;
+            margin: 0 auto;
+          }
+        `}
+        </style>
+      </Head>
+      <div className="wrapper">
+        <div id="planner-widget" className="widget">
+          <div dangerouslySetInnerHTML={{ __html: html }} />
+        </div>
+      </div>
+      {!isLoaded && <p>Loading widget...</p>}
+    </DefaultLayout>
+  );
+};
+
+export default WidgetPage;


### PR DESCRIPTION
This makes it possible to access a version of the widget a bit more "in context".
Made as part of becoming familiar with the widget ~~not sure if we should merge this?~~ To be merged due to [_popular demand_](https://github.com/AtB-AS/planner-web/pull/531#issuecomment-2835374418).
Going to `http://localhost:3000/widget/fullscreen` will default to the most recent version of the widget, or a specific version can be selected, such as e.g. `http://localhost:3000/widget/fullscreen/2.0.0`

The implementation is mostly based on the existing `src/pages/widget/index.tsx`.

![Skjermbilde 2025-04-28 kl  15 59 57](https://github.com/user-attachments/assets/2512af72-3079-415a-a044-b840d8de2003)

