### PR TITLE
fix(accessibility): move label inside date/time fields to fix aria label issues in date/time components

### DIFF
--- a/src/page-modules/contact/components/form/date-selector.tsx
+++ b/src/page-modules/contact/components/form/date-selector.tsx
@@ -38,7 +38,6 @@ export default function DateSelector({
 
   return (
     <div className={style.dateSelectorContainer}>
-      <Label>{t(label)}</Label>
       <DatePicker
         granularity="day"
         value={zonedDateTime}
@@ -46,9 +45,15 @@ export default function DateSelector({
         className={style.dateSelector}
         shouldForceLeadingZeros
       >
+        <Label>{t(label)}</Label>
         <Group className={style.calendarSelectorGroup}>
           <DateInput className={style.dateSelectorInput}>
-            {(segment) => <DateSegment segment={segment} />}
+            {(segment) => (
+              <DateSegment
+                segment={segment}
+                className={style.dateSelectorSegment}
+              />
+            )}
           </DateInput>
           <Button className={style.calendarButton}>
             <MonoIcon icon="time/Date" />

--- a/src/page-modules/contact/components/form/form.module.css
+++ b/src/page-modules/contact/components/form/form.module.css
@@ -467,6 +467,7 @@
 
 .dateSelector,
 .timeSelector {
+  display: contents;
   --height: 2.75rem;
   overflow: hidden;
   border-radius: token('border.radius.small');
@@ -480,6 +481,30 @@
   background-color: transparent;
   color: token('color.background.neutral.0.foreground.primary');
   flex: 1;
+}
+
+.dateSelectorInput,
+.timeSelectorInput {
+  width: 100%;
+  height: var(--height);
+  display: flex;
+  align-items: center;
+  padding: token('spacing.medium');
+  color: token('color.background.neutral.0.foreground.primary');
+  border-radius: token('border.radius.small');
+  border: token('border.width.slim') solid
+    token('color.foreground.dynamic.primary');
+}
+
+.dateSelectorInput:focus-within,
+.timeSelectorInput:focus-within {
+  box-shadow: inset 0 0 0 token('border.width.slim')
+    token('color.interactive.2.outline.background');
+}
+
+.dateSelectorSegment:focus,
+.timeSelectorSegment:focus {
+  border-radius: token('border.radius.small');
 }
 
 .calendarSelectorGroup {
@@ -544,30 +569,6 @@
   color: token('color.interactive.2.active.foreground.primary');
   font-weight: bold;
   border-radius: token('border.radius.small');
-}
-
-.dateSelectorInput,
-.timeSelectorInput {
-  width: 100%;
-  height: var(--height);
-  display: flex;
-  align-items: center;
-  padding: token('spacing.medium');
-  color: token('color.background.neutral.0.foreground.primary');
-  border-radius: token('border.radius.small');
-  border: token('border.width.slim') solid
-    token('color.foreground.dynamic.primary');
-}
-
-.dateSelector input[type='date']:focus,
-.timeSelector input[type='time']:focus {
-  outline: 0;
-}
-
-.dateSelector:focus-within,
-.timeSelector:focus-within {
-  box-shadow: inset 0 0 0 token('border.width.medium')
-    token('color.interactive.2.outline.background');
 }
 
 :global(.dark)

--- a/src/page-modules/contact/components/form/time-selector.tsx
+++ b/src/page-modules/contact/components/form/time-selector.tsx
@@ -26,7 +26,6 @@ export default function TimeSelector({
 
   return (
     <div className={style.timeSelectorContainer}>
-      <Label>{t(label)}</Label>
       <TimeField
         value={parsedValue}
         onChange={(change) => {
@@ -39,6 +38,7 @@ export default function TimeSelector({
         data-testid="searchTimeSelector-time"
         granularity="minute"
       >
+        <Label>{t(label)}</Label>
         <DateInput className={style.timeSelectorInput}>
           {(segment) => (
             <DateSegment


### PR DESCRIPTION
Move Label inside DatePicker and TimeFiled to avoid aria-lable error messages. Afterwards, update the css styling to make the components appear as before.

| Before | After |
|--------|--------|
| <img width="1070" alt="Skjermbilde 2025-04-29 kl  11 03 55" src="https://github.com/user-attachments/assets/529963b5-28bf-4c06-b1ec-adeac5a6c604" /> |<img width="1077" alt="Skjermbilde 2025-04-29 kl  11 04 10" src="https://github.com/user-attachments/assets/19647a96-3dc8-468c-9413-c2ba42445a3b" /> |





