### PR TITLE
feat: reduce maxSlack in viaTripQuery

### DIFF
--- a/src/page-modules/assistant/server/journey-planner/index.ts
+++ b/src/page-modules/assistant/server/journey-planner/index.ts
@@ -391,7 +391,7 @@ function inputToViaLocation(input: TripInput) {
     },
     name: input.via.name,
     minSlack: 'PT120S',
-    maxSlack: 'PT9H',
+    maxSlack: 'PT2H',
   };
 }
 


### PR DESCRIPTION
Unexpected behavior has been reported concerning the via search. Since the max slack has been set to 9 hours, a high number of suggestions will be returned for the same second departure (see image). The reason behind the 9 hours seems to be lost (and no significant use-case identified by AtB or FRAM), so reducing to 2 hours for now.

![image](https://github.com/user-attachments/assets/53595ab2-7ef5-4019-b0a2-97d43e54158f)
