### PR TITLE
feat: id property to textarea component

### DIFF
--- a/src/page-modules/contact/components/form/textarea.tsx
+++ b/src/page-modules/contact/components/form/textarea.tsx
@@ -5,13 +5,23 @@ export type CheckboxProps = {
   onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
   error?: string;
   value: string;
-};
+} & JSX.IntrinsicElements['textarea'];
 
-export default function Textarea({ onChange, error, value }: CheckboxProps) {
+export default function Textarea({
+  onChange,
+  error,
+  value,
+  name,
+}: CheckboxProps) {
   return (
-    <div>
-      <textarea className={style.textarea} value={value} onChange={onChange} />
+    <>
+      <textarea
+        name={name}
+        className={style.textarea}
+        value={value}
+        onChange={onChange}
+      />
       {error && <ErrorMessage message={error} />}
-    </div>
+    </>
   );
 }

--- a/src/page-modules/contact/components/form/textarea.tsx
+++ b/src/page-modules/contact/components/form/textarea.tsx
@@ -8,15 +8,15 @@ export type CheckboxProps = {
 } & JSX.IntrinsicElements['textarea'];
 
 export default function Textarea({
+  id,
   onChange,
   error,
   value,
-  name,
 }: CheckboxProps) {
   return (
     <>
       <textarea
-        name={name}
+        id={`textarea__${id}`}
         className={style.textarea}
         value={value}
         onChange={onChange}

--- a/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
@@ -160,6 +160,7 @@ export const DelayForm = ({ state, send }: DelayFormProps) => {
           {t(PageText.Contact.input.feedback.description)}
         </Typo.p>
         <Textarea
+          name="feedback"
           value={state.context.feedback || ''}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
@@ -160,7 +160,7 @@ export const DelayForm = ({ state, send }: DelayFormProps) => {
           {t(PageText.Contact.input.feedback.description)}
         </Typo.p>
         <Textarea
-          name="feedback"
+          id="feedback"
           value={state.context.feedback || ''}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
@@ -160,6 +160,7 @@ export const DriverForm = ({ state, send }: DriverFormProps) => {
           {t(PageText.Contact.input.feedback.description)}
         </Typo.p>
         <Textarea
+          name="feedback"
           value={state.context.feedback || ''}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
@@ -160,7 +160,7 @@ export const DriverForm = ({ state, send }: DriverFormProps) => {
           {t(PageText.Contact.input.feedback.description)}
         </Typo.p>
         <Textarea
-          name="feedback"
+          id="feedback"
           value={state.context.feedback || ''}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
@@ -159,6 +159,7 @@ export const InjuryForm = ({ state, send }: InjuryFormProps) => {
           {t(PageText.Contact.input.feedback.description)}
         </Typo.p>
         <Textarea
+          name="feedback"
           value={state.context.feedback || ''}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
@@ -159,7 +159,7 @@ export const InjuryForm = ({ state, send }: InjuryFormProps) => {
           {t(PageText.Contact.input.feedback.description)}
         </Typo.p>
         <Textarea
-          name="feedback"
+          id="feedback"
           value={state.context.feedback || ''}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/means-of-transport/forms/serviceOfferingForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/serviceOfferingForm.tsx
@@ -98,6 +98,7 @@ export const ServiceOfferingForm = ({
           {t(PageText.Contact.input.feedback.description)}
         </Typo.p>
         <Textarea
+          name="feedback"
           value={state.context.feedback || ''}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/means-of-transport/forms/serviceOfferingForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/serviceOfferingForm.tsx
@@ -98,7 +98,7 @@ export const ServiceOfferingForm = ({
           {t(PageText.Contact.input.feedback.description)}
         </Typo.p>
         <Textarea
-          name="feedback"
+          id="feedback"
           value={state.context.feedback || ''}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/means-of-transport/forms/stopForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/stopForm.tsx
@@ -123,6 +123,7 @@ export const StopForm = ({ state, send }: StopFormProps) => {
           {t(PageText.Contact.input.feedback.description)}
         </Typo.p>
         <Textarea
+          name="feedback"
           value={state.context.feedback || ''}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/means-of-transport/forms/stopForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/stopForm.tsx
@@ -123,7 +123,7 @@ export const StopForm = ({ state, send }: StopFormProps) => {
           {t(PageText.Contact.input.feedback.description)}
         </Typo.p>
         <Textarea
-          name="feedback"
+          id="feedback"
           value={state.context.feedback || ''}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
@@ -168,7 +168,7 @@ export const TransportationForm = ({
           {t(PageText.Contact.input.feedback.description)}
         </Typo.p>
         <Textarea
-          name="feedback"
+          id="feedback"
           value={state.context.feedback || ''}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
@@ -168,6 +168,7 @@ export const TransportationForm = ({
           {t(PageText.Contact.input.feedback.description)}
         </Typo.p>
         <Textarea
+          name="feedback"
           value={state.context.feedback || ''}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundCarForm.tsx
+++ b/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundCarForm.tsx
@@ -230,6 +230,7 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
 
       <Fieldset title={t(PageText.Contact.input.feedback.optionalTitle)}>
         <Textarea
+          name="feedback"
           value={state.context.feedback || ''}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundCarForm.tsx
+++ b/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundCarForm.tsx
@@ -230,7 +230,7 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
 
       <Fieldset title={t(PageText.Contact.input.feedback.optionalTitle)}>
         <Textarea
-          name="feedback"
+          id="feedback"
           value={state.context.feedback || ''}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundTaxiForm.tsx
+++ b/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundTaxiForm.tsx
@@ -214,7 +214,7 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
       </Fieldset>
       <Fieldset title={t(PageText.Contact.input.feedback.optionalTitle)}>
         <Textarea
-          name="feedback"
+          id="feedback"
           value={state.context.feedback || ''}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundTaxiForm.tsx
+++ b/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundTaxiForm.tsx
@@ -214,6 +214,7 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
       </Fieldset>
       <Fieldset title={t(PageText.Contact.input.feedback.optionalTitle)}>
         <Textarea
+          name="feedback"
           value={state.context.feedback || ''}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/refund/forms/refund-ticket/appTicketRefund.tsx
+++ b/src/page-modules/contact/refund/forms/refund-ticket/appTicketRefund.tsx
@@ -96,6 +96,7 @@ export const AppTicketRefund = ({ state, send }: AppTicketRefundProps) => {
       </Typo.p>
 
       <Textarea
+        name="refundReason"
         value={state.context.refundReason || ''}
         onChange={(e) =>
           send({

--- a/src/page-modules/contact/refund/forms/refund-ticket/appTicketRefund.tsx
+++ b/src/page-modules/contact/refund/forms/refund-ticket/appTicketRefund.tsx
@@ -96,7 +96,7 @@ export const AppTicketRefund = ({ state, send }: AppTicketRefundProps) => {
       </Typo.p>
 
       <Textarea
-        name="refundReason"
+        id="refundReason"
         value={state.context.refundReason || ''}
         onChange={(e) =>
           send({

--- a/src/page-modules/contact/refund/forms/refund-ticket/otherTicketRefund.tsx
+++ b/src/page-modules/contact/refund/forms/refund-ticket/otherTicketRefund.tsx
@@ -141,6 +141,7 @@ const RefundSection = ({ state, send }: RefundSectionProps) => {
       </Typo.p>
 
       <Textarea
+        name="refundReason"
         value={state.context.refundReason || ''}
         onChange={(e) =>
           send({

--- a/src/page-modules/contact/refund/forms/refund-ticket/otherTicketRefund.tsx
+++ b/src/page-modules/contact/refund/forms/refund-ticket/otherTicketRefund.tsx
@@ -141,7 +141,7 @@ const RefundSection = ({ state, send }: RefundSectionProps) => {
       </Typo.p>
 
       <Textarea
-        name="refundReason"
+        id="refundReason"
         value={state.context.refundReason || ''}
         onChange={(e) =>
           send({

--- a/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
@@ -212,7 +212,7 @@ const FormContent = ({ state, send }: FormProps) => {
       </Fieldset>
       <Fieldset title={t(PageText.Contact.input.feedback.title)}>
         <Textarea
-          name="feedback"
+          id="feedback"
           value={state.context.feedback || ''}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
@@ -212,6 +212,7 @@ const FormContent = ({ state, send }: FormProps) => {
       </Fieldset>
       <Fieldset title={t(PageText.Contact.input.feedback.title)}>
         <Textarea
+          name="feedback"
           value={state.context.feedback || ''}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
@@ -142,7 +142,7 @@ export const FeedbackForm = ({ state, send }: FeedbackFormProps) => {
       </Fieldset>
       <Fieldset title={t(PageText.Contact.input.feedback.title)}>
         <Textarea
-          name="feedback"
+          id="feedback"
           value={state.context.feedback || ''}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
@@ -142,6 +142,7 @@ export const FeedbackForm = ({ state, send }: FeedbackFormProps) => {
       </Fieldset>
       <Fieldset title={t(PageText.Contact.input.feedback.title)}>
         <Textarea
+          name="feedback"
           value={state.context.feedback || ''}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/ticket-control/ticket-control-form-machine.ts
+++ b/src/page-modules/contact/ticket-control/ticket-control-form-machine.ts
@@ -178,10 +178,6 @@ export const ticketControlFormMachine = setup({
       event.formType === FormType.PostponePayment,
   },
   actions: {
-    cleanErrorMessages: assign({
-      errorMessages: () => ({}),
-    }),
-
     navigateToErrorPage: () => {
       window.location.href = '/contact/error';
     },
@@ -331,7 +327,7 @@ export const ticketControlFormMachine = setup({
           entry: assign({
             formType: () => FormType.FeeComplaint,
           }),
-          exit: 'cleanErrorMessages',
+          exit: 'clearValidationErrors',
         },
         feedback: {
           id: 'feedback',

--- a/src/page-modules/contact/ticket-control/ticket-control-form-machine.ts
+++ b/src/page-modules/contact/ticket-control/ticket-control-form-machine.ts
@@ -178,6 +178,10 @@ export const ticketControlFormMachine = setup({
       event.formType === FormType.PostponePayment,
   },
   actions: {
+    cleanErrorMessages: assign({
+      errorMessages: () => ({}),
+    }),
+
     navigateToErrorPage: () => {
       window.location.href = '/contact/error';
     },
@@ -327,7 +331,7 @@ export const ticketControlFormMachine = setup({
           entry: assign({
             formType: () => FormType.FeeComplaint,
           }),
-          exit: 'clearValidationErrors',
+          exit: 'cleanErrorMessages',
         },
         feedback: {
           id: 'feedback',

--- a/src/page-modules/contact/ticketing/forms/app/appAccountForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/app/appAccountForm.tsx
@@ -19,7 +19,7 @@ export const AppAccountForm = ({ state, send }: AppAccountFormProps) => {
           {t(PageText.Contact.input.question.info)}
         </Typo.p>
         <Textarea
-          name="question"
+          id="question"
           value={state.context.question || ''}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/ticketing/forms/app/appAccountForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/app/appAccountForm.tsx
@@ -19,6 +19,7 @@ export const AppAccountForm = ({ state, send }: AppAccountFormProps) => {
           {t(PageText.Contact.input.question.info)}
         </Typo.p>
         <Textarea
+          name="question"
           value={state.context.question || ''}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/ticketing/forms/app/appTicketingForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/app/appTicketingForm.tsx
@@ -44,6 +44,7 @@ export const AppTicketingForm = ({ state, send }: AppTicketingFormProps) => {
           {t(PageText.Contact.input.question.info)}
         </Typo.p>
         <Textarea
+          name="question"
           value={state.context.question || ''}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/ticketing/forms/app/appTicketingForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/app/appTicketingForm.tsx
@@ -44,7 +44,7 @@ export const AppTicketingForm = ({ state, send }: AppTicketingFormProps) => {
           {t(PageText.Contact.input.question.info)}
         </Typo.p>
         <Textarea
-          name="question"
+          id="question"
           value={state.context.question || ''}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/ticketing/forms/app/appTravelSuggestionForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/app/appTravelSuggestionForm.tsx
@@ -22,7 +22,7 @@ export const AppTravelSuggestionForm = ({
           {t(PageText.Contact.input.question.info)}
         </Typo.p>
         <Textarea
-          name="question"
+          id="question"
           value={state.context.question || ''}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/ticketing/forms/app/appTravelSuggestionForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/app/appTravelSuggestionForm.tsx
@@ -22,6 +22,7 @@ export const AppTravelSuggestionForm = ({
           {t(PageText.Contact.input.question.info)}
         </Typo.p>
         <Textarea
+          name="question"
           value={state.context.question || ''}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/ticketing/forms/priceAndTicketTypesForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/priceAndTicketTypesForm.tsx
@@ -22,6 +22,7 @@ export const PriceAndTicketTypesForm = ({
           {t(PageText.Contact.input.question.info)}
         </Typo.p>
         <Textarea
+          name="question"
           value={state.context.question || ''}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/ticketing/forms/priceAndTicketTypesForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/priceAndTicketTypesForm.tsx
@@ -22,7 +22,7 @@ export const PriceAndTicketTypesForm = ({
           {t(PageText.Contact.input.question.info)}
         </Typo.p>
         <Textarea
-          name="question"
+          id="question"
           value={state.context.question || ''}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/ticketing/forms/travel-card/travelCardQuestionForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/travel-card/travelCardQuestionForm.tsx
@@ -46,7 +46,7 @@ export const TravelCardQuestionForm = ({
           {t(PageText.Contact.input.question.info)}
         </Typo.p>
         <Textarea
-          name="question"
+          id="question"
           value={state.context.question || ''}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/ticketing/forms/travel-card/travelCardQuestionForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/travel-card/travelCardQuestionForm.tsx
@@ -46,6 +46,7 @@ export const TravelCardQuestionForm = ({
           {t(PageText.Contact.input.question.info)}
         </Typo.p>
         <Textarea
+          name="question"
           value={state.context.question || ''}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/ticketing/forms/webshop/webshopAccountForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/webshop/webshopAccountForm.tsx
@@ -22,6 +22,7 @@ export const WebshopAccountForm = ({
           {t(PageText.Contact.input.question.info)}
         </Typo.p>
         <Textarea
+          name="question"
           value={state.context.question || ''}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/ticketing/forms/webshop/webshopAccountForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/webshop/webshopAccountForm.tsx
@@ -22,7 +22,7 @@ export const WebshopAccountForm = ({
           {t(PageText.Contact.input.question.info)}
         </Typo.p>
         <Textarea
-          name="question"
+          id="question"
           value={state.context.question || ''}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/ticketing/forms/webshop/webshopTicketingForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/webshop/webshopTicketingForm.tsx
@@ -53,6 +53,7 @@ export const WebshopTicketingForm = ({
           {t(PageText.Contact.input.question.info)}
         </Typo.p>
         <Textarea
+          name="question"
           value={state.context.question || ''}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/ticketing/forms/webshop/webshopTicketingForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/webshop/webshopTicketingForm.tsx
@@ -53,7 +53,7 @@ export const WebshopTicketingForm = ({
           {t(PageText.Contact.input.question.info)}
         </Typo.p>
         <Textarea
-          name="question"
+          id="question"
           value={state.context.question || ''}
           onChange={(e) =>
             send({


### PR DESCRIPTION
Add id property to textarea component. This is done to include the textarea component in the automatic focus and scroll on submit,  as described in https://github.com/AtB-AS/planner-web/pull/539.