### PR TITLE
feat: automatic focus on the first form error message

### DIFF
--- a/src/page-modules/contact/components/form/input.tsx
+++ b/src/page-modules/contact/components/form/input.tsx
@@ -9,6 +9,7 @@ import DescriptionModal from './description-modal';
 import { ErrorMessage } from '@atb/components/error-message';
 
 type InputProps = {
+  id: string;
   label: string;
   modalContent?: {
     description?: string;
@@ -20,6 +21,7 @@ type InputProps = {
 } & JSX.IntrinsicElements['input'];
 
 export const Input = ({
+  id,
   label,
   errorMessage,
   type,
@@ -70,6 +72,7 @@ export const Input = ({
         )}
       </div>
       <input
+        id={`input__${id}`}
         type={type}
         name={name}
         className={andIf({

--- a/src/page-modules/contact/means-of-transport/events.ts
+++ b/src/page-modules/contact/means-of-transport/events.ts
@@ -14,6 +14,7 @@ const meansOfTransportSpecificFormEvents = {} as
     }
   | {
       type: 'SUBMIT';
+      orderedFormFieldNames: string[];
     };
 
 export const meansOfTransportFormEvents = {} as

--- a/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
@@ -188,6 +188,7 @@ export const DelayForm = ({ state, send }: DelayFormProps) => {
       </Fieldset>
       <Fieldset title={t(PageText.Contact.aboutYouInfo.optionalTitle)}>
         <Input
+          id="firstName"
           label={t(PageText.Contact.input.firstName.label)}
           type="text"
           name="firstName"
@@ -202,6 +203,7 @@ export const DelayForm = ({ state, send }: DelayFormProps) => {
         />
 
         <Input
+          id="lastName"
           label={t(PageText.Contact.input.lastName.label)}
           type="text"
           name="lastName"
@@ -216,6 +218,7 @@ export const DelayForm = ({ state, send }: DelayFormProps) => {
         />
 
         <Input
+          id="email"
           label={t(PageText.Contact.input.email.label)}
           type="email"
           name="email"

--- a/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
@@ -188,6 +188,7 @@ export const DriverForm = ({ state, send }: DriverFormProps) => {
       </Fieldset>
       <Fieldset title={t(PageText.Contact.aboutYouInfo.optionalTitle)}>
         <Input
+          id="firstName"
           label={t(PageText.Contact.input.firstName.label)}
           type="text"
           name="firstName"
@@ -202,6 +203,7 @@ export const DriverForm = ({ state, send }: DriverFormProps) => {
         />
 
         <Input
+          id="lastName"
           label={t(PageText.Contact.input.lastName.label)}
           type="text"
           name="lastName"
@@ -216,6 +218,7 @@ export const DriverForm = ({ state, send }: DriverFormProps) => {
         />
 
         <Input
+          id="email"
           label={t(PageText.Contact.input.email.label)}
           type="email"
           name="email"

--- a/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
@@ -187,6 +187,7 @@ export const InjuryForm = ({ state, send }: InjuryFormProps) => {
       </Fieldset>
       <Fieldset title={t(PageText.Contact.aboutYouInfo.optionalTitle)}>
         <Input
+          id="firstName"
           label={t(PageText.Contact.input.firstName.label)}
           type="text"
           name="firstName"
@@ -201,6 +202,7 @@ export const InjuryForm = ({ state, send }: InjuryFormProps) => {
         />
 
         <Input
+          id="lastName"
           label={t(PageText.Contact.input.lastName.label)}
           type="text"
           name="lastName"
@@ -215,6 +217,7 @@ export const InjuryForm = ({ state, send }: InjuryFormProps) => {
         />
 
         <Input
+          id="email"
           label={t(PageText.Contact.input.email.label)}
           type="email"
           name="email"

--- a/src/page-modules/contact/means-of-transport/forms/serviceOfferingForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/serviceOfferingForm.tsx
@@ -126,6 +126,7 @@ export const ServiceOfferingForm = ({
       </Fieldset>
       <Fieldset title={t(PageText.Contact.aboutYouInfo.optionalTitle)}>
         <Input
+          id="firstName"
           label={t(PageText.Contact.input.firstName.label)}
           type="text"
           name="firstName"
@@ -140,6 +141,7 @@ export const ServiceOfferingForm = ({
         />
 
         <Input
+          id="lastName"
           label={t(PageText.Contact.input.lastName.label)}
           type="text"
           name="lastName"

--- a/src/page-modules/contact/means-of-transport/forms/stopForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/stopForm.tsx
@@ -151,6 +151,7 @@ export const StopForm = ({ state, send }: StopFormProps) => {
       </Fieldset>
       <Fieldset title={t(PageText.Contact.aboutYouInfo.optionalTitle)}>
         <Input
+          id="firstName"
           label={t(PageText.Contact.input.firstName.label)}
           type="text"
           name="firstName"
@@ -165,6 +166,7 @@ export const StopForm = ({ state, send }: StopFormProps) => {
         />
 
         <Input
+          id="lastName"
           label={t(PageText.Contact.input.lastName.label)}
           type="text"
           name="lastName"
@@ -179,6 +181,7 @@ export const StopForm = ({ state, send }: StopFormProps) => {
         />
 
         <Input
+          id="email"
           label={t(PageText.Contact.input.email.label)}
           type="email"
           name="email"

--- a/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
@@ -196,6 +196,7 @@ export const TransportationForm = ({
       </Fieldset>
       <Fieldset title={t(PageText.Contact.aboutYouInfo.optionalTitle)}>
         <Input
+          id="firstName"
           label={t(PageText.Contact.input.firstName.label)}
           type="text"
           name="firstName"
@@ -210,6 +211,7 @@ export const TransportationForm = ({
         />
 
         <Input
+          id="lastName"
           label={t(PageText.Contact.input.lastName.label)}
           type="text"
           name="lastName"
@@ -224,6 +226,7 @@ export const TransportationForm = ({
         />
 
         <Input
+          id="email"
           label={t(PageText.Contact.input.email.isResponseWanted.label)}
           type="email"
           name="email"

--- a/src/page-modules/contact/means-of-transport/index.tsx
+++ b/src/page-modules/contact/means-of-transport/index.tsx
@@ -16,6 +16,7 @@ import { PageText, useTranslation } from '@atb/translations';
 import { FormEventHandler } from 'react';
 import { Radio, Fieldset } from '../components';
 import style from '../contact.module.css';
+import { findOrderFormFields } from '../utils';
 
 const MeansOfTransportContent = () => {
   const { t } = useTranslation();
@@ -24,7 +25,7 @@ const MeansOfTransportContent = () => {
 
   const onSubmit: FormEventHandler<HTMLFormElement> = async (e) => {
     e.preventDefault();
-    send({ type: 'SUBMIT' });
+    send({ type: 'SUBMIT', orderedFormFieldNames: findOrderFormFields(e) });
   };
 
   return (

--- a/src/page-modules/contact/refund/events.ts
+++ b/src/page-modules/contact/refund/events.ts
@@ -79,6 +79,7 @@ const RefundSpecificFormEvents = {} as
     }
   | {
       type: 'SUBMIT';
+      orderedFormFieldNames: string[];
     };
 
 export const RefundFormEvents = {} as typeof RefundSpecificFormEvents;

--- a/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundCarForm.tsx
+++ b/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundCarForm.tsx
@@ -31,9 +31,10 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
     <>
       <Fieldset title={t(PageText.Contact.refund.refundTaxi.carTrip.title)}>
         <Input
+          id="kilometersDriven"
           label={t(PageText.Contact.input.kilometersDriven.label)}
           type="text"
-          name="km"
+          name="kilometersDriven"
           value={state.context.kilometersDriven || ''}
           errorMessage={
             state.context?.errorMessages['kilometersDriven']?.[0] || undefined
@@ -47,6 +48,7 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
           }
         />
         <Input
+          id="fromAddress"
           label={t(PageText.Contact.input.fromAddress.label)}
           type="text"
           name="fromAddress"
@@ -63,9 +65,10 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
           }
         />
         <Input
+          id="toAddress"
           label={t(PageText.Contact.input.toAddress.label)}
-          type="toAddress"
-          name="km"
+          type="text"
+          name="toAddress"
           value={state.context.toAddress || ''}
           errorMessage={
             state.context?.errorMessages['toAddress']?.[0] || undefined
@@ -254,6 +257,7 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
       </Fieldset>
       <Fieldset title={t(PageText.Contact.aboutYouInfo.title)}>
         <Input
+          id="firstName"
           label={t(PageText.Contact.input.firstName.label)}
           type="text"
           autoComplete="given-name additional-name"
@@ -270,6 +274,7 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
         />
 
         <Input
+          id="lastName"
           label={t(PageText.Contact.input.lastName.label)}
           type="text"
           autoComplete="family-name"
@@ -285,6 +290,7 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
           }
         />
         <Input
+          id="address"
           label={t(PageText.Contact.input.address.label)}
           type="text"
           autoComplete="street-address"
@@ -300,6 +306,7 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
           }
         />
         <Input
+          id="postalCode"
           label={t(PageText.Contact.input.postalCode.label)}
           type="number"
           autoComplete="postal-code"
@@ -315,6 +322,7 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
           }
         />
         <Input
+          id="city"
           label={t(PageText.Contact.input.city.label)}
           type="text"
           name="city"
@@ -329,6 +337,7 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
           }
         />
         <Input
+          id="email"
           label={t(PageText.Contact.input.email.label)}
           type="email"
           autoComplete="email"
@@ -345,6 +354,7 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
         />
 
         <Input
+          id="phoneNumber"
           label={t(PageText.Contact.input.phoneNumber.label)}
           type="tel"
           name="phoneNumber"
@@ -360,6 +370,7 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
         />
 
         <Input
+          id="bankAccountNumber"
           label={t(
             PageText.Contact.input.bankInformation.bankAccountNumber.label,
           )}
@@ -396,6 +407,7 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
         {state.context.hasInternationalBankAccount && (
           <div>
             <Input
+              id="IBAN"
               label={t(PageText.Contact.input.bankInformation.IBAN.label)}
               type="string"
               name="IBAN"
@@ -411,6 +423,7 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
             />
 
             <Input
+              id="SWIFT"
               label={t(PageText.Contact.input.bankInformation.SWIFT.label)}
               type="string"
               name="SWIFT"

--- a/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundTaxiForm.tsx
+++ b/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundTaxiForm.tsx
@@ -48,6 +48,7 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
           errorMessage={state.context?.errorMessages['attachments']?.[0]}
         />
         <Input
+          id="amount"
           label={t(PageText.Contact.input.amount.label)}
           type="text"
           name="amount"
@@ -240,6 +241,7 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
       </Fieldset>
       <Fieldset title={t(PageText.Contact.aboutYouInfo.title)}>
         <Input
+          id="firstName"
           label={t(PageText.Contact.input.firstName.label)}
           type="text"
           autoComplete="given-name additional-name"
@@ -256,6 +258,7 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
         />
 
         <Input
+          id="lastName"
           label={t(PageText.Contact.input.lastName.label)}
           type="text"
           autoComplete="family-name"
@@ -271,6 +274,7 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
           }
         />
         <Input
+          id="address"
           label={t(PageText.Contact.input.address.label)}
           type="text"
           autoComplete="street-address"
@@ -286,6 +290,7 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
           }
         />
         <Input
+          id="postalCode"
           label={t(PageText.Contact.input.postalCode.label)}
           type="number"
           autoComplete="postal-code"
@@ -301,6 +306,7 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
           }
         />
         <Input
+          id="city"
           label={t(PageText.Contact.input.city.label)}
           type="text"
           name="city"
@@ -315,6 +321,7 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
           }
         />
         <Input
+          id="email"
           label={t(PageText.Contact.input.email.label)}
           type="email"
           autoComplete="email"
@@ -330,6 +337,7 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
           }
         />
         <Input
+          id="phoneNumber"
           label={t(PageText.Contact.input.phoneNumber.label)}
           type="tel"
           name="phoneNumber"
@@ -345,6 +353,7 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
         />
 
         <Input
+          id="bankAccountNumber"
           label={t(
             PageText.Contact.input.bankInformation.bankAccountNumber.label,
           )}
@@ -381,6 +390,7 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
         {state.context.hasInternationalBankAccount && (
           <div>
             <Input
+              id="IBAN"
               label={t(PageText.Contact.input.bankInformation.IBAN.label)}
               type="string"
               name="IBAN"
@@ -396,6 +406,7 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
             />
 
             <Input
+              id="SWIFT"
               label={t(PageText.Contact.input.bankInformation.SWIFT.label)}
               type="string"
               name="SWIFT"

--- a/src/page-modules/contact/refund/forms/refund-ticket/appTicketRefund.tsx
+++ b/src/page-modules/contact/refund/forms/refund-ticket/appTicketRefund.tsx
@@ -2,7 +2,7 @@ import { PageText, useTranslation } from '@atb/translations';
 import { RefundContextProps } from '../../refundFormMachine';
 import { RefundFormEvents } from '../../events';
 import { Typo } from '@atb/components/typography';
-import { PurchasePlatformType, TransportModeType } from '../../../types';
+import { PurchasePlatformType } from '../../../types';
 import {
   Fieldset,
   Input,
@@ -24,6 +24,7 @@ export const AppTicketRefund = ({ state, send }: AppTicketRefundProps) => {
       title={t(PageText.Contact.ticketing.refund.appTicketRefund.label)}
     >
       <Input
+        id="customerNumber"
         label={t(PageText.Contact.input.customerNumber.label)}
         type="text"
         name="customerNumber"
@@ -42,6 +43,7 @@ export const AppTicketRefund = ({ state, send }: AppTicketRefundProps) => {
       />
 
       <Input
+        id="orderId"
         label={t(PageText.Contact.input.orderId.label(true))}
         type="text"
         name="orderId"

--- a/src/page-modules/contact/refund/forms/refund-ticket/otherTicketRefund.tsx
+++ b/src/page-modules/contact/refund/forms/refund-ticket/otherTicketRefund.tsx
@@ -75,6 +75,7 @@ const RefundSection = ({ state, send }: RefundSectionProps) => {
 
       {state.context.showInputTravelCardNumber && (
         <Input
+          id="travelCardNumber"
           label={t(PageText.Contact.input.travelCardNumber.label)}
           type="number"
           name="travelCardNumber"
@@ -92,6 +93,7 @@ const RefundSection = ({ state, send }: RefundSectionProps) => {
 
       {!state.context.showInputTravelCardNumber && (
         <Input
+          id="customerNumber"
           label={t(PageText.Contact.input.customerNumber.label)}
           type="text"
           name="customerNumber"
@@ -111,6 +113,7 @@ const RefundSection = ({ state, send }: RefundSectionProps) => {
       )}
 
       <Input
+        id="orderId"
         label={t(PageText.Contact.input.orderId.label(false))}
         type="text"
         name="orderId"
@@ -154,6 +157,7 @@ const RefundSection = ({ state, send }: RefundSectionProps) => {
       />
 
       <Input
+        id="amount"
         label={t(PageText.Contact.input.amount.label)}
         type="text"
         name="amount"
@@ -193,6 +197,7 @@ const AboutYouSection = ({ state, send }: AboutYouSectionProps) => {
   return (
     <Fieldset title={t(PageText.Contact.aboutYouInfo.title)}>
       <Input
+        id="firstName"
         label={t(PageText.Contact.input.firstName.label)}
         type="text"
         autoComplete="given-name additional-name"
@@ -209,6 +214,7 @@ const AboutYouSection = ({ state, send }: AboutYouSectionProps) => {
       />
 
       <Input
+        id="lastName"
         label={t(PageText.Contact.input.lastName.label)}
         type="text"
         autoComplete="family-name"
@@ -224,6 +230,7 @@ const AboutYouSection = ({ state, send }: AboutYouSectionProps) => {
         }
       />
       <Input
+        id="address"
         label={t(PageText.Contact.input.address.label)}
         type="text"
         autoComplete="street-address"
@@ -239,6 +246,7 @@ const AboutYouSection = ({ state, send }: AboutYouSectionProps) => {
         }
       />
       <Input
+        id="postalCode"
         label={t(PageText.Contact.input.postalCode.label)}
         type="number"
         autoComplete="postal-code"
@@ -254,6 +262,7 @@ const AboutYouSection = ({ state, send }: AboutYouSectionProps) => {
         }
       />
       <Input
+        id="city"
         label={t(PageText.Contact.input.city.label)}
         type="text"
         name="city"
@@ -268,6 +277,7 @@ const AboutYouSection = ({ state, send }: AboutYouSectionProps) => {
         }
       />
       <Input
+        id="email"
         label={t(PageText.Contact.input.email.label)}
         type="email"
         autoComplete="email"
@@ -283,6 +293,7 @@ const AboutYouSection = ({ state, send }: AboutYouSectionProps) => {
         }
       />
       <Input
+        id="phoneNumber"
         label={t(PageText.Contact.input.phoneNumber.label)}
         type="tel"
         name="phoneNumber"
@@ -298,6 +309,7 @@ const AboutYouSection = ({ state, send }: AboutYouSectionProps) => {
       />
 
       <Input
+        id="bankAccountNumber"
         label={t(
           PageText.Contact.input.bankInformation.bankAccountNumber.label,
         )}
@@ -333,6 +345,7 @@ const AboutYouSection = ({ state, send }: AboutYouSectionProps) => {
       {state.context.hasInternationalBankAccount && (
         <div>
           <Input
+            id="IBAN"
             label={t(PageText.Contact.input.bankInformation.IBAN.label)}
             type="string"
             name="IBAN"
@@ -348,6 +361,7 @@ const AboutYouSection = ({ state, send }: AboutYouSectionProps) => {
           />
 
           <Input
+            id="SWIFT"
             label={t(PageText.Contact.input.bankInformation.SWIFT.label)}
             type="string"
             name="SWIFT"

--- a/src/page-modules/contact/refund/index.tsx
+++ b/src/page-modules/contact/refund/index.tsx
@@ -8,6 +8,7 @@ import { Fieldset, Radio } from '../components';
 import RefundAndTravelGuaranteeForms from './forms/refund-and-travel-guarantee';
 import RefundTicketForms from './forms/refund-ticket';
 import { ResidualValueOnTravelCard } from './forms/residualValueOnTravelCard';
+import { findOrderFormFields } from '../utils';
 
 const RefundContent = () => {
   const { t } = useTranslation();
@@ -18,7 +19,7 @@ const RefundContent = () => {
 
   const onSubmit: FormEventHandler<HTMLFormElement> = async (e) => {
     e.preventDefault();
-    send({ type: 'SUBMIT' });
+    send({ type: 'SUBMIT', orderedFormFieldNames: findOrderFormFields(e) });
   };
 
   return (

--- a/src/page-modules/contact/ticket-control/events.ts
+++ b/src/page-modules/contact/ticket-control/events.ts
@@ -25,6 +25,7 @@ const ticketControlSpecificFormEvents = {} as
     }
   | {
       type: 'SUBMIT';
+      orderedFormFieldNames: string[];
     };
 export const ticketControlFormEvents = {} as
   | typeof ticketControlSpecificFormEvents

--- a/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
@@ -106,6 +106,7 @@ const FormContent = ({ state, send }: FormProps) => {
     <>
       <Fieldset title={t(PageText.Contact.ticketControl.feeComplaint.title)}>
         <Input
+          id="feeNumber"
           label={t(PageText.Contact.input.feeNumber.label)}
           type="text"
           name="feeNumber"
@@ -159,6 +160,7 @@ const FormContent = ({ state, send }: FormProps) => {
         {state.context.isAppTicketStorageMode && (
           <div>
             <Input
+              id="appPhoneNumber"
               label={t(PageText.Contact.input.appPhoneNumber.label)}
               type="tel"
               name="appPhoneNumber"
@@ -174,6 +176,7 @@ const FormContent = ({ state, send }: FormProps) => {
             />
 
             <Input
+              id="customerNumber"
               label={t(PageText.Contact.input.customerNumber.label)}
               type="number"
               name="customerNumber"
@@ -191,6 +194,7 @@ const FormContent = ({ state, send }: FormProps) => {
         )}
         {!state.context.isAppTicketStorageMode && (
           <Input
+            id="travelCardNumber"
             label={t(PageText.Contact.input.travelCardNumber.label)}
             type="number"
             name="travelCardNumber"
@@ -237,6 +241,7 @@ const FormContent = ({ state, send }: FormProps) => {
 
       <Fieldset title={t(PageText.Contact.aboutYouInfo.title)}>
         <Input
+          id="firstName"
           label={t(PageText.Contact.input.firstName.label)}
           type="text"
           autoComplete="given-name additional-name"
@@ -253,6 +258,7 @@ const FormContent = ({ state, send }: FormProps) => {
         />
 
         <Input
+          id="lastName"
           label={t(PageText.Contact.input.lastName.label)}
           type="text"
           autoComplete="family-name"
@@ -268,6 +274,7 @@ const FormContent = ({ state, send }: FormProps) => {
           }
         />
         <Input
+          id="address"
           label={t(PageText.Contact.input.address.label)}
           type="text"
           autoComplete="street-address"
@@ -283,6 +290,7 @@ const FormContent = ({ state, send }: FormProps) => {
           }
         />
         <Input
+          id="postalCode"
           label={t(PageText.Contact.input.postalCode.label)}
           type="number"
           autoComplete="postal-code"
@@ -298,6 +306,7 @@ const FormContent = ({ state, send }: FormProps) => {
           }
         />
         <Input
+          id="city"
           label={t(PageText.Contact.input.city.label)}
           type="text"
           name="city"
@@ -312,6 +321,7 @@ const FormContent = ({ state, send }: FormProps) => {
           }
         />
         <Input
+          id="email"
           label={t(PageText.Contact.input.email.label)}
           type="email"
           autoComplete="email"
@@ -327,6 +337,7 @@ const FormContent = ({ state, send }: FormProps) => {
           }
         />
         <Input
+          id="phoneNumber"
           label={t(PageText.Contact.input.phoneNumber.label)}
           type="tel"
           name="phoneNumber"
@@ -342,6 +353,7 @@ const FormContent = ({ state, send }: FormProps) => {
         />
 
         <Input
+          id="bankAccountNumber"
           label={t(
             PageText.Contact.input.bankInformation.bankAccountNumber.label,
           )}
@@ -378,6 +390,7 @@ const FormContent = ({ state, send }: FormProps) => {
         {state.context.hasInternationalBankAccount && (
           <div>
             <Input
+              id="IBAN"
               label={t(PageText.Contact.input.bankInformation.IBAN.label)}
               type="string"
               name="IBAN"
@@ -393,6 +406,7 @@ const FormContent = ({ state, send }: FormProps) => {
             />
 
             <Input
+              id="SWIFT"
               label={t(PageText.Contact.input.bankInformation.SWIFT.label)}
               type="string"
               name="SWIFT"

--- a/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
@@ -171,6 +171,7 @@ export const FeedbackForm = ({ state, send }: FeedbackFormProps) => {
 
       <Fieldset title={t(PageText.Contact.aboutYouInfo.title)}>
         <Input
+          id="firstName"
           label={t(PageText.Contact.input.firstName.label)}
           type="text"
           autoComplete="given-name additonal-name"
@@ -188,6 +189,7 @@ export const FeedbackForm = ({ state, send }: FeedbackFormProps) => {
           }
         />
         <Input
+          id="lastName"
           label={t(PageText.Contact.input.lastName.label)}
           type="text"
           autoComplete="family-name"
@@ -205,6 +207,7 @@ export const FeedbackForm = ({ state, send }: FeedbackFormProps) => {
           }
         />
         <Input
+          id="email"
           label={t(PageText.Contact.input.email.label)}
           type="email"
           name="email"

--- a/src/page-modules/contact/ticket-control/forms/postponePayment.tsx
+++ b/src/page-modules/contact/ticket-control/forms/postponePayment.tsx
@@ -23,6 +23,7 @@ export const PostponePaymentForm = ({
         </Typo.p>
 
         <Input
+          id="feeNumber"
           label={t(PageText.Contact.input.feeNumber.label)}
           type="text"
           name="feeNumber"
@@ -41,6 +42,7 @@ export const PostponePaymentForm = ({
         />
 
         <Input
+          id="invoiceNumber"
           label={t(PageText.Contact.input.invoiceNumber.label)}
           type="text"
           name="invoiceNumber"
@@ -60,6 +62,7 @@ export const PostponePaymentForm = ({
       </Fieldset>
       <Fieldset title={t(PageText.Contact.aboutYouInfo.title)}>
         <Input
+          id="firstName"
           label={t(PageText.Contact.input.firstName.label)}
           type="text"
           autoComplete="given-name additional-name"
@@ -75,6 +78,7 @@ export const PostponePaymentForm = ({
           }
         />
         <Input
+          id="lastName"
           label={t(PageText.Contact.input.lastName.label)}
           type="text"
           autoComplete="family-name"
@@ -90,6 +94,7 @@ export const PostponePaymentForm = ({
           }
         />
         <Input
+          id="email"
           label={t(PageText.Contact.input.email.label)}
           type="email"
           name="email"

--- a/src/page-modules/contact/ticket-control/index.tsx
+++ b/src/page-modules/contact/ticket-control/index.tsx
@@ -11,6 +11,7 @@ import FeeComplaintForm from './forms/feeComplaintForm';
 import FeedbackForm from './forms/feedbackForm';
 import PostponePaymentForm from './forms/postponePayment';
 import { Fieldset, Radio } from '../components';
+import { findOrderFormFields } from '../utils';
 
 const TicketControlPageContent = () => {
   const { t } = useTranslation();
@@ -22,7 +23,7 @@ const TicketControlPageContent = () => {
 
   const onSubmit: FormEventHandler<HTMLFormElement> = async (e) => {
     e.preventDefault();
-    send({ type: 'SUBMIT' });
+    send({ type: 'SUBMIT', orderedFormFieldNames: findOrderFormFields(e) });
   };
 
   return (

--- a/src/page-modules/contact/ticketing/events.ts
+++ b/src/page-modules/contact/ticketing/events.ts
@@ -43,6 +43,7 @@ const ticketingSpecificFormEvents = {} as
     }
   | {
       type: 'SUBMIT';
+      orderedFormFieldNames: string[];
     };
 
 export const ticketingFormEvents = {} as

--- a/src/page-modules/contact/ticketing/forms/app/appAccountForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/app/appAccountForm.tsx
@@ -47,6 +47,7 @@ export const AppAccountForm = ({ state, send }: AppAccountFormProps) => {
       </Fieldset>
       <Fieldset title={t(PageText.Contact.aboutYouInfo.title)}>
         <Input
+          id="customerNumber"
           label={t(PageText.Contact.input.customerNumber.label)}
           type="text"
           name="customerNumber"
@@ -64,6 +65,7 @@ export const AppAccountForm = ({ state, send }: AppAccountFormProps) => {
           }}
         />
         <Input
+          id="firstName"
           label={t(PageText.Contact.input.firstName.label)}
           type="text"
           autoComplete="given-name additional-name"
@@ -80,6 +82,7 @@ export const AppAccountForm = ({ state, send }: AppAccountFormProps) => {
         />
 
         <Input
+          id="lastName"
           label={t(PageText.Contact.input.lastName.label)}
           type="text"
           autoComplete="family-name"
@@ -95,6 +98,7 @@ export const AppAccountForm = ({ state, send }: AppAccountFormProps) => {
           }
         />
         <Input
+          id="email"
           label={t(PageText.Contact.input.email.label)}
           type="email"
           autoComplete="email"
@@ -110,6 +114,7 @@ export const AppAccountForm = ({ state, send }: AppAccountFormProps) => {
           }
         />
         <Input
+          id="phoneNumber"
           label={t(PageText.Contact.input.phoneNumber.label)}
           type="tel"
           name="phoneNumber"

--- a/src/page-modules/contact/ticketing/forms/app/appTicketingForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/app/appTicketingForm.tsx
@@ -16,6 +16,7 @@ export const AppTicketingForm = ({ state, send }: AppTicketingFormProps) => {
     <>
       <Fieldset title={t(PageText.Contact.ticketing.app.appTicketing.title)}>
         <Input
+          id="orderId"
           label={t(PageText.Contact.input.orderId.label(false))}
           type="text"
           name="orderId"
@@ -71,6 +72,7 @@ export const AppTicketingForm = ({ state, send }: AppTicketingFormProps) => {
       </Fieldset>
       <Fieldset title={t(PageText.Contact.aboutYouInfo.title)}>
         <Input
+          id="customerNumber"
           label={t(PageText.Contact.input.customerNumber.labelOptional)}
           type="text"
           name="customerNumber"
@@ -87,6 +89,7 @@ export const AppTicketingForm = ({ state, send }: AppTicketingFormProps) => {
           }}
         />
         <Input
+          id="firstName"
           label={t(PageText.Contact.input.firstName.label)}
           type="text"
           autoComplete="given-name additional-name"
@@ -103,6 +106,7 @@ export const AppTicketingForm = ({ state, send }: AppTicketingFormProps) => {
         />
 
         <Input
+          id="lastName"
           label={t(PageText.Contact.input.lastName.label)}
           type="text"
           autoComplete="family-name"
@@ -118,6 +122,7 @@ export const AppTicketingForm = ({ state, send }: AppTicketingFormProps) => {
           }
         />
         <Input
+          id="email"
           label={t(PageText.Contact.input.email.label)}
           type="email"
           autoComplete="email"
@@ -133,6 +138,7 @@ export const AppTicketingForm = ({ state, send }: AppTicketingFormProps) => {
           }
         />
         <Input
+          id="phoneNumber"
           label={t(PageText.Contact.input.phoneNumber.label)}
           type="tel"
           name="phoneNumber"

--- a/src/page-modules/contact/ticketing/forms/app/appTravelSuggestionForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/app/appTravelSuggestionForm.tsx
@@ -50,6 +50,7 @@ export const AppTravelSuggestionForm = ({
       </Fieldset>
       <Fieldset title={t(PageText.Contact.aboutYouInfo.title)}>
         <Input
+          id="firstName"
           label={t(PageText.Contact.input.firstName.label)}
           type="text"
           autoComplete="given-name additional-name"
@@ -66,6 +67,7 @@ export const AppTravelSuggestionForm = ({
         />
 
         <Input
+          id="lastName"
           label={t(PageText.Contact.input.lastName.label)}
           type="text"
           autoComplete="family-name"
@@ -81,6 +83,7 @@ export const AppTravelSuggestionForm = ({
           }
         />
         <Input
+          id="email"
           label={t(PageText.Contact.input.email.label)}
           type="email"
           autoComplete="email"

--- a/src/page-modules/contact/ticketing/forms/priceAndTicketTypesForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/priceAndTicketTypesForm.tsx
@@ -50,6 +50,7 @@ export const PriceAndTicketTypesForm = ({
       </Fieldset>
       <Fieldset title={t(PageText.Contact.aboutYouInfo.title)}>
         <Input
+          id="firstName"
           label={t(PageText.Contact.input.firstName.label)}
           type="text"
           autoComplete="given-name additional-name"
@@ -66,6 +67,7 @@ export const PriceAndTicketTypesForm = ({
         />
 
         <Input
+          id="lastName"
           label={t(PageText.Contact.input.lastName.label)}
           type="text"
           autoComplete="family-name"
@@ -81,6 +83,7 @@ export const PriceAndTicketTypesForm = ({
           }
         />
         <Input
+          id="email"
           label={t(PageText.Contact.input.email.label)}
           type="email"
           autoComplete="email"

--- a/src/page-modules/contact/ticketing/forms/travel-card/travelCardQuestionForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/travel-card/travelCardQuestionForm.tsx
@@ -26,6 +26,7 @@ export const TravelCardQuestionForm = ({
           {t(PageText.Contact.input.travelCardNumber.info)}
         </Typo.p>
         <Input
+          id="travelCardNumber"
           label={t(PageText.Contact.input.travelCardNumber.label)}
           type="text"
           name="travelCardNumber"
@@ -73,6 +74,7 @@ export const TravelCardQuestionForm = ({
       </Fieldset>
       <Fieldset title={t(PageText.Contact.aboutYouInfo.title)}>
         <Input
+          id="firstName"
           label={t(PageText.Contact.input.firstName.label)}
           type="text"
           autoComplete="given-name additional-name"
@@ -89,6 +91,7 @@ export const TravelCardQuestionForm = ({
         />
 
         <Input
+          id="lastName"
           label={t(PageText.Contact.input.lastName.label)}
           type="text"
           autoComplete="family-name"
@@ -104,6 +107,7 @@ export const TravelCardQuestionForm = ({
           }
         />
         <Input
+          id="email"
           label={t(PageText.Contact.input.email.label)}
           type="email"
           autoComplete="email"
@@ -119,6 +123,7 @@ export const TravelCardQuestionForm = ({
           }
         />
         <Input
+          id="phoneNumber"
           label={t(PageText.Contact.input.phoneNumber.label)}
           type="tel"
           name="phoneNumber"

--- a/src/page-modules/contact/ticketing/forms/webshop/webshopAccountForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/webshop/webshopAccountForm.tsx
@@ -50,6 +50,7 @@ export const WebshopAccountForm = ({
       </Fieldset>
       <Fieldset title={t(PageText.Contact.aboutYouInfo.title)}>
         <Input
+          id="customerNumber"
           label={t(PageText.Contact.input.customerNumber.labelOptional)}
           type="text"
           name="customerNumber"
@@ -64,6 +65,7 @@ export const WebshopAccountForm = ({
           }
         />
         <Input
+          id="firstName"
           label={t(PageText.Contact.input.firstName.labelOptional)}
           type="text"
           autoComplete="given-name additional-name"
@@ -79,6 +81,7 @@ export const WebshopAccountForm = ({
         />
 
         <Input
+          id="lastName"
           label={t(PageText.Contact.input.lastName.labelOptional)}
           type="text"
           autoComplete="family-name"
@@ -93,6 +96,7 @@ export const WebshopAccountForm = ({
           }
         />
         <Input
+          id="email"
           label={t(
             PageText.Contact.input.email
               .labelOptionalIfCustomerNumberIsProvided,
@@ -115,6 +119,7 @@ export const WebshopAccountForm = ({
           }
         />
         <Input
+          id="phoneNumber"
           label={t(PageText.Contact.input.phoneNumber.labelOptional)}
           type="phoneNumber"
           autoComplete="tel"

--- a/src/page-modules/contact/ticketing/forms/webshop/webshopTicketingForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/webshop/webshopTicketingForm.tsx
@@ -32,6 +32,7 @@ export const WebshopTicketingForm = ({
         </ul>
 
         <Input
+          id="orderId"
           label={t(PageText.Contact.input.orderId.label(false))}
           type="text"
           name="orderId"
@@ -80,6 +81,7 @@ export const WebshopTicketingForm = ({
       </Fieldset>
       <Fieldset title={t(PageText.Contact.aboutYouInfo.title)}>
         <Input
+          id="customerNumber"
           label={t(PageText.Contact.input.customerNumber.labelOptional)}
           type="text"
           name="customerNumber"
@@ -94,6 +96,7 @@ export const WebshopTicketingForm = ({
           }
         />
         <Input
+          id="firstName"
           label={t(PageText.Contact.input.firstName.labelOptional)}
           type="text"
           autoComplete="given-name additional-name"
@@ -109,6 +112,7 @@ export const WebshopTicketingForm = ({
         />
 
         <Input
+          id="lastName"
           label={t(PageText.Contact.input.lastName.labelOptional)}
           type="text"
           autoComplete="family-name"
@@ -123,6 +127,7 @@ export const WebshopTicketingForm = ({
           }
         />
         <Input
+          id="email"
           label={t(
             PageText.Contact.input.email
               .labelOptionalIfCustomerNumberIsProvided,
@@ -145,6 +150,7 @@ export const WebshopTicketingForm = ({
           }
         />
         <Input
+          id="phoneNumber"
           label={t(PageText.Contact.input.phoneNumber.labelOptional)}
           type="phoneNumber"
           autoComplete="tel"

--- a/src/page-modules/contact/ticketing/index.tsx
+++ b/src/page-modules/contact/ticketing/index.tsx
@@ -9,6 +9,7 @@ import PriceAndTicketTypesForm from './forms/priceAndTicketTypesForm';
 import AppForms from './forms/app';
 import WebshopForms from './forms/webshop';
 import TravelCardForms from './forms/travel-card';
+import { findOrderFormFields } from '../utils';
 
 const TicketingContent = () => {
   const { t } = useTranslation();
@@ -18,7 +19,7 @@ const TicketingContent = () => {
 
   const onSubmit: FormEventHandler<HTMLFormElement> = async (e) => {
     e.preventDefault();
-    send({ type: 'SUBMIT' });
+    send({ type: 'SUBMIT', orderedFormFieldNames: findOrderFormFields(e) });
   };
 
   return (

--- a/src/page-modules/contact/utils.ts
+++ b/src/page-modules/contact/utils.ts
@@ -1,5 +1,7 @@
 import { TransportModeType } from './types';
 import { Line } from '.';
+import { FormEvent } from 'react';
+import { InputErrorMessages } from './validation';
 
 export const shouldShowContactPage = (): boolean => {
   return process.env.NEXT_PUBLIC_CONTACT_API_URL ? true : false;
@@ -84,4 +86,45 @@ export const setBankAccountStatusAndResetBankInformation = (
       bankAccountNumber: [],
     },
   };
+};
+
+export const findOrderFormFields = (e: FormEvent<HTMLFormElement>): string[] =>
+  Array.from(e.currentTarget.elements).reduce<string[]>((fields, element) => {
+    if (
+      (element instanceof HTMLInputElement ||
+        element instanceof HTMLSelectElement ||
+        element instanceof HTMLTextAreaElement) &&
+      element.name
+    ) {
+      fields.push(element.name);
+    }
+    return fields;
+  }, []);
+
+export const scrollToFirstErrorMessage = (
+  fieldName: string | undefined,
+): void => {
+  if (!fieldName) return;
+
+  const element = document.querySelector<
+    HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
+  >(`[name="${fieldName}"]`);
+
+  if (element) {
+    element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    element.focus();
+  }
+};
+
+export const findFirstErrorMessage = (
+  formFields: string[] | undefined,
+  errors: InputErrorMessages,
+): string | undefined => {
+  if (!formFields) return undefined;
+
+  for (const field of formFields) {
+    if (errors[field]) {
+      return field;
+    }
+  }
 };

--- a/src/page-modules/contact/utils.ts
+++ b/src/page-modules/contact/utils.ts
@@ -88,27 +88,23 @@ export const setBankAccountStatusAndResetBankInformation = (
   };
 };
 
+const formFieldsPrefixes = ['input__', 'select__', 'textarea__'];
+
 export const findOrderFormFields = (e: FormEvent<HTMLFormElement>): string[] =>
-  Array.from(e.currentTarget.elements).reduce<string[]>((fields, element) => {
-    if (
-      (element instanceof HTMLInputElement ||
-        element instanceof HTMLSelectElement ||
-        element instanceof HTMLTextAreaElement) &&
-      element.name
-    ) {
-      fields.push(element.name);
-    }
-    return fields;
-  }, []);
+  Array.from(e.currentTarget.elements)
+    .filter(
+      (el): el is HTMLElement =>
+        el instanceof HTMLElement &&
+        formFieldsPrefixes.some((prefix) => el.id.startsWith(prefix)),
+    )
+    .map((el) => el.id.split('__')[1]);
 
-export const scrollToFirstErrorMessage = (
-  fieldName: string | undefined,
-): void => {
-  if (!fieldName) return;
+export const scrollToFirstErrorMessage = (id: string | undefined): void => {
+  if (!id) return;
 
-  const element = document.querySelector<
-    HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
-  >(`[name="${fieldName}"]`);
+  const element = formFieldsPrefixes
+    .map((prefix) => document.getElementById(`${prefix}${id}`))
+    .find((el): el is HTMLElement => el !== null);
 
   if (element) {
     element.scrollIntoView({ behavior: 'smooth', block: 'center' });


### PR DESCRIPTION
This PR ensures that the window scrolls up and focuses on the input field displaying an error message in the form due to invalid input. This makes it much easier for the user to get an overview of which input fields that are missing in order to submit the form.


NB! The scroll will not work for all types of input fields yet. This is because these input fields  are missing name properties. To avoid making this PR to large and unclear, name properties will be added to input fiels in separate PRs.

https://github.com/user-attachments/assets/f85d6199-5bd5-463d-a965-76bf4d2a3232

