### PR TITLE
feat: add id property to select component

### DIFF
--- a/src/page-modules/contact/components/form/select.tsx
+++ b/src/page-modules/contact/components/form/select.tsx
@@ -1,4 +1,3 @@
-import { useId } from 'react';
 import { MonoIcon } from '@atb/components/icon';
 import style from './form.module.css';
 import {
@@ -13,7 +12,7 @@ import {
 import { ErrorMessage } from '@atb/components/error-message';
 
 export type SelectProps<T> = {
-  name: string;
+  id: string;
   label?: string;
   onChange: (value?: T) => void;
   error?: string;
@@ -26,7 +25,7 @@ export type SelectProps<T> = {
 };
 
 export default function CustomSelect<T>({
-  name,
+  id,
   label,
   onChange,
   error,
@@ -37,7 +36,6 @@ export default function CustomSelect<T>({
   placeholder,
   disabled,
 }: SelectProps<T>) {
-  const id = useId();
   const showError = !!error;
 
   const findItemFromOptions = (key: string) =>
@@ -52,8 +50,7 @@ export default function CustomSelect<T>({
 
   return (
     <Select
-      id={`select-${id}`}
-      name={name}
+      id={`select__${id}`}
       onSelectionChange={onChangeInternal}
       isDisabled={disabled}
       className={style.select__select_container}

--- a/src/page-modules/contact/components/form/select.tsx
+++ b/src/page-modules/contact/components/form/select.tsx
@@ -13,6 +13,7 @@ import {
 import { ErrorMessage } from '@atb/components/error-message';
 
 export type SelectProps<T> = {
+  name: string;
   label?: string;
   onChange: (value?: T) => void;
   error?: string;
@@ -24,7 +25,8 @@ export type SelectProps<T> = {
   disabled?: boolean;
 };
 
-export default function CustomeSelect<T>({
+export default function CustomSelect<T>({
+  name,
   label,
   onChange,
   error,
@@ -51,6 +53,7 @@ export default function CustomeSelect<T>({
   return (
     <Select
       id={`select-${id}`}
+      name={name}
       onSelectionChange={onChangeInternal}
       isDisabled={disabled}
       className={style.select__select_container}

--- a/src/page-modules/contact/layouts/contact-page-layout.tsx
+++ b/src/page-modules/contact/layouts/contact-page-layout.tsx
@@ -99,6 +99,7 @@ function ContactPageLayout({ children }: ContactPageLayoutProps) {
           </Typo.h2>
           <div className={style.contact_page_navigator__dropdown}>
             <Select
+              name="selectorContactPage"
               options={contactPages}
               value={selectedContactPage}
               placeholder={t(PageText.Contact.contactPageLayout.placeholder)}

--- a/src/page-modules/contact/layouts/contact-page-layout.tsx
+++ b/src/page-modules/contact/layouts/contact-page-layout.tsx
@@ -99,7 +99,7 @@ function ContactPageLayout({ children }: ContactPageLayoutProps) {
           </Typo.h2>
           <div className={style.contact_page_navigator__dropdown}>
             <Select
-              name="selectorContactPage"
+              id="contactPage"
               options={contactPages}
               value={selectedContactPage}
               placeholder={t(PageText.Contact.contactPageLayout.placeholder)}

--- a/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
@@ -41,7 +41,7 @@ export const DelayForm = ({ state, send }: DelayFormProps) => {
         </Typo.p>
 
         <Select
-          name="transportMode"
+          id="transportMode"
           label={t(PageText.Contact.input.transportMode.label)}
           value={state.context.transportMode || ''}
           onChange={(value) =>

--- a/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
@@ -41,6 +41,7 @@ export const DelayForm = ({ state, send }: DelayFormProps) => {
         </Typo.p>
 
         <Select
+          name="transportMode"
           label={t(PageText.Contact.input.transportMode.label)}
           value={state.context.transportMode || ''}
           onChange={(value) =>

--- a/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
@@ -41,6 +41,7 @@ export const DriverForm = ({ state, send }: DriverFormProps) => {
         </Typo.p>
 
         <Select
+          name="transportMode"
           label={t(PageText.Contact.input.transportMode.label)}
           value={state.context.transportMode || ''}
           onChange={(value) =>

--- a/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
@@ -41,7 +41,7 @@ export const DriverForm = ({ state, send }: DriverFormProps) => {
         </Typo.p>
 
         <Select
-          name="transportMode"
+          id="transportMode"
           label={t(PageText.Contact.input.transportMode.label)}
           value={state.context.transportMode || ''}
           onChange={(value) =>

--- a/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
@@ -40,6 +40,7 @@ export const InjuryForm = ({ state, send }: InjuryFormProps) => {
         </Typo.p>
 
         <Select
+          name="transportMode"
           label={t(PageText.Contact.input.transportMode.label)}
           value={state.context.transportMode || ''}
           onChange={(value) =>

--- a/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
@@ -40,7 +40,7 @@ export const InjuryForm = ({ state, send }: InjuryFormProps) => {
         </Typo.p>
 
         <Select
-          name="transportMode"
+          id="transportMode"
           label={t(PageText.Contact.input.transportMode.label)}
           value={state.context.transportMode || ''}
           onChange={(value) =>

--- a/src/page-modules/contact/means-of-transport/forms/serviceOfferingForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/serviceOfferingForm.tsx
@@ -47,7 +47,7 @@ export const ServiceOfferingForm = ({
         </Typo.p>
 
         <Select
-          name="transportMode"
+          id="transportMode"
           label={t(PageText.Contact.input.transportMode.label)}
           value={state.context.transportMode || ''}
           onChange={(value) =>

--- a/src/page-modules/contact/means-of-transport/forms/serviceOfferingForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/serviceOfferingForm.tsx
@@ -47,6 +47,7 @@ export const ServiceOfferingForm = ({
         </Typo.p>
 
         <Select
+          name="transportMode"
           label={t(PageText.Contact.input.transportMode.label)}
           value={state.context.transportMode || ''}
           onChange={(value) =>

--- a/src/page-modules/contact/means-of-transport/forms/stopForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/stopForm.tsx
@@ -40,7 +40,7 @@ export const StopForm = ({ state, send }: StopFormProps) => {
         </Typo.p>
 
         <Select
-          name="transportMode"
+          id="transportMode"
           label={t(PageText.Contact.input.transportMode.label)}
           value={state.context.transportMode || ''}
           onChange={(value) =>

--- a/src/page-modules/contact/means-of-transport/forms/stopForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/stopForm.tsx
@@ -40,6 +40,7 @@ export const StopForm = ({ state, send }: StopFormProps) => {
         </Typo.p>
 
         <Select
+          name="transportMode"
           label={t(PageText.Contact.input.transportMode.label)}
           value={state.context.transportMode || ''}
           onChange={(value) =>

--- a/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
@@ -49,7 +49,7 @@ export const TransportationForm = ({
         </Typo.p>
 
         <Select
-          name="transportMode"
+          id="transportMode"
           label={t(PageText.Contact.input.transportMode.label)}
           value={state.context.transportMode || ''}
           onChange={(value) =>

--- a/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
@@ -49,6 +49,7 @@ export const TransportationForm = ({
         </Typo.p>
 
         <Select
+          name="transportMode"
           label={t(PageText.Contact.input.transportMode.label)}
           value={state.context.transportMode || ''}
           onChange={(value) =>

--- a/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundCarForm.tsx
+++ b/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundCarForm.tsx
@@ -86,6 +86,7 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
         title={t(PageText.Contact.refund.refundTaxi.aboutYourTrip.title)}
       >
         <Select
+          name="transportMode"
           label={t(PageText.Contact.input.transportMode.label)}
           value={state.context.transportMode || ''}
           onChange={(value) =>
@@ -199,6 +200,7 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
         />
 
         <Select
+          name="reasonForTransportFailure"
           label={t(PageText.Contact.input.reasonForTransportFailure.label)}
           value={state.context.reasonForTransportFailure}
           disabled={!state.context.line}

--- a/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundCarForm.tsx
+++ b/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundCarForm.tsx
@@ -86,7 +86,7 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
         title={t(PageText.Contact.refund.refundTaxi.aboutYourTrip.title)}
       >
         <Select
-          name="transportMode"
+          id="transportMode"
           label={t(PageText.Contact.input.transportMode.label)}
           value={state.context.transportMode || ''}
           onChange={(value) =>
@@ -200,7 +200,7 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
         />
 
         <Select
-          name="reasonForTransportFailure"
+          id="reasonForTransportFailure"
           label={t(PageText.Contact.input.reasonForTransportFailure.label)}
           value={state.context.reasonForTransportFailure}
           disabled={!state.context.line}

--- a/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundTaxiForm.tsx
+++ b/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundTaxiForm.tsx
@@ -70,6 +70,7 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
         title={t(PageText.Contact.refund.refundTaxi.aboutYourTrip.title)}
       >
         <Select
+          name="transportMode"
           label={t(PageText.Contact.input.transportMode.label)}
           value={state.context.transportMode || ''}
           onChange={(value) =>
@@ -184,6 +185,7 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
         />
 
         <Select
+          name="reasonForTransportFailure"
           label={t(PageText.Contact.input.reasonForTransportFailure.label)}
           value={state.context.reasonForTransportFailure}
           disabled={!state.context.line}

--- a/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundTaxiForm.tsx
+++ b/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundTaxiForm.tsx
@@ -70,7 +70,7 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
         title={t(PageText.Contact.refund.refundTaxi.aboutYourTrip.title)}
       >
         <Select
-          name="transportMode"
+          id="transportMode"
           label={t(PageText.Contact.input.transportMode.label)}
           value={state.context.transportMode || ''}
           onChange={(value) =>
@@ -185,7 +185,7 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
         />
 
         <Select
-          name="reasonForTransportFailure"
+          id="reasonForTransportFailure"
           label={t(PageText.Contact.input.reasonForTransportFailure.label)}
           value={state.context.reasonForTransportFailure}
           disabled={!state.context.line}

--- a/src/page-modules/contact/refund/forms/refund-ticket/appTicketRefund.tsx
+++ b/src/page-modules/contact/refund/forms/refund-ticket/appTicketRefund.tsx
@@ -66,6 +66,7 @@ export const AppTicketRefund = ({ state, send }: AppTicketRefundProps) => {
       />
 
       <Select
+        name="purchasePlatform"
         label={t(PageText.Contact.input.purchasePlatform.label)}
         value={state.context.purchasePlatform || ''}
         onChange={(value) =>

--- a/src/page-modules/contact/refund/forms/refund-ticket/appTicketRefund.tsx
+++ b/src/page-modules/contact/refund/forms/refund-ticket/appTicketRefund.tsx
@@ -66,7 +66,7 @@ export const AppTicketRefund = ({ state, send }: AppTicketRefundProps) => {
       />
 
       <Select
-        name="purchasePlatform"
+        id="purchasePlatform"
         label={t(PageText.Contact.input.purchasePlatform.label)}
         value={state.context.purchasePlatform || ''}
         onChange={(value) =>

--- a/src/page-modules/contact/refund/forms/refund-ticket/otherTicketRefund.tsx
+++ b/src/page-modules/contact/refund/forms/refund-ticket/otherTicketRefund.tsx
@@ -26,7 +26,7 @@ const RefundSection = ({ state, send }: RefundSectionProps) => {
       title={t(PageText.Contact.ticketing.refund.otherTicketRefund.label)}
     >
       <Select
-        name="ticketType"
+        id="ticketType"
         label={t(PageText.Contact.input.ticketType.labelRefund)}
         value={state.context.ticketType}
         valueToId={(option: TicketType) => option.id}

--- a/src/page-modules/contact/refund/forms/refund-ticket/otherTicketRefund.tsx
+++ b/src/page-modules/contact/refund/forms/refund-ticket/otherTicketRefund.tsx
@@ -26,6 +26,7 @@ const RefundSection = ({ state, send }: RefundSectionProps) => {
       title={t(PageText.Contact.ticketing.refund.otherTicketRefund.label)}
     >
       <Select
+        name="ticketType"
         label={t(PageText.Contact.input.ticketType.labelRefund)}
         value={state.context.ticketType}
         valueToId={(option: TicketType) => option.id}

--- a/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
@@ -35,7 +35,7 @@ export const FeedbackForm = ({ state, send }: FeedbackFormProps) => {
         </Typo.p>
 
         <Select
-          name="transportMode"
+          id="transportMode"
           label={t(PageText.Contact.input.transportMode.label)}
           value={state.context.transportMode || ''}
           onChange={(value) =>

--- a/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
@@ -35,6 +35,7 @@ export const FeedbackForm = ({ state, send }: FeedbackFormProps) => {
         </Typo.p>
 
         <Select
+          name="transportMode"
           label={t(PageText.Contact.input.transportMode.label)}
           value={state.context.transportMode || ''}
           onChange={(value) =>


### PR DESCRIPTION
Add id property to select component. This is done to include the select component in the automatic focus and scroll on submit, as described in https://github.com/AtB-AS/planner-web/pull/539.