### PR TITLE
fix: validation error caused by wrong input types in contact form  

### DIFF
--- a/src/page-modules/contact/refund/events.ts
+++ b/src/page-modules/contact/refund/events.ts
@@ -1,14 +1,15 @@
-import { TranslatedString } from '@atb/translations';
 import {
   FormCategory,
   RefundAndTravelGuarantee,
   RefundTicketForm,
 } from './refundFormMachine';
-import { PurchasePlatformType, TransportModeType } from '../types';
+import {
+  PurchasePlatformType,
+  ReasonForTransportFailure,
+  TicketType,
+  TransportModeType,
+} from '../types';
 import { Line } from '..';
-
-export type ReasonForTransportFailure = { id: string; name: TranslatedString };
-export type TicketType = { id: string; name: TranslatedString };
 
 const RefundSpecificFormEvents = {} as
   | {

--- a/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundCarForm.tsx
+++ b/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundCarForm.tsx
@@ -1,8 +1,8 @@
 import { PageText, useTranslation } from '@atb/translations';
 import { useLines } from '../../../lines/use-lines';
-import { TransportModeType } from '../../../types';
+import { TransportModeType, ReasonForTransportFailure } from '../../../types';
 import { Line } from '../../..';
-import { ReasonForTransportFailure, RefundFormEvents } from '../../events';
+import { RefundFormEvents } from '../../events';
 import { RefundContextProps } from '../../refundFormMachine';
 import {
   Fieldset,

--- a/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundTaxiForm.tsx
+++ b/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundTaxiForm.tsx
@@ -1,8 +1,8 @@
 import { PageText, useTranslation } from '@atb/translations';
 import { useLines } from '../../../lines/use-lines';
-import { TransportModeType } from '../../../types';
+import { ReasonForTransportFailure, TransportModeType } from '../../../types';
 import { Line } from '../../..';
-import { ReasonForTransportFailure, RefundFormEvents } from '../../events';
+import { RefundFormEvents } from '../../events';
 import { RefundContextProps } from '../../refundFormMachine';
 import { Typo } from '@atb/components/typography';
 import {

--- a/src/page-modules/contact/refund/forms/refund-ticket/otherTicketRefund.tsx
+++ b/src/page-modules/contact/refund/forms/refund-ticket/otherTicketRefund.tsx
@@ -1,5 +1,5 @@
 import { PageText, useTranslation } from '@atb/translations';
-import { RefundFormEvents, TicketType } from '../../events';
+import { RefundFormEvents } from '../../events';
 import { Typo } from '@atb/components/typography';
 import {
   Fieldset,
@@ -11,6 +11,7 @@ import {
 } from '../../../components';
 import { RefundContextProps } from '../../refundFormMachine';
 import { Checkbox } from '@atb/components/checkbox';
+import { TicketType } from '@atb/page-modules/contact/types';
 
 type OtherTicketRefundProps = {
   state: { context: RefundContextProps };

--- a/src/page-modules/contact/refund/refundFormMachine.ts
+++ b/src/page-modules/contact/refund/refundFormMachine.ts
@@ -1,7 +1,11 @@
-import { PurchasePlatformType, TransportModeType } from '../types';
+import {
+  PurchasePlatformType,
+  TransportModeType,
+  ReasonForTransportFailure,
+  TicketType,
+} from '../types';
 import { assign, fromPromise, setup } from 'xstate';
 import { Line } from '../server/journey-planner/validators';
-import { ReasonForTransportFailure, TicketType } from './events';
 import { commonInputValidator, InputErrorMessages } from '../validation';
 import {
   convertFilesToBase64,
@@ -240,7 +244,9 @@ export const refundStateMachine = setup({
   guards: {
     isFormValid: ({ context }) => {
       const inputsToValidate = setInputToValidate(context);
+      console.log('inputsToValidate: ', inputsToValidate);
       const errors = commonInputValidator(inputsToValidate);
+      console.log('errors: ', errors);
       return Object.keys(errors).length === 0;
     },
     isRefundOfTicket: ({ event }) =>
@@ -321,6 +327,9 @@ export const refundStateMachine = setup({
         }
 
         context.errorMessages[inputName] = [];
+
+        console.log(value);
+
         return {
           ...context,
           [inputName]: value,

--- a/src/page-modules/contact/ticketing/ticketingStateMachine.ts
+++ b/src/page-modules/contact/ticketing/ticketingStateMachine.ts
@@ -7,7 +7,7 @@ import {
   scrollToFirstErrorMessage,
   setBankAccountStatusAndResetBankInformation,
 } from '../utils';
-import { TicketType } from '../refund/events';
+import { TicketType } from '../types';
 
 export enum FormCategory {
   PriceAndTicketTypes = 'priceAndTicketTypes',

--- a/src/page-modules/contact/types.ts
+++ b/src/page-modules/contact/types.ts
@@ -1,4 +1,8 @@
+import { TranslatedString } from '@atb/translations';
+
 export type TransportModeType = 'bus' | 'expressboat' | 'ferry';
+export type ReasonForTransportFailure = { id: string; name: TranslatedString };
+export type TicketType = { id: string; name: TranslatedString };
 export type PurchasePlatformType =
   | 'framApp'
   | 'enturApp'

--- a/src/page-modules/contact/validation/validationRules.ts
+++ b/src/page-modules/contact/validation/validationRules.ts
@@ -1,6 +1,10 @@
 import { PageText, TranslatedString } from '@atb/translations';
 import { Line } from '..';
-import { TransportModeType } from '../types';
+import {
+  ReasonForTransportFailure,
+  TicketType,
+  TransportModeType,
+} from '../types';
 
 const isDefined = <T>(value: T | undefined): value is T => value !== undefined;
 
@@ -204,7 +208,8 @@ const rulesPlannedDepartureTime: ValidationRule[] = [
 
 const rulesReasonForTransportFailure: ValidationRule[] = [
   {
-    validate: isNonEmptyString,
+    validate: (_reasonForTransportFailure: ReasonForTransportFailure) =>
+      isDefined(_reasonForTransportFailure),
     errorMessage:
       PageText.Contact.input.reasonForTransportFailure.errorMessages.empty,
   },
@@ -307,7 +312,7 @@ const rulesAmount: ValidationRule[] = [
 
 const rulesTicketType: ValidationRule[] = [
   {
-    validate: isNonEmptyString,
+    validate: (_ticketType: TicketType) => isDefined(_ticketType),
     errorMessage: PageText.Contact.input.ticketType.errorMessages.empty,
   },
 ];

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -1,7 +1,7 @@
 import {
   ReasonForTransportFailure,
   TicketType,
-} from '@atb/page-modules/contact/refund/events';
+} from '@atb/page-modules/contact/types';
 import { translation as _ } from '@atb/translations/commons';
 import { orgSpecificTranslations } from '../utils';
 


### PR DESCRIPTION
Update the validation rules to expect correct input values. Previously, the `rulesTicketType`  and `rulesReasonForTransportFailure` expected string params, and not `TicketType` and `ReasonForTransportFailure` objects, causing the rules to always return false during validation. 


