### PR TITLE
feat: extend textarea component in contact from 

### DIFF
--- a/src/page-modules/contact/components/form/fieldset/fieldset.module.css
+++ b/src/page-modules/contact/components/form/fieldset/fieldset.module.css
@@ -2,21 +2,22 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  padding: token('spacing.xLarge');
-  padding-bottom: token('spacing.medium');
+  padding: token('spacing.medium');
+  padding-top: token('spacing.large');
   margin: token('spacing.large');
   margin-top: 0px;
   border: none;
   border-radius: token('border.radius.regular');
   color: token('color.background.neutral.0.foreground.primary');
   background-color: token('color.background.neutral.0.background');
+  gap: token('spacing.xSmall');
 }
 
 .fieldset > * + * {
-  margin-top: token('spacing.medium');
+  margin-top: token('spacing.xLarge');
 }
 
 .legend {
   position: absolute;
-  top: token('spacing.small');
+  top: token('spacing.medium');
 }

--- a/src/page-modules/contact/components/form/form.module.css
+++ b/src/page-modules/contact/components/form/form.module.css
@@ -9,7 +9,6 @@
   gap: token('spacing.small');
   color: token('color.background.neutral.0.foreground.primary');
   background-color: token('color.background.neutral.0.background');
-  margin-bottom: token('spacing.medium');
 }
 
 .rowDisplay {

--- a/src/page-modules/contact/components/form/form.module.css
+++ b/src/page-modules/contact/components/form/form.module.css
@@ -157,16 +157,19 @@
 }
 
 /* textare */
+.textarea_container {
+  display: flex;
+  flex-direction: column;
+  gap: token('spacing.small');
+}
+
 .textarea {
   border: token('border.width.slim') solid
     token('color.foreground.dynamic.primary');
   border-radius: token('border.radius.small');
-
   padding: token('spacing.small');
-
   width: 100%;
   min-height: 6rem;
-
   font-family: var(--font-main) !important;
   font-size: 1rem !important;
   line-height: var(--baseTypo-body__primary-lineHeight, 1.25rem) !important;

--- a/src/page-modules/contact/components/form/textarea.tsx
+++ b/src/page-modules/contact/components/form/textarea.tsx
@@ -1,27 +1,35 @@
 import { ErrorMessage } from '@atb/components/error-message';
 import style from './form.module.css';
+import FileInput, { FileInputProps } from './file-input';
+import { Typo } from '@atb/components/typography';
 
 export type CheckboxProps = {
-  onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
-  error?: string;
+  description?: string;
   value: string;
+  error?: string;
+  fileInputProps?: FileInputProps;
+  onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
 } & JSX.IntrinsicElements['textarea'];
 
 export default function Textarea({
   id,
+  description,
   onChange,
   error,
   value,
+  fileInputProps,
 }: CheckboxProps) {
   return (
-    <>
+    <div className={style.textarea_container}>
+      {description && <Typo.p textType="body__primary">{description}</Typo.p>}
       <textarea
         id={`textarea__${id}`}
         className={style.textarea}
         value={value}
         onChange={onChange}
       />
+      {fileInputProps && <FileInput {...fileInputProps} />}
       {error && <ErrorMessage message={error} />}
-    </>
+    </div>
   );
 }

--- a/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
@@ -9,7 +9,6 @@ import {
   Fieldset,
   Select,
   Input,
-  FileInput,
   Textarea,
   SearchableSelect,
   getLineOptions,
@@ -160,11 +159,9 @@ export const DelayForm = ({ state, send }: DelayFormProps) => {
       </Fieldset>
 
       <Fieldset title={t(PageText.Contact.input.feedback.title)}>
-        <Typo.p textType="body__primary">
-          {t(PageText.Contact.input.feedback.description)}
-        </Typo.p>
         <Textarea
           id="feedback"
+          description={t(PageText.Contact.input.feedback.description)}
           value={state.context.feedback || ''}
           onChange={(e) =>
             send({
@@ -175,19 +172,19 @@ export const DelayForm = ({ state, send }: DelayFormProps) => {
           }
           error={
             state.context.errorMessages['feedback']?.[0]
-              ? t(state.context.errorMessages['feedback']?.[0]).toString()
+              ? t(state.context.errorMessages['feedback']?.[0])
               : undefined
           }
-        />
-        <FileInput
-          name="attachments"
-          label={t(PageText.Contact.input.feedback.attachment)}
-          onChange={(files) => {
-            send({
-              type: 'ON_INPUT_CHANGE',
-              inputName: 'attachments',
-              value: files,
-            });
+          fileInputProps={{
+            name: 'attachments',
+            label: t(PageText.Contact.input.feedback.attachment),
+            onChange: (files) => {
+              send({
+                type: 'ON_INPUT_CHANGE',
+                inputName: 'attachments',
+                value: files,
+              });
+            },
           }}
         />
       </Fieldset>

--- a/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
@@ -9,7 +9,6 @@ import {
   Fieldset,
   Select,
   Input,
-  FileInput,
   Textarea,
   SearchableSelect,
   getLineOptions,
@@ -160,11 +159,9 @@ export const DriverForm = ({ state, send }: DriverFormProps) => {
       </Fieldset>
 
       <Fieldset title={t(PageText.Contact.input.feedback.title)}>
-        <Typo.p textType="body__primary">
-          {t(PageText.Contact.input.feedback.description)}
-        </Typo.p>
         <Textarea
           id="feedback"
+          description={t(PageText.Contact.input.feedback.description)}
           value={state.context.feedback || ''}
           onChange={(e) =>
             send({
@@ -175,19 +172,19 @@ export const DriverForm = ({ state, send }: DriverFormProps) => {
           }
           error={
             state.context.errorMessages['feedback']?.[0]
-              ? t(state.context.errorMessages['feedback']?.[0]).toString()
+              ? t(state.context.errorMessages['feedback']?.[0])
               : undefined
           }
-        />
-        <FileInput
-          name="attachments"
-          label={t(PageText.Contact.input.feedback.attachment)}
-          onChange={(files) => {
-            send({
-              type: 'ON_INPUT_CHANGE',
-              inputName: 'attachments',
-              value: files,
-            });
+          fileInputProps={{
+            name: 'attachments',
+            label: t(PageText.Contact.input.feedback.attachment),
+            onChange: (files) => {
+              send({
+                type: 'ON_INPUT_CHANGE',
+                inputName: 'attachments',
+                value: files,
+              });
+            },
           }}
         />
       </Fieldset>

--- a/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
@@ -9,7 +9,6 @@ import {
   Fieldset,
   Select,
   Input,
-  FileInput,
   Textarea,
   SearchableSelect,
   getLineOptions,
@@ -159,11 +158,9 @@ export const InjuryForm = ({ state, send }: InjuryFormProps) => {
       </Fieldset>
 
       <Fieldset title={t(PageText.Contact.input.feedback.title)}>
-        <Typo.p textType="body__primary">
-          {t(PageText.Contact.input.feedback.description)}
-        </Typo.p>
         <Textarea
           id="feedback"
+          description={t(PageText.Contact.input.feedback.description)}
           value={state.context.feedback || ''}
           onChange={(e) =>
             send({
@@ -174,19 +171,19 @@ export const InjuryForm = ({ state, send }: InjuryFormProps) => {
           }
           error={
             state.context.errorMessages['feedback']?.[0]
-              ? t(state.context.errorMessages['feedback']?.[0]).toString()
+              ? t(state.context.errorMessages['feedback']?.[0])
               : undefined
           }
-        />
-        <FileInput
-          name="attachments"
-          label={t(PageText.Contact.input.feedback.attachment)}
-          onChange={(files) => {
-            send({
-              type: 'ON_INPUT_CHANGE',
-              inputName: 'attachments',
-              value: files,
-            });
+          fileInputProps={{
+            name: 'attachments',
+            label: t(PageText.Contact.input.feedback.attachment),
+            onChange: (files) => {
+              send({
+                type: 'ON_INPUT_CHANGE',
+                inputName: 'attachments',
+                value: files,
+              });
+            },
           }}
         />
       </Fieldset>

--- a/src/page-modules/contact/means-of-transport/forms/serviceOfferingForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/serviceOfferingForm.tsx
@@ -9,7 +9,6 @@ import {
   Fieldset,
   Select,
   Input,
-  FileInput,
   Textarea,
   SearchableSelect,
   getLineOptions,
@@ -96,11 +95,9 @@ export const ServiceOfferingForm = ({
       </Fieldset>
 
       <Fieldset title={t(PageText.Contact.input.feedback.title)}>
-        <Typo.p textType="body__primary">
-          {t(PageText.Contact.input.feedback.description)}
-        </Typo.p>
         <Textarea
           id="feedback"
+          description={t(PageText.Contact.input.feedback.description)}
           value={state.context.feedback || ''}
           onChange={(e) =>
             send({
@@ -111,19 +108,19 @@ export const ServiceOfferingForm = ({
           }
           error={
             state.context.errorMessages['feedback']?.[0]
-              ? t(state.context.errorMessages['feedback']?.[0]).toString()
+              ? t(state.context.errorMessages['feedback']?.[0])
               : undefined
           }
-        />
-        <FileInput
-          name="attachments"
-          label={t(PageText.Contact.input.feedback.attachment)}
-          onChange={(files) => {
-            send({
-              type: 'ON_INPUT_CHANGE',
-              inputName: 'attachments',
-              value: files,
-            });
+          fileInputProps={{
+            name: 'attachments',
+            label: t(PageText.Contact.input.feedback.attachment),
+            onChange: (files) => {
+              send({
+                type: 'ON_INPUT_CHANGE',
+                inputName: 'attachments',
+                value: files,
+              });
+            },
           }}
         />
       </Fieldset>

--- a/src/page-modules/contact/means-of-transport/forms/stopForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/stopForm.tsx
@@ -9,7 +9,6 @@ import {
   Fieldset,
   Select,
   Input,
-  FileInput,
   Textarea,
   SearchableSelect,
   getLineOptions,
@@ -122,11 +121,9 @@ export const StopForm = ({ state, send }: StopFormProps) => {
       </Fieldset>
 
       <Fieldset title={t(PageText.Contact.input.feedback.title)}>
-        <Typo.p textType="body__primary">
-          {t(PageText.Contact.input.feedback.description)}
-        </Typo.p>
         <Textarea
           id="feedback"
+          description={t(PageText.Contact.input.feedback.description)}
           value={state.context.feedback || ''}
           onChange={(e) =>
             send({
@@ -137,19 +134,19 @@ export const StopForm = ({ state, send }: StopFormProps) => {
           }
           error={
             state.context.errorMessages['feedback']?.[0]
-              ? t(state.context.errorMessages['feedback']?.[0]).toString()
+              ? t(state.context.errorMessages['feedback']?.[0])
               : undefined
           }
-        />
-        <FileInput
-          name="attachments"
-          label={t(PageText.Contact.input.feedback.attachment)}
-          onChange={(files) => {
-            send({
-              type: 'ON_INPUT_CHANGE',
-              inputName: 'attachments',
-              value: files,
-            });
+          fileInputProps={{
+            name: 'attachments',
+            label: t(PageText.Contact.input.feedback.attachment),
+            onChange: (files) => {
+              send({
+                type: 'ON_INPUT_CHANGE',
+                inputName: 'attachments',
+                value: files,
+              });
+            },
           }}
         />
       </Fieldset>

--- a/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
@@ -9,7 +9,6 @@ import {
   Fieldset,
   Select,
   Input,
-  FileInput,
   Textarea,
   SearchableSelect,
   getLineOptions,
@@ -168,10 +167,8 @@ export const TransportationForm = ({
       </Fieldset>
 
       <Fieldset title={t(PageText.Contact.input.feedback.title)}>
-        <Typo.p textType="body__primary">
-          {t(PageText.Contact.input.feedback.description)}
-        </Typo.p>
         <Textarea
+          description={t(PageText.Contact.input.feedback.description)}
           id="feedback"
           value={state.context.feedback || ''}
           onChange={(e) =>
@@ -183,19 +180,19 @@ export const TransportationForm = ({
           }
           error={
             state.context.errorMessages['feedback']?.[0]
-              ? t(state.context.errorMessages['feedback']?.[0]).toString()
+              ? t(state.context.errorMessages['feedback']?.[0])
               : undefined
           }
-        />
-        <FileInput
-          name="attachments"
-          label={t(PageText.Contact.input.feedback.attachment)}
-          onChange={(files) => {
-            send({
-              type: 'ON_INPUT_CHANGE',
-              inputName: 'attachments',
-              value: files,
-            });
+          fileInputProps={{
+            name: 'attachments',
+            label: t(PageText.Contact.input.feedback.attachment),
+            onChange: (files) => {
+              send({
+                type: 'ON_INPUT_CHANGE',
+                inputName: 'attachments',
+                value: files,
+              });
+            },
           }}
         />
       </Fieldset>

--- a/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundCarForm.tsx
+++ b/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundCarForm.tsx
@@ -410,7 +410,7 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
         />
 
         {state.context.hasInternationalBankAccount && (
-          <div>
+          <>
             <Input
               id="IBAN"
               label={t(PageText.Contact.input.bankInformation.IBAN.label)}
@@ -442,7 +442,7 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
                 })
               }
             />
-          </div>
+          </>
         )}
       </Fieldset>
     </>

--- a/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundCarForm.tsx
+++ b/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundCarForm.tsx
@@ -9,7 +9,6 @@ import {
   Input,
   Select,
   Textarea,
-  FileInput,
   SearchableSelect,
   getLineOptions,
   getStopOptions,
@@ -246,19 +245,19 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
           }
           error={
             state.context.errorMessages['feedback']?.[0] &&
-            t(state.context.errorMessages['feedback']?.[0]).toString()
+            t(state.context.errorMessages['feedback']?.[0])
           }
-        />
-        <FileInput
-          name="attachments"
-          onChange={(files) => {
-            send({
-              type: 'ON_INPUT_CHANGE',
-              inputName: 'attachments',
-              value: files,
-            });
+          fileInputProps={{
+            name: 'attachments',
+            label: t(PageText.Contact.input.feedback.attachment),
+            onChange: (files) => {
+              send({
+                type: 'ON_INPUT_CHANGE',
+                inputName: 'attachments',
+                value: files,
+              });
+            },
           }}
-          label={t(PageText.Contact.input.feedback.attachment)}
         />
       </Fieldset>
       <Fieldset title={t(PageText.Contact.aboutYouInfo.title)}>

--- a/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundTaxiForm.tsx
+++ b/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundTaxiForm.tsx
@@ -228,21 +228,17 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
               value: e.target.value,
             })
           }
-          error={
-            state.context.errorMessages['feedback']?.[0] &&
-            t(state.context.errorMessages['feedback']?.[0]).toString()
-          }
-        />
-        <FileInput
-          name="attachments"
-          onChange={(files) => {
+          fileInputProps={{
+            label: t(PageText.Contact.input.feedback.attachment),
+            name: 'attachments',
+            onChange: (files) => {
             send({
               type: 'ON_INPUT_CHANGE',
               inputName: 'attachments',
               value: files,
             });
+            },
           }}
-          label={t(PageText.Contact.input.feedback.attachment)}
         />
       </Fieldset>
       <Fieldset title={t(PageText.Contact.aboutYouInfo.title)}>

--- a/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundTaxiForm.tsx
+++ b/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundTaxiForm.tsx
@@ -232,11 +232,11 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
             label: t(PageText.Contact.input.feedback.attachment),
             name: 'attachments',
             onChange: (files) => {
-            send({
-              type: 'ON_INPUT_CHANGE',
-              inputName: 'attachments',
-              value: files,
-            });
+              send({
+                type: 'ON_INPUT_CHANGE',
+                inputName: 'attachments',
+                value: files,
+              });
             },
           }}
         />
@@ -390,7 +390,7 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
         />
 
         {state.context.hasInternationalBankAccount && (
-          <div>
+          <>
             <Input
               id="IBAN"
               label={t(PageText.Contact.input.bankInformation.IBAN.label)}
@@ -422,7 +422,7 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
                 })
               }
             />
-          </div>
+          </>
         )}
       </Fieldset>
     </>

--- a/src/page-modules/contact/refund/forms/refund-ticket/appTicketRefund.tsx
+++ b/src/page-modules/contact/refund/forms/refund-ticket/appTicketRefund.tsx
@@ -1,15 +1,8 @@
 import { PageText, useTranslation } from '@atb/translations';
 import { RefundContextProps } from '../../refundFormMachine';
 import { RefundFormEvents } from '../../events';
-import { Typo } from '@atb/components/typography';
 import { PurchasePlatformType } from '../../../types';
-import {
-  Fieldset,
-  Input,
-  Textarea,
-  FileInput,
-  Select,
-} from '../../../components';
+import { Fieldset, Input, Textarea, Select } from '../../../components';
 
 type AppTicketRefundProps = {
   state: { context: RefundContextProps };
@@ -92,12 +85,9 @@ export const AppTicketRefund = ({ state, send }: AppTicketRefundProps) => {
         placeholder={t(PageText.Contact.input.purchasePlatform.optionLabel)}
       />
 
-      <Typo.p textType="body__primary">
-        {t(PageText.Contact.input.refundReason.question)}
-      </Typo.p>
-
       <Textarea
         id="refundReason"
+        description={t(PageText.Contact.input.refundReason.question)}
         value={state.context.refundReason || ''}
         onChange={(e) =>
           send({
@@ -111,17 +101,17 @@ export const AppTicketRefund = ({ state, send }: AppTicketRefundProps) => {
             ? t(state.context.errorMessages['refundReason']?.[0])
             : undefined
         }
-      />
-      <FileInput
-        name="attachments"
-        onChange={(files) => {
-          send({
-            type: 'ON_INPUT_CHANGE',
-            inputName: 'attachments',
-            value: files,
-          });
+        fileInputProps={{
+          label: t(PageText.Contact.input.feedback.attachment),
+          name: 'attachments',
+          onChange: (files) => {
+            send({
+              type: 'ON_INPUT_CHANGE',
+              inputName: 'attachments',
+              value: files,
+            });
+          },
         }}
-        label={t(PageText.Contact.input.feedback.attachment)}
       />
     </Fieldset>
   );

--- a/src/page-modules/contact/refund/forms/refund-ticket/otherTicketRefund.tsx
+++ b/src/page-modules/contact/refund/forms/refund-ticket/otherTicketRefund.tsx
@@ -137,12 +137,9 @@ const RefundSection = ({ state, send }: RefundSectionProps) => {
         }}
       />
 
-      <Typo.p textType="body__primary">
-        {t(PageText.Contact.input.refundReason.question)}
-      </Typo.p>
-
       <Textarea
         id="refundReason"
+        description={t(PageText.Contact.input.refundReason.question)}
         value={state.context.refundReason || ''}
         onChange={(e) =>
           send({

--- a/src/page-modules/contact/refund/forms/refund-ticket/otherTicketRefund.tsx
+++ b/src/page-modules/contact/refund/forms/refund-ticket/otherTicketRefund.tsx
@@ -47,32 +47,33 @@ const RefundSection = ({ state, send }: RefundSectionProps) => {
             : undefined
         }
       />
+      <div>
+        <Radio
+          label={t(PageText.Contact.input.travelCardNumber.labelRadioButton)}
+          name="showInputTravelCardNumber"
+          checked={state.context.showInputTravelCardNumber}
+          onChange={() =>
+            send({
+              type: 'ON_INPUT_CHANGE',
+              inputName: 'showInputTravelCardNumber',
+              value: !state.context.showInputTravelCardNumber,
+            })
+          }
+        />
 
-      <Radio
-        label={t(PageText.Contact.input.travelCardNumber.labelRadioButton)}
-        name="showInputTravelCardNumber"
-        checked={state.context.showInputTravelCardNumber}
-        onChange={() =>
-          send({
-            type: 'ON_INPUT_CHANGE',
-            inputName: 'showInputTravelCardNumber',
-            value: !state.context.showInputTravelCardNumber,
-          })
-        }
-      />
-
-      <Radio
-        label={t(PageText.Contact.input.customerNumber.label)}
-        name="isAppTicketStorageMode"
-        checked={!state.context.showInputTravelCardNumber}
-        onChange={() =>
-          send({
-            type: 'ON_INPUT_CHANGE',
-            inputName: 'showInputTravelCardNumber',
-            value: !state.context.showInputTravelCardNumber,
-          })
-        }
-      />
+        <Radio
+          label={t(PageText.Contact.input.customerNumber.label)}
+          name="isAppTicketStorageMode"
+          checked={!state.context.showInputTravelCardNumber}
+          onChange={() =>
+            send({
+              type: 'ON_INPUT_CHANGE',
+              inputName: 'showInputTravelCardNumber',
+              value: !state.context.showInputTravelCardNumber,
+            })
+          }
+        />
+      </div>
 
       {state.context.showInputTravelCardNumber && (
         <Input
@@ -342,7 +343,7 @@ const AboutYouSection = ({ state, send }: AboutYouSectionProps) => {
       />
 
       {state.context.hasInternationalBankAccount && (
-        <div>
+        <>
           <Input
             id="IBAN"
             label={t(PageText.Contact.input.bankInformation.IBAN.label)}
@@ -374,7 +375,7 @@ const AboutYouSection = ({ state, send }: AboutYouSectionProps) => {
               })
             }
           />
-        </div>
+        </>
       )}
     </Fieldset>
   );

--- a/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
@@ -130,35 +130,38 @@ const FormContent = ({ state, send }: FormProps) => {
           )}
         </Typo.h3>
 
-        <Radio
-          label={t(
-            PageText.Contact.ticketControl.feeComplaint.ticketStorage.app.title,
-          )}
-          name="isAppTicketStorageMode"
-          checked={state.context.isAppTicketStorageMode}
-          onChange={() =>
-            send({
-              type: 'ON_INPUT_CHANGE',
-              inputName: 'isAppTicketStorageMode',
-              value: !state.context.isAppTicketStorageMode,
-            })
-          }
-        />
-        <Radio
-          label={t(PageText.Contact.input.travelCardNumber.labelRadioButton)}
-          name="isAppTicketStorageMode"
-          checked={!state.context.isAppTicketStorageMode}
-          onChange={() =>
-            send({
-              type: 'ON_INPUT_CHANGE',
-              inputName: 'isAppTicketStorageMode',
-              value: !state.context.isAppTicketStorageMode,
-            })
-          }
-        />
+        <div>
+          <Radio
+            label={t(
+              PageText.Contact.ticketControl.feeComplaint.ticketStorage.app
+                .title,
+            )}
+            name="isAppTicketStorageMode"
+            checked={state.context.isAppTicketStorageMode}
+            onChange={() =>
+              send({
+                type: 'ON_INPUT_CHANGE',
+                inputName: 'isAppTicketStorageMode',
+                value: !state.context.isAppTicketStorageMode,
+              })
+            }
+          />
+          <Radio
+            label={t(PageText.Contact.input.travelCardNumber.labelRadioButton)}
+            name="isAppTicketStorageMode"
+            checked={!state.context.isAppTicketStorageMode}
+            onChange={() =>
+              send({
+                type: 'ON_INPUT_CHANGE',
+                inputName: 'isAppTicketStorageMode',
+                value: !state.context.isAppTicketStorageMode,
+              })
+            }
+          />
+        </div>
 
         {state.context.isAppTicketStorageMode && (
-          <div>
+          <>
             <Input
               id="appPhoneNumber"
               label={t(PageText.Contact.input.appPhoneNumber.label)}
@@ -190,8 +193,9 @@ const FormContent = ({ state, send }: FormProps) => {
                 })
               }
             />
-          </div>
+          </>
         )}
+
         {!state.context.isAppTicketStorageMode && (
           <Input
             id="travelCardNumber"
@@ -388,7 +392,7 @@ const FormContent = ({ state, send }: FormProps) => {
         />
 
         {state.context.hasInternationalBankAccount && (
-          <div>
+          <>
             <Input
               id="IBAN"
               label={t(PageText.Contact.input.bankInformation.IBAN.label)}
@@ -420,7 +424,7 @@ const FormContent = ({ state, send }: FormProps) => {
                 })
               }
             />
-          </div>
+          </>
         )}
       </Fieldset>
     </>

--- a/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
@@ -3,7 +3,7 @@ import { PageText, TranslatedString, useTranslation } from '@atb/translations';
 import { Typo } from '@atb/components/typography';
 import { TicketControlContextProps } from '../ticket-control-form-machine';
 import { ticketControlFormEvents } from '../events';
-import { Input, Radio, Textarea, FileInput, Fieldset } from '../../components';
+import { Input, Radio, Textarea, Fieldset } from '../../components';
 import { Checkbox } from '@atb/components/checkbox';
 
 type FeeComplaintFormProps = {
@@ -223,20 +223,19 @@ const FormContent = ({ state, send }: FormProps) => {
           }
           error={
             state.context.errorMessages['feedback']?.[0] &&
-            t(state.context.errorMessages['feedback']?.[0]).toString()
+            t(state.context.errorMessages['feedback']?.[0])
           }
-        />
-
-        <FileInput
-          name="attachments"
-          onChange={(files) => {
-            send({
-              type: 'ON_INPUT_CHANGE',
-              inputName: 'attachments',
-              value: files,
-            });
+          fileInputProps={{
+            name: 'attachments',
+            label: t(PageText.Contact.input.feedback.attachment),
+            onChange: (files) => {
+              send({
+                type: 'ON_INPUT_CHANGE',
+                inputName: 'attachments',
+                value: files,
+              });
+            },
           }}
-          label={t(PageText.Contact.input.feedback.attachment)}
         />
       </Fieldset>
 

--- a/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
@@ -8,7 +8,6 @@ import { useLines } from '../../lines/use-lines';
 import {
   Input,
   Textarea,
-  FileInput,
   Fieldset,
   Select,
   SearchableSelect,
@@ -157,20 +156,19 @@ export const FeedbackForm = ({ state, send }: FeedbackFormProps) => {
           }
           error={
             state.context.errorMessages['feedback']?.[0] &&
-            t(state.context.errorMessages['feedback']?.[0]).toString()
+            t(state.context.errorMessages['feedback']?.[0])
           }
-        />
-
-        <FileInput
-          name="attachments"
-          onChange={(files) => {
-            send({
-              type: 'ON_INPUT_CHANGE',
-              inputName: 'attachments',
-              value: files,
-            });
+          fileInputProps={{
+            name: 'attachments',
+            label: t(PageText.Contact.input.feedback.attachment),
+            onChange: (files) => {
+              send({
+                type: 'ON_INPUT_CHANGE',
+                inputName: 'attachments',
+                value: files,
+              });
+            },
           }}
-          label={t(PageText.Contact.input.feedback.attachment)}
         />
       </Fieldset>
 

--- a/src/page-modules/contact/ticketing/forms/app/appAccountForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/app/appAccountForm.tsx
@@ -1,8 +1,7 @@
 import { PageText, useTranslation } from '@atb/translations';
 import { ticketingFormEvents } from '../../events';
 import { TicketingContextType } from '../../ticketingStateMachine';
-import { Typo } from '@atb/components/typography';
-import { Fieldset, Input, Textarea, FileInput } from '../../../components';
+import { Fieldset, Input, Textarea } from '../../../components';
 
 type AppAccountFormProps = {
   state: { context: TicketingContextType };
@@ -15,11 +14,9 @@ export const AppAccountForm = ({ state, send }: AppAccountFormProps) => {
   return (
     <>
       <Fieldset title={t(PageText.Contact.input.question.title)}>
-        <Typo.p textType="body__primary">
-          {t(PageText.Contact.input.question.info)}
-        </Typo.p>
         <Textarea
           id="question"
+          description={t(PageText.Contact.input.question.info)}
           value={state.context.question || ''}
           onChange={(e) =>
             send({
@@ -33,16 +30,16 @@ export const AppAccountForm = ({ state, send }: AppAccountFormProps) => {
               ? t(state.context.errorMessages['question']?.[0])
               : undefined
           }
-        />
-        <FileInput
-          name="attachments"
-          label={t(PageText.Contact.input.question.attachment)}
-          onChange={(files) => {
-            send({
-              type: 'ON_INPUT_CHANGE',
-              inputName: 'attachments',
-              value: files,
-            });
+          fileInputProps={{
+            name: 'attachments',
+            label: t(PageText.Contact.input.question.attachment),
+            onChange: (files) => {
+              send({
+                type: 'ON_INPUT_CHANGE',
+                inputName: 'attachments',
+                value: files,
+              });
+            },
           }}
         />
       </Fieldset>

--- a/src/page-modules/contact/ticketing/forms/app/appTicketingForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/app/appTicketingForm.tsx
@@ -1,8 +1,7 @@
 import { PageText, useTranslation } from '@atb/translations';
 import { ticketingFormEvents } from '../../events';
 import { TicketingContextType } from '../../ticketingStateMachine';
-import { Typo } from '@atb/components/typography';
-import { Fieldset, Input, Textarea, FileInput } from '../../../components';
+import { Fieldset, Input, Textarea } from '../../../components';
 
 type AppTicketingFormProps = {
   state: { context: TicketingContextType };
@@ -40,11 +39,9 @@ export const AppTicketingForm = ({ state, send }: AppTicketingFormProps) => {
         />
       </Fieldset>
       <Fieldset title={t(PageText.Contact.input.question.title)}>
-        <Typo.p textType="body__primary">
-          {t(PageText.Contact.input.question.info)}
-        </Typo.p>
         <Textarea
           id="question"
+          description={t(PageText.Contact.input.question.info)}
           value={state.context.question || ''}
           onChange={(e) =>
             send({
@@ -58,16 +55,16 @@ export const AppTicketingForm = ({ state, send }: AppTicketingFormProps) => {
               ? t(state.context.errorMessages['question']?.[0])
               : undefined
           }
-        />
-        <FileInput
-          name="attachments"
-          label={t(PageText.Contact.input.question.attachment)}
-          onChange={(files) => {
-            send({
-              type: 'ON_INPUT_CHANGE',
-              inputName: 'attachments',
-              value: files,
-            });
+          fileInputProps={{
+            name: 'attachments',
+            label: t(PageText.Contact.input.question.attachment),
+            onChange: (files) => {
+              send({
+                type: 'ON_INPUT_CHANGE',
+                inputName: 'attachments',
+                value: files,
+              });
+            },
           }}
         />
       </Fieldset>

--- a/src/page-modules/contact/ticketing/forms/app/appTravelSuggestionForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/app/appTravelSuggestionForm.tsx
@@ -1,8 +1,7 @@
 import { PageText, useTranslation } from '@atb/translations';
-import { Typo } from '@atb/components/typography';
 import { TicketingContextType } from '../../ticketingStateMachine';
 import { ticketingFormEvents } from '../../events';
-import { Fieldset, Input, Textarea, FileInput } from '../../../components';
+import { Fieldset, Input, Textarea } from '../../../components';
 
 type AppTravelSuggestionFormProps = {
   state: { context: TicketingContextType };
@@ -18,11 +17,9 @@ export const AppTravelSuggestionForm = ({
   return (
     <>
       <Fieldset title={t(PageText.Contact.input.question.title)}>
-        <Typo.p textType="body__primary">
-          {t(PageText.Contact.input.question.info)}
-        </Typo.p>
         <Textarea
           id="question"
+          description={t(PageText.Contact.input.question.info)}
           value={state.context.question || ''}
           onChange={(e) =>
             send({
@@ -36,16 +33,16 @@ export const AppTravelSuggestionForm = ({
               ? t(state.context.errorMessages['question']?.[0])
               : undefined
           }
-        />
-        <FileInput
-          name="attachments"
-          label={t(PageText.Contact.input.question.attachment)}
-          onChange={(files) => {
-            send({
-              type: 'ON_INPUT_CHANGE',
-              inputName: 'attachments',
-              value: files,
-            });
+          fileInputProps={{
+            name: 'attachments',
+            label: t(PageText.Contact.input.question.attachment),
+            onChange: (files) => {
+              send({
+                type: 'ON_INPUT_CHANGE',
+                inputName: 'attachments',
+                value: files,
+              });
+            },
           }}
         />
       </Fieldset>

--- a/src/page-modules/contact/ticketing/forms/priceAndTicketTypesForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/priceAndTicketTypesForm.tsx
@@ -1,8 +1,7 @@
 import { PageText, useTranslation } from '@atb/translations';
 import { TicketingContextType } from '../ticketingStateMachine';
-import { Typo } from '@atb/components/typography';
 import { ticketingFormEvents } from '../events';
-import { Fieldset, Input, Textarea, FileInput } from '../../components';
+import { Fieldset, Input, Textarea } from '../../components';
 
 type PriceAndTicketTypesFormProps = {
   state: { context: TicketingContextType };
@@ -18,11 +17,9 @@ export const PriceAndTicketTypesForm = ({
   return (
     <>
       <Fieldset title={t(PageText.Contact.input.question.title)}>
-        <Typo.p textType="body__primary">
-          {t(PageText.Contact.input.question.info)}
-        </Typo.p>
         <Textarea
           id="question"
+          description={t(PageText.Contact.input.question.info)}
           value={state.context.question || ''}
           onChange={(e) =>
             send({
@@ -33,19 +30,19 @@ export const PriceAndTicketTypesForm = ({
           }
           error={
             state.context.errorMessages['question']?.[0]
-              ? t(state.context.errorMessages['question']?.[0]).toString()
+              ? t(state.context.errorMessages['question']?.[0])
               : undefined
           }
-        />
-        <FileInput
-          name="attachments"
-          label={t(PageText.Contact.input.question.attachment)}
-          onChange={(files) => {
-            send({
-              type: 'ON_INPUT_CHANGE',
-              inputName: 'attachments',
-              value: files,
-            });
+          fileInputProps={{
+            name: 'attachments',
+            label: t(PageText.Contact.input.question.attachment),
+            onChange: (files) => {
+              send({
+                type: 'ON_INPUT_CHANGE',
+                inputName: 'attachments',
+                value: files,
+              });
+            },
           }}
         />
       </Fieldset>

--- a/src/page-modules/contact/ticketing/forms/travel-card/travelCardQuestionForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/travel-card/travelCardQuestionForm.tsx
@@ -2,7 +2,7 @@ import { PageText, useTranslation } from '@atb/translations';
 import { ticketingFormEvents } from '../../events';
 import { TicketingContextType } from '../../ticketingStateMachine';
 import { Typo } from '@atb/components/typography';
-import { Fieldset, Input, Textarea, FileInput } from '../../../components';
+import { Fieldset, Input, Textarea } from '../../../components';
 
 type TravelCardQuestionFormProps = {
   state: { context: TicketingContextType };
@@ -42,11 +42,9 @@ export const TravelCardQuestionForm = ({
         />
       </Fieldset>
       <Fieldset title={t(PageText.Contact.input.question.title)}>
-        <Typo.p textType="body__primary">
-          {t(PageText.Contact.input.question.info)}
-        </Typo.p>
         <Textarea
           id="question"
+          description={t(PageText.Contact.input.question.info)}
           value={state.context.question || ''}
           onChange={(e) =>
             send({
@@ -60,16 +58,16 @@ export const TravelCardQuestionForm = ({
               ? t(state.context.errorMessages['question']?.[0])
               : undefined
           }
-        />
-        <FileInput
-          name="attachments"
-          label={t(PageText.Contact.input.question.attachment)}
-          onChange={(files) => {
-            send({
-              type: 'ON_INPUT_CHANGE',
-              inputName: 'attachments',
-              value: files,
-            });
+          fileInputProps={{
+            name: 'attachments',
+            label: t(PageText.Contact.input.question.attachment),
+            onChange: (files) => {
+              send({
+                type: 'ON_INPUT_CHANGE',
+                inputName: 'attachments',
+                value: files,
+              });
+            },
           }}
         />
       </Fieldset>

--- a/src/page-modules/contact/ticketing/forms/webshop/webshopAccountForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/webshop/webshopAccountForm.tsx
@@ -1,8 +1,7 @@
 import { PageText, useTranslation } from '@atb/translations';
 import { ticketingFormEvents } from '../../events';
 import { TicketingContextType } from '../../ticketingStateMachine';
-import { Typo } from '@atb/components/typography';
-import { Fieldset, Textarea, FileInput, Input } from '../../../components';
+import { Fieldset, Textarea, Input } from '../../../components';
 
 type WebshopAccountFormProps = {
   state: { context: TicketingContextType };
@@ -18,11 +17,9 @@ export const WebshopAccountForm = ({
   return (
     <>
       <Fieldset title={t(PageText.Contact.input.question.title)}>
-        <Typo.p textType="body__primary">
-          {t(PageText.Contact.input.question.info)}
-        </Typo.p>
         <Textarea
           id="question"
+          description={t(PageText.Contact.input.question.info)}
           value={state.context.question || ''}
           onChange={(e) =>
             send({
@@ -36,16 +33,16 @@ export const WebshopAccountForm = ({
               ? t(state.context.errorMessages['question'][0])
               : undefined
           }
-        />
-        <FileInput
-          name="attachments"
-          label={t(PageText.Contact.input.question.attachment)}
-          onChange={(files) => {
-            send({
-              type: 'ON_INPUT_CHANGE',
-              inputName: 'attachments',
-              value: files,
-            });
+          fileInputProps={{
+            name: 'attachments',
+            label: t(PageText.Contact.input.question.attachment),
+            onChange: (files) => {
+              send({
+                type: 'ON_INPUT_CHANGE',
+                inputName: 'attachments',
+                value: files,
+              });
+            },
           }}
         />
       </Fieldset>

--- a/src/page-modules/contact/ticketing/forms/webshop/webshopTicketingForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/webshop/webshopTicketingForm.tsx
@@ -2,7 +2,7 @@ import { PageText, useTranslation } from '@atb/translations';
 import { ticketingFormEvents } from '../../events';
 import { TicketingContextType } from '../../ticketingStateMachine';
 import { Typo } from '@atb/components/typography';
-import { Fieldset, Textarea, FileInput, Input } from '../../../components';
+import { Fieldset, Textarea, Input } from '../../../components';
 import style from '../../../contact.module.css';
 
 type WebshopTicketingFormProps = {
@@ -49,11 +49,9 @@ export const WebshopTicketingForm = ({
       </Fieldset>
 
       <Fieldset title={t(PageText.Contact.input.question.title)}>
-        <Typo.p textType="body__primary">
-          {t(PageText.Contact.input.question.info)}
-        </Typo.p>
         <Textarea
           id="question"
+          description={t(PageText.Contact.input.question.info)}
           value={state.context.question || ''}
           onChange={(e) =>
             send({
@@ -67,16 +65,16 @@ export const WebshopTicketingForm = ({
               ? t(state.context.errorMessages['question'][0])
               : undefined
           }
-        />
-        <FileInput
-          name="attachments"
-          label={t(PageText.Contact.input.question.attachment)}
-          onChange={(files) => {
-            send({
-              type: 'ON_INPUT_CHANGE',
-              inputName: 'attachments',
-              value: files,
-            });
+          fileInputProps={{
+            name: 'attachments',
+            label: t(PageText.Contact.input.question.attachment),
+            onChange: (files) => {
+              send({
+                type: 'ON_INPUT_CHANGE',
+                inputName: 'attachments',
+                value: files,
+              });
+            },
           }}
         />
       </Fieldset>


### PR DESCRIPTION
This PR does the following:
 - Update the distances between the components used inside the contact forms, to make the forms appear less cramped. 
 - Extend textarea by moving the FileInput component into textarea. 
 - Extend the textarea component with the optional property `description` that can be used to describe the context of the textarea component.

| Before | After |
|--------|--------|
| <img width="933" alt="Skjermbilde 2025-05-07 kl  08 54 09" src="https://github.com/user-attachments/assets/23a10cfd-d4dc-4def-af4f-ca03de76ae66" /> | <img width="873" alt="Skjermbilde 2025-05-07 kl  08 54 54" src="https://github.com/user-attachments/assets/3ff7e90d-7dd4-473c-894c-74558b40a0c4" /> |


| Before | After |
|--------|--------|
| <img width="933" alt="Skjermbilde 2025-05-07 kl  08 53 25" src="https://github.com/user-attachments/assets/5017908d-a683-465b-ae6e-3fb206266a89" /> | <img width="865" alt="Skjermbilde 2025-05-07 kl  08 52 33" src="https://github.com/user-attachments/assets/7d0d3565-783b-4e25-bace-3b97a70b31a2" />  |
| <img width="933" alt="Skjermbilde 2025-05-07 kl  08 53 40" src="https://github.com/user-attachments/assets/007c657e-8009-405e-86cf-3952fa70f146" /> | <img width="865" alt="Skjermbilde 2025-05-07 kl  08 52 53" src="https://github.com/user-attachments/assets/6caf5365-9c1c-4c4c-89d1-04f4e9d75a16" /> | 