### PR TITLE
fix: validation errors in contact form 

### DIFF
--- a/src/page-modules/contact/means-of-transport/forms/stopForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/stopForm.tsx
@@ -104,8 +104,8 @@ export const StopForm = ({ state, send }: StopFormProps) => {
           placeholder={t(PageText.Contact.input.fromStop.optionLabel)}
           isRequired
           error={
-            state.context?.errorMessages['fromStop']?.[0]
-              ? t(state.context?.errorMessages['fromStop']?.[0])
+            state.context?.errorMessages['stop']?.[0]
+              ? t(state.context?.errorMessages['stop']?.[0])
               : undefined
           }
         />

--- a/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundCarForm.tsx
+++ b/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundCarForm.tsx
@@ -328,7 +328,7 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
         <Input
           id="postalCode"
           label={t(PageText.Contact.input.postalCode.label)}
-          type="number"
+          type="text"
           autoComplete="postal-code"
           name="postalCode"
           value={state.context.postalCode || ''}

--- a/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundTaxiForm.tsx
+++ b/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundTaxiForm.tsx
@@ -307,7 +307,7 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
         <Input
           id="postalCode"
           label={t(PageText.Contact.input.postalCode.label)}
-          type="number"
+          type="text"
           autoComplete="postal-code"
           name="postalCode"
           value={state.context.postalCode || ''}

--- a/src/page-modules/contact/refund/forms/refund-ticket/otherTicketRefund.tsx
+++ b/src/page-modules/contact/refund/forms/refund-ticket/otherTicketRefund.tsx
@@ -81,9 +81,12 @@ const RefundSection = ({ state, send }: RefundSectionProps) => {
         <Input
           id="travelCardNumber"
           label={t(PageText.Contact.input.travelCardNumber.label)}
-          type="number"
+          type="text"
           name="travelCardNumber"
           value={state.context.travelCardNumber || ''}
+          modalContent={{
+            description: t(PageText.Contact.input.travelCardNumber.info),
+          }}
           isRequired
           errorMessage={state.context.errorMessages['travelCardNumber']?.[0]}
           onChange={(e) =>

--- a/src/page-modules/contact/refund/forms/refund-ticket/otherTicketRefund.tsx
+++ b/src/page-modules/contact/refund/forms/refund-ticket/otherTicketRefund.tsx
@@ -260,7 +260,7 @@ const AboutYouSection = ({ state, send }: AboutYouSectionProps) => {
       <Input
         id="postalCode"
         label={t(PageText.Contact.input.postalCode.label)}
-        type="number"
+        type="text"
         autoComplete="postal-code"
         name="postalCode"
         value={state.context.postalCode || ''}

--- a/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
@@ -306,7 +306,7 @@ const FormContent = ({ state, send }: FormProps) => {
         <Input
           id="postalCode"
           label={t(PageText.Contact.input.postalCode.label)}
-          type="number"
+          type="text"
           autoComplete="postal-code"
           name="postalCode"
           value={state.context.postalCode || ''}

--- a/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
@@ -203,9 +203,12 @@ const FormContent = ({ state, send }: FormProps) => {
           <Input
             id="travelCardNumber"
             label={t(PageText.Contact.input.travelCardNumber.label)}
-            type="number"
+            type="text"
             name="travelCardNumber"
             value={state.context.travelCardNumber || ''}
+            modalContent={{
+              description: t(PageText.Contact.input.travelCardNumber.info),
+            }}
             isRequired
             errorMessage={state.context.errorMessages['travelCardNumber']?.[0]}
             onChange={(e) =>

--- a/src/page-modules/contact/ticketing/forms/app/appTicketingForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/app/appTicketingForm.tsx
@@ -76,6 +76,7 @@ export const AppTicketingForm = ({ state, send }: AppTicketingFormProps) => {
           type="text"
           name="customerNumber"
           value={state.context.customerNumber || ''}
+          errorMessage={state.context?.errorMessages['customerNumber']?.[0]}
           onChange={(e) =>
             send({
               type: 'ON_INPUT_CHANGE',

--- a/src/page-modules/contact/ticketing/forms/travel-card/travelCardQuestionForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/travel-card/travelCardQuestionForm.tsx
@@ -31,6 +31,9 @@ export const TravelCardQuestionForm = ({
           type="text"
           name="travelCardNumber"
           value={state.context.travelCardNumber || ''}
+          modalContent={{
+            description: t(PageText.Contact.input.travelCardNumber.info),
+          }}
           isRequired
           errorMessage={state.context?.errorMessages['travelCardNumber']?.[0]}
           onChange={(e) =>

--- a/src/page-modules/contact/ticketing/forms/webshop/webshopTicketingForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/webshop/webshopTicketingForm.tsx
@@ -1,9 +1,7 @@
 import { PageText, useTranslation } from '@atb/translations';
 import { ticketingFormEvents } from '../../events';
 import { TicketingContextType } from '../../ticketingStateMachine';
-import { Typo } from '@atb/components/typography';
 import { Fieldset, Textarea, Input } from '../../../components';
-import style from '../../../contact.module.css';
 
 type WebshopTicketingFormProps = {
   state: { context: TicketingContextType };
@@ -21,16 +19,6 @@ export const WebshopTicketingForm = ({
       <Fieldset
         title={t(PageText.Contact.ticketing.webshop.webshopTicketing.title)}
       >
-        <ul className={style.rules__list}>
-          {PageText.Contact.input.orderId.descriptionBulletPoints.map(
-            (desc, index) => (
-              <li key={index}>
-                <Typo.p textType="body__primary">{t(desc)}</Typo.p>
-              </li>
-            ),
-          )}
-        </ul>
-
         <Input
           id="orderId"
           label={t(PageText.Contact.input.orderId.label(false))}
@@ -38,6 +26,13 @@ export const WebshopTicketingForm = ({
           name="orderId"
           value={state.context.orderId || ''}
           isRequired
+          modalContent={{
+            description: t(PageText.Contact.input.orderId.description),
+            bulletPoints:
+              PageText.Contact.input.orderId.descriptionBulletPoints.map(
+                (bulletPoint) => t(bulletPoint),
+              ),
+          }}
           errorMessage={state.context?.errorMessages['orderId']?.[0]}
           onChange={(e) =>
             send({

--- a/src/page-modules/contact/ticketing/ticketingStateMachine.ts
+++ b/src/page-modules/contact/ticketing/ticketingStateMachine.ts
@@ -114,6 +114,7 @@ const setInputsToValidate = (context: TicketingContextType) => {
         ...commonAppFields,
         orderId,
         phoneNumber,
+        ...(customerNumber && { customerNumber }),
       };
 
     case FormType.AppTravelSuggestion:

--- a/src/page-modules/contact/ticketing/ticketingStateMachine.ts
+++ b/src/page-modules/contact/ticketing/ticketingStateMachine.ts
@@ -140,10 +140,19 @@ const setInputsToValidate = (context: TicketingContextType) => {
       };
 
     case FormType.WebshopTicketing:
-      return { formType, orderId, question, ...(!customerNumber && { email }) };
+      return {
+        formType,
+        orderId,
+        question,
+        ...(customerNumber ? { customerNumber } : { email }),
+      };
 
     case FormType.WebshopAccount:
-      return { formType, question, ...(!customerNumber && { email }) };
+      return {
+        formType,
+        question,
+        ...(customerNumber ? { customerNumber } : { email }),
+      };
   }
 };
 

--- a/src/page-modules/contact/validation/validationRules.ts
+++ b/src/page-modules/contact/validation/validationRules.ts
@@ -93,6 +93,10 @@ const rulesPostalCode: ValidationRule[] = [
     validate: hasExpectedLength(4),
     errorMessage: PageText.Contact.input.postalCode.errorMessages.invalidFormat,
   },
+  {
+    validate: isDigitsOnly,
+    errorMessage: PageText.Contact.input.postalCode.errorMessages.invalidFormat,
+  },
 ];
 
 const rulesCity: ValidationRule[] = [

--- a/src/page-modules/contact/validation/validationRules.ts
+++ b/src/page-modules/contact/validation/validationRules.ts
@@ -368,6 +368,16 @@ const rulesTravelCardNumber: ValidationRule[] = [
     validate: isNonEmptyString,
     errorMessage: PageText.Contact.input.travelCardNumber.errorMessages.empty,
   },
+  {
+    validate: hasExpectedLength(9),
+    errorMessage:
+      PageText.Contact.input.travelCardNumber.errorMessages.invalidFormat,
+  },
+  {
+    validate: isDigitsOnly,
+    errorMessage:
+      PageText.Contact.input.travelCardNumber.errorMessages.invalidFormat,
+  },
 ];
 
 type ValidationRulesMap = {

--- a/src/page-modules/contact/validation/validationRules.ts
+++ b/src/page-modules/contact/validation/validationRules.ts
@@ -177,6 +177,13 @@ const rulesToStop: ValidationRule[] = [
   },
 ];
 
+const rulesStop: ValidationRule[] = [
+  {
+    validate: (_stop: Line['quays'][0]) => isDefined(_stop),
+    errorMessage: PageText.Contact.input.stop.errorMessages.empty,
+  },
+];
+
 const rulesDate: ValidationRule[] = [
   {
     validate: isNonEmptyString,
@@ -382,6 +389,7 @@ export const validationRules: ValidationRulesMap = {
   line: rulesLine,
   fromStop: rulesFromStop,
   toStop: rulesToStop,
+  stop: rulesStop,
   date: rulesDate,
   dateOfTicketControl: rulesDateOfTicketControl,
   timeOfTicketControl: rulesTimeOfTicketControl,

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -1336,6 +1336,11 @@ const ContactInternal = {
           'Enter travelcard number',
           'Legg til reisekortnummer',
         ),
+        invalidFormat: _(
+          'Ugyldig reisekortnummer. Skriv inn et gyldig 9-siffered nummer.',
+          'Invalid travel card number. Please enter a valid 9-digit number.',
+          'Ugyldig reisekortnummer. Skriv inn eit gyldig 9-siffered nummer.',
+        ),
       },
     },
 

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -174,9 +174,9 @@ const ContactInternal = {
         'Eg vil gi ei tilbakemelding knytt til billettkontroll',
       ),
       info: _(
-        'Har du tilbakemelding på en bestemt billettkontroll, trenger vi en beskrivelse av hvor og når billettkontrollen fant sted for å kunne gå videre med saken. Hvis du har en generell tilbakemelding, kan du hoppe over de første punktene.',
-        'If you have feedback regarding a specific ticket inspection, we need a description of where and when the ticket inspection took place in order to proceed with the matter. If you have general feedback, you can skip the initial points.',
-        'Har du tilbakemelding på ein bestemt billettkontroll, treng vi ei beskriving av kor og kva tid billettkontrollen var for å kunne gå vidare med saka. Har du ei generell tilbakemelding, kan du hoppe over dei første punkta.',
+        'Har du tilbakemelding på en bestemt billettkontroll, trenger vi en beskrivelse av hvor og når billettkontrollen fant sted for å kunne gå videre med saken.',
+        'If you have feedback regarding a specific ticket inspection, we need a description of where and when the ticket inspection took place in order to proceed with the matter.',
+        'Har du tilbakemelding på ein bestemt billettkontroll, treng vi ei beskriving av kor og kva tid billettkontrollen var for å kunne gå vidare med saka.',
       ),
     },
   },

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -713,9 +713,9 @@ const ContactInternal = {
               'Periodebillett 30 dagar: Du får refusjon for antall resterande døgn.',
             ),
             _(
-              'Fylkesbillettene FRAM Ung, FRAM Student, FRAM Vaksen og FRAM Honnør: Du får refusjon for antall resterende døgn.',
-              'The county tickets FRAM Ung, FRAM Student, FRAM Vaksen and FRAM Honnør: You will receive a refund for numbers remaining on the day.',
-              'Fylkesbillettane FRAM Ung, FRAM Student, FRAM Vaksen og FRAM Honnør: Du får refusjon for antall resterande døgn. ',
+              'Periodebillettene for hele fylket: Du får refusjon for antall resterende døgn.',
+              'The period tickets for the entire county: You will receive a refund for numbers remaining on the day.',
+              'Periodebillettane for heile fylket: Du får refusjon for antall resterande døgn. ',
             ),
             _(
               'Reisekort: Du får tilbakebetalt verdien som gjenstår på reisekortet. ',

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -881,9 +881,9 @@ const ContactInternal = {
           'Vennligst fyll ut postnummer',
         ),
         invalidFormat: _(
-          'Skriv inn et gyldig postnummer med fire sifre',
-          'Enter a valid postal code with four digits',
-          'Skriv inn eit gyldig postnummer med fire siffer',
+          'Ugyldig postkode. Skriv inn et gyldig postnummer med 4 sifre',
+          'Invalid postal code. Enter a valid postal code with 4 digits',
+          'Ugyldig postkode. Skriv inn eit gyldig postnummer med 4 siffer',
         ),
       },
     },
@@ -913,9 +913,9 @@ const ContactInternal = {
           'Vennligst fyll ut ditt telefonnummer',
         ),
         invalidFormat: _(
-          'Vennligst fyll ut telefonnummeret på et gyldig format.',
-          'Please enter your phone number in a valid format.',
-          'Vennligst fyll ut telefonnummeret på eit gyldig format.',
+          'Ugyldig telefonnummer.Vennligst fyll ut telefonnummeret på et gyldig format.',
+          'Invalid phone number.Please enter your phone number in a valid format.',
+          'Ugyldig telefonnummer.Vennligst fyll ut telefonnummeret på eit gyldig format.',
         ),
       },
     },
@@ -1204,9 +1204,9 @@ const ContactInternal = {
     feeNumber: {
       label: _('Gebyrnummer', 'Fee number', 'Gebyrnummer'),
       description: _(
-        'Gebyrnummeret har fire siffer. Du finner det øverst i høyre hjørne på gebyret',
-        'The fee number has four digits. You can find it in the top right corner of the fee',
-        'Gebyrnummert har fire siffer. Du finn det øvst i høgre hjørne på gebyret',
+        'Gebyrnummeret har 4 siffer. Du finner det øverst i høyre hjørne på gebyret',
+        'The fee number has 4 digits. You can find it in the top right corner of the fee',
+        'Gebyrnummert har 4 siffer. Du finn det øvst i høgre hjørne på gebyret',
       ),
       instruction: _(
         'Fyll ut gebyrnummeret ditt',
@@ -1220,9 +1220,9 @@ const ContactInternal = {
           'Fyll ut gebyrnummeret ditt',
         ),
         invalidFormat: _(
-          'Ugyldig format. Gebyrnummeret består av fire siffer',
-          'Invalid format. The fee number consists of four digits',
-          'Ugyldig format. Gebyrnummeret består av fire siffer',
+          'Ugyldig gebyrnummer. Gebyrnummeret består av 4 siffer',
+          'Invalid fee number. The fee number consists of 4 digits',
+          'Ugyldig gebyrnummer. Gebyrnummeret består av 4 siffer',
         ),
       },
     },
@@ -1315,9 +1315,9 @@ const ContactInternal = {
           'Fyll inn kundenummer',
         ),
         invalidFormat: _(
-          'Ugyldig kundenummer. Skriv inn et gyldig nummer med 7 siffer.',
+          'Ugyldig kundenummer. Skriv inn et gyldig 7-siffered nummer.',
           'Invalid customer number. Please enter a valid 7-digit number.',
-          'Ugyldig kundenummer. Skriv inn eit gyldig nummer med 7 siffer.',
+          'Ugyldig kundenummer. Skriv inn eit gyldig 7-siffered nummer.',
         ),
       },
     },
@@ -1326,9 +1326,9 @@ const ContactInternal = {
       labelRadioButton: _('Reisekort', 'Travelcard', 'Reisekort'),
       label: _('Reisekortnummer', 'Travelcard number', 'Reisekortnummer'),
       info: _(
-        'Legg inn reisekortnummeret her hvis du allerede har et reisekort. Reisekortnummeret finner du på baksiden av reisekortet ditt',
-        'Enter the travel card number here if you already have a travel card. The travel card number can be found on the back of your travel card',
-        'Legg inn reisekortnummeret her viss du allereie har eit reisekort. Reisekortnummeret finn du bak på reisekortet ditt.',
+        'Legg inn reisekortnummeret her hvis du allerede har et reisekort. Reisekortnummeret består av 9 siffer og du finner det på baksiden av reisekortet ditt',
+        'Enter the travel card number here if you already have a travel card. The travel card number consists of 9 digits and can be found on the back of your travel card',
+        'Legg inn reisekortnummeret her viss du allereie har eit reisekort. Reisekortnummeret består av 9 siffer, og du finn det bak på reisekortet ditt.',
       ),
       errorMessages: {
         empty: _(
@@ -1411,9 +1411,9 @@ const ContactInternal = {
             'Ugyldig ordre-ID. Skriv inn ein gyldig ID på 8 teikn.',
           ),
           multipleIds: _(
-            'Én eller flere ordre-IDer ugyldige. En gyldig ID består av 8 tegn.',
+            'En eller flere ordre-IDer ugyldige. En gyldig ID består av 8 tegn.',
             'One or more order IDs are invalid. A vaild ID consists of 8 characters.',
-            'Éin eller fleire ordre-IDar er ugyldige. Ein gyldig ID består av 8 teikn.',
+            'Ein eller fleire ordre-IDar er ugyldige. Ein gyldig ID består av 8 teikn.',
           ),
         },
       },

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -1401,14 +1401,14 @@ const ContactInternal = {
         empty: _('Ordre-id mangler', 'Order-id is missing', 'Ordre-id manglar'),
         invalidFormat: {
           singleId: _(
-            'Ordre-IDen er skrevet i ugyldig format',
-            'The order ID is written in an invalid format',
-            'Ordre-IDen er skriven i ugyldig format',
+            'Ugyldig ordre-ID. Skriv inn en gyldig ID på 8 tegn.',
+            'Invalid order ID. Please enter a valid ID of 8 characters.',
+            'Ugyldig ordre-ID. Skriv inn ein gyldig ID på 8 teikn.',
           ),
           multipleIds: _(
-            'Én eller flere ordre-IDer er skrevet i ugyldig format',
-            'One or more order IDs are written in an invalid format',
-            'Éin eller fleire ordre-IDar er skriven i ugyldig format',
+            'Én eller flere ordre-IDer ugyldige. En gyldig ID består av 8 tegn.',
+            'One or more order IDs are invalid. A vaild ID consists of 8 characters.',
+            'Éin eller fleire ordre-IDar er ugyldige. Ein gyldig ID består av 8 teikn.',
           ),
         },
       },


### PR DESCRIPTION
This PR consists of various improvements to form validation and general language cleanup. More specifically, the following validation improvements have been made:

- Include missing errorMessage for the property `stop`.
- Extend ticketingStateMachine to validate `customerNumer` if included. 
- Extend the validation rules of of `travelCardNumber` and `postalCode`
