### PR TITLE
feat: move situation/notice icons and rail replacement bus icons

### DIFF
--- a/src/modules/situations/situation-or-notice-icon.tsx
+++ b/src/modules/situations/situation-or-notice-icon.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { getIconForMostCriticalSituationOrNotice } from './utils';
-import { ColorIcon } from '@atb/components/icon';
+import { ColorIcon, SizeProps } from '@atb/components/icon';
 import {
   NoticeFragment,
   SituationFragment,
@@ -11,6 +11,7 @@ type SituationOrNoticeIconProps = {
   notices?: NoticeFragment[];
   cancellation?: boolean;
   className?: string;
+  iconSize?: SizeProps;
 } & ({ situations: SituationFragment[] } | { situation: SituationFragment });
 
 export const SituationOrNoticeIcon = ({
@@ -18,6 +19,7 @@ export const SituationOrNoticeIcon = ({
   notices,
   cancellation,
   className,
+  iconSize = 'normal',
   ...props
 }: SituationOrNoticeIconProps) => {
   const situations =
@@ -32,6 +34,11 @@ export const SituationOrNoticeIcon = ({
   if (!icon) return null;
 
   return (
-    <ColorIcon className={className} icon={icon} alt={accessibilityLabel} />
+    <ColorIcon
+      className={className}
+      size={iconSize}
+      icon={icon}
+      alt={accessibilityLabel}
+    />
   );
 };

--- a/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/index.tsx
@@ -40,6 +40,14 @@ export function TripPatternHeader({
           alt={t(PageText.Assistant.trip.tripPattern.isCancelled.label)}
         />
       )}
+      <SituationOrNoticeIcon
+        situations={flatMap(tripPattern.legs, (leg) => leg.situations)}
+        notices={tripPattern.legs.flatMap(getNoticesForLeg)}
+        accessibilityLabel={startModeAndPlaceText}
+        cancellation={isCancelled}
+        iconSize="large"
+      />
+      <RailReplacementBusMessage tripPattern={tripPattern} />
       <Typo.span textType="body__secondary--bold">
         {startModeAndPlaceText}
         {isCancelled &&
@@ -50,15 +58,6 @@ export function TripPatternHeader({
       <Typo.span textType="body__secondary" className={style.header__duration}>
         {duration}
       </Typo.span>
-
-      <RailReplacementBusMessage tripPattern={tripPattern} />
-
-      <SituationOrNoticeIcon
-        situations={flatMap(tripPattern.legs, (leg) => leg.situations)}
-        notices={tripPattern.legs.flatMap(getNoticesForLeg)}
-        accessibilityLabel={startModeAndPlaceText}
-        cancellation={isCancelled}
-      />
     </header>
   );
 }

--- a/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/rail-replacement-bus.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/rail-replacement-bus.tsx
@@ -19,6 +19,7 @@ export const RailReplacementBusMessage = ({
 
   return (
     <ColorIcon
+      size="large"
       icon="status/Warning"
       alt={t(
         PageText.Assistant.trip.tripPattern.tripIncludesRailReplacementBus,

--- a/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/trip-pattern-header.module.css
+++ b/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/trip-pattern-header.module.css
@@ -1,6 +1,7 @@
 .header {
   display: flex;
   gap: token('spacing.small');
+  align-items: center;
   padding: token('spacing.small') token('spacing.medium');
 }
 


### PR DESCRIPTION
Fixes https://github.com/AtB-AS/kundevendt/issues/20572

Moved both icons to the left side and added size modifier. 
`SituationOrNoticeIcon` is used in multiple place, therefore I added a size modifier for the icon.
`RailReplacementBus` is only used in the trips list, so I don't add size modifier and just hardcoded it as large icon.

New icons are added here https://github.com/AtB-AS/planner-web/pull/549