### PR TITLE
fix: add alt text for situation and notice icons

### DIFF
--- a/src/modules/situations/situation-or-notice-icon.tsx
+++ b/src/modules/situations/situation-or-notice-icon.tsx
@@ -5,6 +5,7 @@ import {
   NoticeFragment,
   SituationFragment,
 } from '@atb/page-modules/assistant/journey-gql/trip.generated.ts';
+import { PageText, useTranslation } from '@atb/translations';
 
 type SituationOrNoticeIconProps = {
   accessibilityLabel?: string;
@@ -25,6 +26,8 @@ export const SituationOrNoticeIcon = ({
   const situations =
     'situation' in props ? [props.situation] : props.situations;
 
+  const { t } = useTranslation();
+
   // TODO: It might be needed to check if the transport is flexible and shows a yellow icon (warning)
   const icon = getIconForMostCriticalSituationOrNotice(
     situations,
@@ -38,7 +41,7 @@ export const SituationOrNoticeIcon = ({
       className={className}
       size={iconSize}
       icon={icon}
-      alt={accessibilityLabel}
+      alt={t(PageText.Assistant.trip.tripPattern.hasSituationsTip)}
     />
   );
 };

--- a/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/index.tsx
@@ -43,7 +43,6 @@ export function TripPatternHeader({
       <SituationOrNoticeIcon
         situations={flatMap(tripPattern.legs, (leg) => leg.situations)}
         notices={tripPattern.legs.flatMap(getNoticesForLeg)}
-        accessibilityLabel={startModeAndPlaceText}
         cancellation={isCancelled}
         iconSize="large"
       />


### PR DESCRIPTION
fix accessibility based on comment: https://github.com/AtB-AS/kundevendt/issues/20572#issuecomment-2866197649

### Acceptance Criteria:
- [ ] Situation & notice icon on trip list & trip details have alt text for accessibility