### PR TITLE
feat: remove page selector from contact page layout

### DIFF
--- a/src/page-modules/contact/layouts/contact-page-layout.tsx
+++ b/src/page-modules/contact/layouts/contact-page-layout.tsx
@@ -105,16 +105,7 @@ function ContactPageLayout({ children }: ContactPageLayoutProps) {
                     [style.contact_page_navigator__activePage]: isActive,
                   })}
                 >
-                  <MonoIcon
-                    className={style.normalIcon}
-                    size="normal"
-                    icon={contactPage.icon}
-                  />
-                  <MonoIcon
-                    className={style.largeIcon}
-                    size="large"
-                    icon={contactPage.icon}
-                  />
+                  <MonoIcon size="large" icon={contactPage.icon} />
                   <Typo.p textType="body__primary">
                     {t(contactPage.title)}
                   </Typo.p>

--- a/src/page-modules/contact/layouts/contact-page-layout.tsx
+++ b/src/page-modules/contact/layouts/contact-page-layout.tsx
@@ -2,13 +2,11 @@ import { PropsWithChildren, useEffect, useState } from 'react';
 import style from './layout.module.css';
 import { PageText, TranslatedString, useTranslation } from '@atb/translations';
 import { usePathname } from 'next/navigation';
-import { useRouter } from 'next/router';
 import Link from 'next/link';
 import { andIf } from '@atb/utils/css';
 import { Typo } from '@atb/components/typography';
 import { MonoIcon, MonoIcons } from '@atb/components/icon';
 import { ButtonLink } from '@atb/components/button';
-import { Select } from '../components';
 
 export type ContactPage = {
   title: TranslatedString;
@@ -61,7 +59,6 @@ export type ContactPageLayoutProps = PropsWithChildren<{
 function ContactPageLayout({ children }: ContactPageLayoutProps) {
   const { t } = useTranslation();
   const pathname = usePathname();
-  const router = useRouter();
   const [selectedContactPage, setSelectedContactPage] = useState<
     ContactPage | undefined
   >(undefined);
@@ -72,10 +69,6 @@ function ContactPageLayout({ children }: ContactPageLayoutProps) {
     );
     setSelectedContactPage(activePage);
   }, [pathname]);
-
-  const handleSelectChange = (contactPage?: ContactPage) => {
-    if (contactPage) router.push(contactPage.href);
-  };
 
   const displayPrivacyAndTerms = (contactPage?: ContactPage) => {
     if (!contactPage) return false;
@@ -97,17 +90,7 @@ function ContactPageLayout({ children }: ContactPageLayoutProps) {
           <Typo.h2 textType="heading--jumbo">
             {t(PageText.Contact.contactPageLayout.title)}
           </Typo.h2>
-          <div className={style.contact_page_navigator__dropdown}>
-            <Select
-              id="contactPage"
-              options={contactPages}
-              value={selectedContactPage}
-              placeholder={t(PageText.Contact.contactPageLayout.placeholder)}
-              onChange={handleSelectChange}
-              valueToId={(contactPage) => contactPage.href}
-              valueToText={(contactPage) => t(contactPage.title)}
-            />
-          </div>
+
           <nav className={style.contact_page_navigator__container}>
             {contactPages.map((contactPage, index) => {
               const isActive = pathname.includes(contactPage.href);
@@ -122,7 +105,16 @@ function ContactPageLayout({ children }: ContactPageLayoutProps) {
                     [style.contact_page_navigator__activePage]: isActive,
                   })}
                 >
-                  <MonoIcon size="large" icon={contactPage.icon} />
+                  <MonoIcon
+                    className={style.normalIcon}
+                    size="normal"
+                    icon={contactPage.icon}
+                  />
+                  <MonoIcon
+                    className={style.largeIcon}
+                    size="large"
+                    icon={contactPage.icon}
+                  />
                   <Typo.p textType="body__primary">
                     {t(contactPage.title)}
                   </Typo.p>

--- a/src/page-modules/contact/layouts/layout.module.css
+++ b/src/page-modules/contact/layouts/layout.module.css
@@ -49,23 +49,7 @@
 @media (max-width: 600px) {
   .contact_page_navigator__link {
     width: 10rem;
-    height: 6rem;
-  }
-}
-
-.normalIcon {
-  display: none;
-}
-
-.largeIcon {
-}
-
-@media (max-width: 600px) {
-  .normalIcon {
-    display: block;
-  }
-  .largeIcon {
-    display: none;
+    height: 8rem;
   }
 }
 

--- a/src/page-modules/contact/layouts/layout.module.css
+++ b/src/page-modules/contact/layouts/layout.module.css
@@ -46,6 +46,29 @@
   border-radius: token('border.radius.regular');
 }
 
+@media (max-width: 600px) {
+  .contact_page_navigator__link {
+    width: 10rem;
+    height: 6rem;
+  }
+}
+
+.normalIcon {
+  display: none;
+}
+
+.largeIcon {
+}
+
+@media (max-width: 600px) {
+  .normalIcon {
+    display: block;
+  }
+  .largeIcon {
+    display: none;
+  }
+}
+
 .contact_page_navigator__link:hover {
   color: token('color.interactive.2.hover.foreground.primary');
   background-color: token('color.interactive.2.hover.background');
@@ -63,20 +86,6 @@
 .contact_page_navigator__activePage {
   border: token('border.width.medium') solid
     token('color.interactive.2.outline.background');
-}
-
-.contact_page_navigator__dropdown {
-  display: none;
-}
-
-@media (max-width: 600px) {
-  .contact_page_navigator__container {
-    display: none;
-  }
-
-  .contact_page_navigator__dropdown {
-    display: block;
-  }
 }
 
 .privacyAndTerms {

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -17,7 +17,6 @@ const ContactInternal = {
       'Back to travel search',
       'Tilbake til reisesøk',
     ),
-    placeholder: _('Velg et skjema', 'Select a form', 'Vel eit skjema'),
     privacyAndTerms: _(
       'Vi ber om de personopplysningene vi trenger for å behandle saken din. Du skal derfor ikke legge inn personopplysninger i fritekstfeltene. Personopplysninger er alle opplysninger som kan knytest til en fysisk person, eller bidra til å identifisere en fysisk person.',
       'We ask for the personal information we need to process your case. You should therefore not enter personal information in the free text field. Personal information is all information that can be linked to a physical person, or help to identify a physical person.',


### PR DESCRIPTION
Remove contact page selector from contact page layout after feedback. Should use the existing contactFormLinks in both desktop and mobile view. 

Before:


https://github.com/user-attachments/assets/3c9ed19f-fe15-4a88-9662-61604ce96933



Now:


https://github.com/user-attachments/assets/0c881a2f-fc41-468c-b758-8625571cf49b


