### PR TITLE
feat: enable automatic scroll to error message for file-input component

### DIFF
--- a/src/page-modules/contact/components/form/file-input.tsx
+++ b/src/page-modules/contact/components/form/file-input.tsx
@@ -8,6 +8,7 @@ import { useTheme } from '@atb/modules/theme';
 import { ErrorMessage } from '@atb/components/error-message';
 
 export type FileInputProps = {
+  id: string;
   label: string;
   errorMessage?: TranslatedString;
   onChange?: (files: File[]) => void;
@@ -16,13 +17,13 @@ export type FileInputProps = {
 const MAX_ALLOWED_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 
 export default function FileInput({
+  id,
   onChange,
   label,
   name,
   errorMessage,
 }: FileInputProps) {
   const { t } = useTranslation();
-  const id = useId();
   const {
     color: { background },
   } = useTheme();
@@ -84,7 +85,7 @@ export default function FileInput({
       className={style.file_input__container}
     >
       <input
-        id={id}
+        id={`file_input__${id}`}
         type="file"
         onChange={handleFileChange}
         name={name}

--- a/src/page-modules/contact/components/form/file-input.tsx
+++ b/src/page-modules/contact/components/form/file-input.tsx
@@ -95,7 +95,7 @@ export default function FileInput({
       />
 
       <label
-        htmlFor={id}
+        htmlFor={`file_input__${id}`}
         className={style.label__file}
         tabIndex={0}
         onKeyDown={(e) => {

--- a/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
@@ -184,6 +184,7 @@ export const DelayForm = ({ state, send }: DelayFormProps) => {
               : undefined
           }
           fileInputProps={{
+            id: 'attachments',
             name: 'attachments',
             label: t(PageText.Contact.input.feedback.attachment),
             onChange: (files) => {

--- a/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
@@ -184,6 +184,7 @@ export const DriverForm = ({ state, send }: DriverFormProps) => {
               : undefined
           }
           fileInputProps={{
+            id: 'attachments',
             name: 'attachments',
             label: t(PageText.Contact.input.feedback.attachment),
             onChange: (files) => {

--- a/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
@@ -183,6 +183,7 @@ export const InjuryForm = ({ state, send }: InjuryFormProps) => {
               : undefined
           }
           fileInputProps={{
+            id: 'attachments',
             name: 'attachments',
             label: t(PageText.Contact.input.feedback.attachment),
             onChange: (files) => {

--- a/src/page-modules/contact/means-of-transport/forms/serviceOfferingForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/serviceOfferingForm.tsx
@@ -114,6 +114,7 @@ export const ServiceOfferingForm = ({
               : undefined
           }
           fileInputProps={{
+            id: 'attachments',
             name: 'attachments',
             label: t(PageText.Contact.input.feedback.attachment),
             onChange: (files) => {

--- a/src/page-modules/contact/means-of-transport/forms/stopForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/stopForm.tsx
@@ -143,6 +143,7 @@ export const StopForm = ({ state, send }: StopFormProps) => {
               : undefined
           }
           fileInputProps={{
+            id: 'attachments',
             name: 'attachments',
             label: t(PageText.Contact.input.feedback.attachment),
             onChange: (files) => {

--- a/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
@@ -192,6 +192,7 @@ export const TransportationForm = ({
               : undefined
           }
           fileInputProps={{
+            id: 'attachments',
             name: 'attachments',
             label: t(PageText.Contact.input.feedback.attachment),
             onChange: (files) => {

--- a/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundCarForm.tsx
+++ b/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundCarForm.tsx
@@ -260,6 +260,7 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
             t(state.context.errorMessages['feedback']?.[0])
           }
           fileInputProps={{
+            id: 'attachments',
             name: 'attachments',
             label: t(PageText.Contact.input.feedback.attachment),
             onChange: (files) => {

--- a/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundTaxiForm.tsx
+++ b/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundTaxiForm.tsx
@@ -36,6 +36,7 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
         </Typo.p>
 
         <FileInput
+          id="attachments"
           label={t(PageText.Contact.input.feedback.attachment)}
           name="attachments"
           onChange={(files) => {
@@ -239,6 +240,7 @@ export const RefundTaxiForm = ({ state, send }: RefundTaxiFormProps) => {
             })
           }
           fileInputProps={{
+            id: 'attachments',
             label: t(PageText.Contact.input.feedback.attachment),
             name: 'attachments',
             onChange: (files) => {

--- a/src/page-modules/contact/refund/forms/refund-ticket/appTicketRefund.tsx
+++ b/src/page-modules/contact/refund/forms/refund-ticket/appTicketRefund.tsx
@@ -105,6 +105,7 @@ export const AppTicketRefund = ({ state, send }: AppTicketRefundProps) => {
             : undefined
         }
         fileInputProps={{
+          id: 'attachments',
           label: t(PageText.Contact.input.feedback.attachment),
           name: 'attachments',
           onChange: (files) => {

--- a/src/page-modules/contact/refund/forms/refund-ticket/otherTicketRefund.tsx
+++ b/src/page-modules/contact/refund/forms/refund-ticket/otherTicketRefund.tsx
@@ -185,6 +185,7 @@ const RefundSection = ({ state, send }: RefundSectionProps) => {
       </Typo.p>
 
       <FileInput
+        id="attachments"
         name="attachments"
         label={t(PageText.Contact.input.question.attachment)}
         onChange={(files) => {

--- a/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
@@ -242,6 +242,7 @@ const FormContent = ({ state, send }: FormProps) => {
             t(state.context.errorMessages['feedback']?.[0])
           }
           fileInputProps={{
+            id: 'attachments',
             name: 'attachments',
             label: t(PageText.Contact.input.feedback.attachment),
             onChange: (files) => {

--- a/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
@@ -165,6 +165,7 @@ export const FeedbackForm = ({ state, send }: FeedbackFormProps) => {
             t(state.context.errorMessages['feedback']?.[0])
           }
           fileInputProps={{
+            id: 'attachments',
             name: 'attachments',
             label: t(PageText.Contact.input.feedback.attachment),
             onChange: (files) => {

--- a/src/page-modules/contact/ticketing/forms/app/appAccountForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/app/appAccountForm.tsx
@@ -31,6 +31,7 @@ export const AppAccountForm = ({ state, send }: AppAccountFormProps) => {
               : undefined
           }
           fileInputProps={{
+            id: 'attachments',
             name: 'attachments',
             label: t(PageText.Contact.input.question.attachment),
             onChange: (files) => {

--- a/src/page-modules/contact/ticketing/forms/app/appTicketingForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/app/appTicketingForm.tsx
@@ -57,6 +57,7 @@ export const AppTicketingForm = ({ state, send }: AppTicketingFormProps) => {
               : undefined
           }
           fileInputProps={{
+            id: 'attachments',
             name: 'attachments',
             label: t(PageText.Contact.input.question.attachment),
             onChange: (files) => {

--- a/src/page-modules/contact/ticketing/forms/app/appTravelSuggestionForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/app/appTravelSuggestionForm.tsx
@@ -34,6 +34,7 @@ export const AppTravelSuggestionForm = ({
               : undefined
           }
           fileInputProps={{
+            id: 'attachments',
             name: 'attachments',
             label: t(PageText.Contact.input.question.attachment),
             onChange: (files) => {

--- a/src/page-modules/contact/ticketing/forms/priceAndTicketTypesForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/priceAndTicketTypesForm.tsx
@@ -34,6 +34,7 @@ export const PriceAndTicketTypesForm = ({
               : undefined
           }
           fileInputProps={{
+            id: 'attachments',
             name: 'attachments',
             label: t(PageText.Contact.input.question.attachment),
             onChange: (files) => {

--- a/src/page-modules/contact/ticketing/forms/travel-card/travelCardQuestionForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/travel-card/travelCardQuestionForm.tsx
@@ -63,6 +63,7 @@ export const TravelCardQuestionForm = ({
               : undefined
           }
           fileInputProps={{
+            id: 'attachments',
             name: 'attachments',
             label: t(PageText.Contact.input.question.attachment),
             onChange: (files) => {

--- a/src/page-modules/contact/ticketing/forms/webshop/webshopAccountForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/webshop/webshopAccountForm.tsx
@@ -34,6 +34,7 @@ export const WebshopAccountForm = ({
               : undefined
           }
           fileInputProps={{
+            id: 'attachments',
             name: 'attachments',
             label: t(PageText.Contact.input.question.attachment),
             onChange: (files) => {

--- a/src/page-modules/contact/ticketing/forms/webshop/webshopTicketingForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/webshop/webshopTicketingForm.tsx
@@ -62,6 +62,7 @@ export const WebshopTicketingForm = ({
               : undefined
           }
           fileInputProps={{
+            id: 'attachments',
             name: 'attachments',
             label: t(PageText.Contact.input.question.attachment),
             onChange: (files) => {

--- a/src/page-modules/contact/utils.ts
+++ b/src/page-modules/contact/utils.ts
@@ -95,6 +95,7 @@ const formFieldsPrefixes = [
   'searchable_select__',
   'date_selector__',
   'time_selector__',
+  'file_input__',
 ];
 
 export const findOrderFormFields = (e: FormEvent<HTMLFormElement>): string[] =>
@@ -113,9 +114,16 @@ export const scrollToFirstErrorMessage = (id: string | undefined): void => {
     .map((prefix) => document.getElementById(`${prefix}${id}`))
     .find((el): el is HTMLElement => el !== null);
 
-  if (element) {
-    element.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    element.focus();
+  // FilInput must be focused by label, as input have display none.
+  const labelElement = document.querySelector(
+    `label[for=${id}]`,
+  ) as HTMLElement | null;
+
+  const scrollTarget = labelElement ?? element;
+
+  if (scrollTarget) {
+    scrollTarget.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    scrollTarget.focus();
   }
 };
 

--- a/src/page-modules/contact/utils.ts
+++ b/src/page-modules/contact/utils.ts
@@ -110,13 +110,23 @@ export const findOrderFormFields = (e: FormEvent<HTMLFormElement>): string[] =>
 export const scrollToFirstErrorMessage = (id: string | undefined): void => {
   if (!id) return;
 
-  const element = formFieldsPrefixes
-    .map((prefix) => document.getElementById(`${prefix}${id}`))
-    .find((el): el is HTMLElement => el !== null);
+  const match = formFieldsPrefixes
+    .map((prefix) => ({
+      prefix,
+      element: document.getElementById(`${prefix}${id}`),
+    }))
+    .find(
+      (item): item is { prefix: string; element: HTMLElement } =>
+        item.element !== null,
+    );
 
-  // FilInput must be focused by label, as input have display none.
+  const element = match?.element;
+  const prefix = match?.prefix;
+
+  // The <input> for FileInput is hidden (display: none), so it can't receive focus.
+  // Instead, we need to focus the corresponding <label> using its `for` attribute.
   const labelElement = document.querySelector(
-    `label[for=${id}]`,
+    `label[for=${prefix}${id}]`,
   ) as HTMLElement | null;
 
   const scrollTarget = labelElement ?? element;


### PR DESCRIPTION
Enable automatic scroll to error message inside contact form, for the `FileInput` component. 


https://github.com/user-attachments/assets/4784000f-ed4c-4645-8b05-f67109fa0982


