### PR TITLE
Small fixes for colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@apollo/client": "^3.11.2",
     "@atb-as/config-specs": "^3.27.0",
-    "@atb-as/theme": "^14.0.0",
+    "@atb-as/theme": "^14.0.1",
     "@github/combobox-nav": "^3.0.1",
     "@internationalized/date": "^3.5.5",
     "@isaacs/ttlcache": "^1.4.1",

--- a/src/layouts/base/index.tsx
+++ b/src/layouts/base/index.tsx
@@ -43,13 +43,9 @@ export function BaseLayout({ children, title }: BaseLayoutProps) {
             content={theme.color.background.accent[0].background}
           />
         </Head>
-
         <OpenGraphBase title={siteTitle} />
-
         <PageHeader />
-
         <main className={style.main}>{children}</main>
-
         <Footer />
       </div>
     </I18nProvider>

--- a/src/modules/search-time/selector/selector.module.css
+++ b/src/modules/search-time/selector/selector.module.css
@@ -4,7 +4,6 @@
 }
 
 .options {
-  --container-height: 2.75rem;
   --option-height: 2.25rem;
   --container-border-radius: 0.75rem;
   --option-border-radius: token('border.radius.regular');
@@ -17,7 +16,6 @@
   border: 1px solid token('color.foreground.dynamic.disabled');
   width: fit-content;
   border-radius: var(--container-border-radius);
-  height: var(--container-height);
   align-items: center;
 }
 

--- a/src/utils/org-theme-definitions.ts
+++ b/src/utils/org-theme-definitions.ts
@@ -11,8 +11,11 @@ export function useOrgThemeDefinitions() {
       ? fylkeskommune?.logoSrcDark
       : fylkeskommune?.logoSrc;
 
-  const overrideMonoIconMode: MonoIconOverrideMode =
-    orgId === 'atb' ? (isDarkMode ? 'dark' : 'light') : 'dark';
+  const overrideMonoIconMode: MonoIconOverrideMode = (() => {
+    if (orgId === 'vkt' || orgId === 'farte') return 'none';
+    else if (orgId === 'atb') return isDarkMode ? 'dark' : 'light';
+    return 'dark';
+  })();
 
   return { fylkeskommuneLogo, overrideMonoIconMode };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -112,10 +112,10 @@
     hex-to-rgba "^2.0.1"
     ts-deepmerge "^4.0.0"
 
-"@atb-as/theme@^14.0.0":
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-14.0.0.tgz#5a76c62bd4743cc0786ac25525b0bc01781c7eae"
-  integrity sha512-FeBYXixUbNHjqRHCqtyVsRRNs1N8kIogISnbPlyqXSTOH67OOGqPA1W589HGJL4Qxuodfxh61TQBIkpekDCiqw==
+"@atb-as/theme@^14.0.1":
+  version "14.0.1"
+  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-14.0.1.tgz#82f3d3cc179ee788a1b32d9d2c89948ea2d88dfb"
+  integrity sha512-NYL92rDfXfkc4OAOWZNdhMvlCrqe6RExPbLGICkXHhpFQgEK77pzJNFO85Rj43+DRYeu32nGOBtEjJsIe1rINA==
   dependencies:
     "@tfk-samf/figma-to-dtcg" "0.4.0"
     hex-to-rgba "^2.0.1"


### PR DESCRIPTION
Fix for AtB-AS/kundevendt#19971

Includes following changes:
- Bump of design system for new colors for Farte, since they though the yellow was too yellow. Is now black header
- Fixes that homePage-button had icon of different color than the rest of the button
- Fixes uneven padding in timeSelector ("Nå", "Avreise", "Avgang")
![443244662-18ebb06f-b34a-49c7-a618-c6b925ac528d](https://github.com/user-attachments/assets/f04c6697-b6b3-4527-8414-683727898412)
