### PR TITLE
feat: improve fieldset spacing and padding in contact form 

### DIFF
--- a/src/page-modules/contact/components/form/fieldset/fieldset.module.css
+++ b/src/page-modules/contact/components/form/fieldset/fieldset.module.css
@@ -2,10 +2,7 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  padding: token('spacing.medium');
-  padding-top: token('spacing.large');
-  margin: token('spacing.large');
-  margin-top: 0px;
+  padding: token('spacing.large');
   border: none;
   border-radius: token('border.radius.regular');
   color: token('color.background.neutral.0.foreground.primary');

--- a/src/page-modules/contact/contact.module.css
+++ b/src/page-modules/contact/contact.module.css
@@ -4,7 +4,9 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
+  gap: token('spacing.large');
 }
+
 .form_options__list {
   list-style-type: none;
 }

--- a/src/page-modules/contact/layouts/layout.module.css
+++ b/src/page-modules/contact/layouts/layout.module.css
@@ -4,12 +4,9 @@
   width: 100%;
   max-width: var(--maxPageWidth);
   margin: 0 auto;
+  padding: 0 token('spacing.medium');
 }
-@media (max-width: 650px) {
-  .layout {
-    padding: 0 token('spacing.medium');
-  }
-}
+
 .homeLink__container {
   padding: 0 token('spacing.medium');
 }


### PR DESCRIPTION
In this PR, the spacing between and around the fieldsets used in the contact form is cleaned up to utilize more of the screen in mobile view. Also, the fieldset padding is increased.  

| Before | After |
|--------|--------|
| ![Screen Shot 2025-05-14 at 10 49 33](https://github.com/user-attachments/assets/81b31992-9cf0-4f78-9be3-792d04718497) | ![Screen Shot 2025-05-14 at 10 49 42](https://github.com/user-attachments/assets/7e6d185d-585a-42db-a32c-98056049d405)|
| ![Screen Shot 2025-05-14 at 10 49 54](https://github.com/user-attachments/assets/9a1612e0-5bad-4054-a140-a80693eeb3e2) | ![Screen Shot 2025-05-14 at 10 49 59](https://github.com/user-attachments/assets/43806eb2-ca3d-4006-851e-64932a851389) | 
| ![Screen Shot 2025-05-14 at 10 50 54](https://github.com/user-attachments/assets/383aa910-8967-42ee-8f0d-50c22d072253) | ![Screen Shot 2025-05-14 at 10 51 02](https://github.com/user-attachments/assets/2b4cf674-1577-4a3a-b29e-069ad7a93695) |


