### PR TITLE
feat: Auto-move time to early morning on date change away from today

### DIFF
--- a/src/modules/search-time/selector/index.tsx
+++ b/src/modules/search-time/selector/index.tsx
@@ -4,7 +4,7 @@ import {
   useTranslation,
 } from '@atb/translations';
 import { fromLocalTimeToCET, setTimezone } from '@atb/utils/date';
-import { format, subDays } from 'date-fns';
+import { format, isFuture, isToday, subDays } from 'date-fns';
 import { AnimatePresence, motion } from 'framer-motion';
 import { CSSProperties, useState } from 'react';
 import { SEARCH_MODES, SearchMode, SearchTime } from '../types';
@@ -83,11 +83,18 @@ export default function SearchTimeSelector({
       return;
     }
 
-    setSelectedDate(new Date(date));
+    const newDate = new Date(date);
+    // resets time to early morning when moving away from today
+    // does not reset time when the date is already in the future
+    const newTime =
+      isToday(selectedDate) && isFuture(newDate) ? '06:00' : selectedTime;
+
+    setSelectedDate(newDate);
+    setSelectedTime(newTime);
 
     onChange({
       mode: selectedMode.mode,
-      dateTime: new Date(date + 'T' + selectedTime).getTime(),
+      dateTime: new Date(date + 'T' + newTime).getTime(),
     });
   };
 


### PR DESCRIPTION
It was requested by @Sebstorvik / customer service to auto-select an early time when selecting a different date than today.
This PR does that, however does not change it when you have already selected another date, because then you probably have already set it yourself..

Acceptance Criteria:
- [ ] When switching from today's date to a date in the future, the time should be reset to 06:00.
- [ ] The time should not be reset for any other date changes.
- [ ] The trip search should use the updated time on the next search