### PR TITLE
fix: keep loading indicator when yet to get results

### DIFF
--- a/src/page-modules/assistant/client/journey-planner/index.ts
+++ b/src/page-modules/assistant/client/journey-planner/index.ts
@@ -39,7 +39,6 @@ export function useTripPatterns(
   tripQuery: FromToTripQuery,
   fallback?: TripApiReturnType,
 ) {
-  const [numberOfTripPatterns, setNumberOfTripPatterns] = useState(0);
   const query = createTripQuery(
     tripQuery.searchTime.mode === 'now'
       ? tripQuery
@@ -57,16 +56,13 @@ export function useTripPatterns(
       swrFetcher,
       {
         fallbackData: fallback ? [fallback] : undefined,
+        persistSize: false,
+        revalidateFirstPage: false,
       },
     );
 
-  useEffect(() => {
-    if (data) {
-      setNumberOfTripPatterns(
-        data.reduce((acc, curr) => acc + curr.tripPatterns.length, 0),
-      );
-    }
-  }, [data]);
+  const numberOfTripPatterns =
+    data?.reduce((acc, curr) => acc + curr.tripPatterns.length, 0) ?? 0;
 
   useEffect(() => {
     if (isLoading || isValidating) {
@@ -81,7 +77,9 @@ export function useTripPatterns(
     setSize(size + 1);
   }, [numberOfTripPatterns, size, setSize, isLoading, isValidating]);
 
-  const isLoadingFirstTrip = !data && isLoading;
+  const isLoadingFirstTrip =
+    isLoading ||
+    (isValidating && !data?.some((page) => page.tripPatterns.length > 0));
   const isLoadingMore = isValidating && size > 1;
 
   return {

--- a/src/page-modules/assistant/trip/index.tsx
+++ b/src/page-modules/assistant/trip/index.tsx
@@ -19,7 +19,6 @@ import { capitalize } from 'lodash';
 import EmptySearchResults from '@atb/components/empty-message';
 import TripPattern from './trip-pattern';
 import EmptySearch from '@atb/components/loading-empty-results';
-import { LoadingIcon } from '@atb/components/loading';
 import ScreenReaderOnly from '@atb/components/screen-reader-only';
 import {
   GlobalMessageContextEnum,
@@ -143,14 +142,10 @@ export default function Trip({ tripQuery, fallback }: TripProps) {
         >
           {t(PageText.Assistant.trip.disabledFetchMore)}
         </Typo.p>
-      ) : isLoadingMore ? (
-        <div className={style.fetchButton}>
-          <LoadingIcon />
-        </div>
       ) : (
         <Button
           className={style.fetchButton}
-          onClick={() => loadMore()}
+          onClick={loadMore}
           mode="secondary"
           backgroundColor={color.background.accent['0']}
           radiusSize="circular"


### PR DESCRIPTION
Changed the `isLoadingFirstTrip` logic to check whether or not the data from the `useSWRInfinite` hook actually has some data or not.

Also set `persistSize` to `false`. We might not want to set this, but I found it to reduce load time of the page if you refresh, in case "Load more" has been pressed one too many times. Also, the page size is not persisted in e.g. the URL, so if someone is to share the URL they might think that the results that they see also is visible to the receiver when in fact it is not since the page size is lower. By not persisting the page size we might show a more realistic view for the sharer if they check the link before sending.

I also set `revalidateFirstPage: false`, since I did not see any benefit in revalidating the first results when loading more. I might have misunderstood how it works though.

