### PR TITLE
fix: don't revalidate trip pattern fetching

### DIFF
--- a/src/page-modules/assistant/client/journey-planner/index.ts
+++ b/src/page-modules/assistant/client/journey-planner/index.ts
@@ -58,6 +58,9 @@ export function useTripPatterns(
         fallbackData: fallback ? [fallback] : undefined,
         persistSize: false,
         revalidateFirstPage: false,
+        revalidateOnFocus: false,
+        revalidateIfStale: false,
+        revalidateOnReconnect: false,
       },
     );
 


### PR DESCRIPTION
```ts
        revalidateOnFocus: false,
        revalidateIfStale: false,
        revalidateOnReconnect: false,
```

Added these options to `useSWRInfinite` to _not_ automatically revalidate the data that has been fetched. Automatic revalidation might cause confusion for the user if it's not intended.