### PR TITLE
fix: use same search config values as the app

### DIFF
--- a/src/page-modules/assistant/client/journey-planner/index.ts
+++ b/src/page-modules/assistant/client/journey-planner/index.ts
@@ -8,12 +8,12 @@ import {
 import { swrFetcher } from '@atb/modules/api-browser';
 import useSWRInfinite from 'swr/infinite';
 import { createTripQuery, tripQueryToQueryString } from '../../utils';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { fromLocalTimeToCET } from '@atb/utils/date';
 import { LineData } from '../../server/journey-planner/validators';
 
-const MAX_NUMBER_OF_INITIAL_SEARCH_ATTEMPTS = 3;
-const INITIAL_NUMBER_OF_WANTED_TRIP_PATTERNS = 6;
+const MAX_NUMBER_OF_INITIAL_SEARCH_ATTEMPTS = 5;
+const INITIAL_NUMBER_OF_WANTED_TRIP_PATTERNS = 8;
 
 export type TripApiReturnType = TripsType['trip'];
 export type NonTransitTripApiReturnType = NonTransitTripData;


### PR DESCRIPTION
The app uses 5 for the amount of search attempts and 8 for the wanted number of trip patterns to show. It also uses 8 as the amount it wants when loading more, but that is not included as of yet in TPW.


## 📋 Acceptance criteria

- [ ] Trip search behaves more like the app