### PR TITLE
refactor: use immutable swr hook

### DIFF
--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, MouseEventHandler } from 'react';
+import React, { MouseEventHandler } from 'react';
 import {
   ButtonBase,
   ButtonBaseProps,

--- a/src/components/map/use-map-tariff-zones.ts
+++ b/src/components/map/use-map-tariff-zones.ts
@@ -4,8 +4,8 @@ import { AnyLayer } from 'mapbox-gl';
 import { getReferenceDataName } from '@atb/utils/reference-data';
 import { centroid } from '@turf/centroid';
 import { type TariffZone, getTariffZones } from '@atb/modules/firebase';
-import useSWR from 'swr';
 import { addLayerIfNotExists, addSourceIfNotExists } from '.';
+import useSWRImmutable from 'swr/immutable';
 
 const TARIFF_ZONE_SOURCE_ID = 'tariff-zones';
 const ZONE_BOUNDARY_LAYER_ID = 'zone-boundary-layer';
@@ -17,11 +17,7 @@ export const useMapTariffZones = async (
   const { language } = useTranslation();
   const [isZonesVisible, setIsZonesVisible] = useState(false);
   const [isStyleLoaded, setIsStyleLoaded] = useState(false);
-  const { data } = useSWR('tariffZones', getTariffZones, {
-    revalidateOnFocus: false,
-    revalidateOnReconnect: false,
-    revalidateIfStale: false,
-  });
+  const { data } = useSWRImmutable('tariffZones', getTariffZones);
 
   const addTariffZonesToMap = useCallback(
     (map: mapboxgl.Map) => {

--- a/src/modules/search-time/selector/__tests__/selector.test.tsx
+++ b/src/modules/search-time/selector/__tests__/selector.test.tsx
@@ -1,7 +1,6 @@
-import { cleanup, render, fireEvent } from '@testing-library/react';
+import { cleanup, render } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
-import { addDays, addHours, format, subDays } from 'date-fns';
 import SearchTimeSelector from '..';
 
 afterEach(function () {

--- a/src/modules/search-time/selector/time-selector-dropdown.tsx
+++ b/src/modules/search-time/selector/time-selector-dropdown.tsx
@@ -22,8 +22,6 @@ export default function TimeSelectorDropdown({
   selectedTime,
   onChange,
 }: TimeSelectorDropdownProps) {
-  const theme = useTheme();
-
   const time = parseTime(selectedTime);
 
   const selectTime = (timeType: 'hour' | 'minute', timeValue: number) => {

--- a/src/modules/transport-mode/utils.ts
+++ b/src/modules/transport-mode/utils.ts
@@ -7,7 +7,6 @@ import {
   TransportSubmodeType,
 } from './types';
 import { TransportMode as GraphQlTransportMode } from '@atb/modules/graphql-types';
-import { TransportSubmode } from '@atb/modules/graphql-types/journeyplanner-types_v3.generated.ts';
 
 export function transportModeToTranslatedString(mode: TransportModeGroup) {
   if (!mode.transportMode) return ComponentText.TransportMode.modes.unknown;

--- a/src/page-modules/assistant/client/journey-planner/index.ts
+++ b/src/page-modules/assistant/client/journey-planner/index.ts
@@ -1,4 +1,3 @@
-import useSWR from 'swr';
 import {
   NonTransitTripData,
   TripQuery,
@@ -11,6 +10,7 @@ import { createTripQuery, tripQueryToQueryString } from '../../utils';
 import { useEffect, useState } from 'react';
 import { fromLocalTimeToCET } from '@atb/utils/date';
 import { LineData } from '../../server/journey-planner/validators';
+import useSWRImmutable from 'swr/immutable';
 
 const MAX_NUMBER_OF_INITIAL_SEARCH_ATTEMPTS = 3;
 const INITIAL_NUMBER_OF_WANTED_TRIP_PATTERNS = 6;
@@ -99,11 +99,11 @@ export function useTripPatterns(
 export function useNonTransitTrip(tripQuery: FromToTripQuery) {
   const query = createTripQuery(tripQuery);
   const queryString = tripQueryToQueryString(query);
-  const { data, error, isLoading } = useSWR<NonTransitTripApiReturnType>(
-    `/api/assistant/non-transit-trip?${queryString}`,
-    swrFetcher,
-    {},
-  );
+  const { data, error, isLoading } =
+    useSWRImmutable<NonTransitTripApiReturnType>(
+      `/api/assistant/non-transit-trip?${queryString}`,
+      swrFetcher,
+    );
 
   return {
     nonTransitTrips: data,

--- a/src/page-modules/assistant/details-body/index.tsx
+++ b/src/page-modules/assistant/details-body/index.tsx
@@ -19,7 +19,6 @@ import {
 } from '@atb/page-modules/assistant';
 import { tripQueryStringToQueryParams } from '@atb/page-modules/assistant/details/utils.ts';
 import { useRouter } from 'next/router';
-import { motion } from 'framer-motion';
 
 type DetailsBodyProps = {
   tripPattern: ExtendedTripPatternWithDetailsType;

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -23,7 +23,6 @@ import { FromToTripQuery } from './types';
 import { createTripQuery, setTransportModeFilters } from './utils';
 import { TabLink } from '@atb/components/tab-link';
 import { logSpecificEvent } from '@atb/modules/firebase';
-import { getOrgData } from '@atb/modules/org-data';
 import { getTransportModeFilter } from '@atb/modules/firebase/transport-mode-filter';
 import useSWRImmutable from 'swr/immutable';
 import { debounce } from 'lodash';

--- a/src/page-modules/assistant/line-filter/index.tsx
+++ b/src/page-modules/assistant/line-filter/index.tsx
@@ -4,10 +4,11 @@ import { getOrgData } from '@atb/modules/org-data';
 import { PageText, useTranslation } from '@atb/translations';
 import { ChangeEvent, FocusEvent, useEffect, useState } from 'react';
 import style from './line-filter.module.css';
-import useSWR from 'swr';
 import { swrFetcher } from '@atb/modules/api-browser';
 import { LinesApiReturnType } from '../client';
 import { isDefined, isTruthy } from '@atb/utils/presence';
+import useSWRImmutable from 'swr/immutable';
+
 type LineFilterProps = {
   filterState: string[] | null;
   onChange: (lineFilter: string[] | null) => void;
@@ -18,7 +19,7 @@ export default function LineFilter({ filterState, onChange }: LineFilterProps) {
 
   const { authorityId } = getOrgData();
 
-  const { data } = useSWR<LinesApiReturnType>(
+  const { data } = useSWRImmutable<LinesApiReturnType>(
     `api/assistant/lines/${authorityId}`,
     swrFetcher,
   );

--- a/src/page-modules/assistant/non-transit-pill/index.tsx
+++ b/src/page-modules/assistant/non-transit-pill/index.tsx
@@ -6,7 +6,6 @@ import {
 } from '@atb/modules/transport-mode';
 import { PageText, TranslateFunction, useTranslation } from '@atb/translations';
 import { secondsToDurationShort } from '@atb/utils/date';
-import { Mode } from '@atb/modules/graphql-types/journeyplanner-types_v3.generated.ts';
 
 type NonTransitTripProps = {
   nonTransit: {

--- a/src/page-modules/assistant/types.ts
+++ b/src/page-modules/assistant/types.ts
@@ -2,7 +2,6 @@ import { GeocoderFeature } from '@atb/page-modules/departures';
 import { z } from 'zod';
 import { searchModeSchema, type SearchTime } from '@atb/modules/search-time';
 import type { TransportModeGroup } from '@atb/modules/transport-mode';
-import { TransportModeType } from '@atb-as/config-specs';
 import { NoticeFragment } from '@atb/page-modules/assistant/journey-gql/trip-with-details.generated.ts';
 import {
   LegWithDetailsFragment,

--- a/src/page-modules/assistant/utils.ts
+++ b/src/page-modules/assistant/utils.ts
@@ -1,4 +1,3 @@
-import type { SearchMode } from '@atb/modules/search-time';
 import { searchTimeToQueryString } from '@atb/modules/search-time';
 import { GeocoderFeature } from '@atb/page-modules/departures';
 import { FromToTripQuery, TripQuery, TripQuerySchema } from './types';

--- a/src/page-modules/departures/client/geocoder/index.ts
+++ b/src/page-modules/departures/client/geocoder/index.ts
@@ -1,7 +1,7 @@
 import { swrFetcher } from '@atb/modules/api-browser';
 import { GeocoderFeature } from '../../types';
-import useSWR from 'swr';
 import useDebounce from '@atb/utils/use-debounce';
+import useSWRImmutable from 'swr/immutable';
 
 export type AutocompleteApiReturnType = GeocoderFeature[];
 export type ReverseApiReturnType = GeocoderFeature | undefined;
@@ -21,15 +21,11 @@ export function useAutocomplete(
 
   const layerQuery = `&onlyStopPlaces=${onlyStopPlaces}`;
 
-  return useSWR<AutocompleteApiReturnType>(
+  return useSWRImmutable<AutocompleteApiReturnType>(
     debouncedQuery !== ''
       ? `/api/departures/autocomplete?q=${debouncedQuery}${focusQuery}${layerQuery}`
       : null,
     swrFetcher,
-    {
-      revalidateOnFocus: false,
-      revalidateOnReconnect: false,
-    },
   );
 }
 

--- a/src/page-modules/departures/details/estimated-call-rows.tsx
+++ b/src/page-modules/departures/details/estimated-call-rows.tsx
@@ -9,10 +9,8 @@ import { Button } from '@atb/components/button';
 import {
   type TransportModeType,
   useTransportationThemeColor,
-  type TransportSubmodeType,
 } from '@atb/modules/transport-mode';
 import {
-  Situation,
   SituationMessageBox,
   SituationOrNoticeIcon,
 } from '@atb/modules/situations';

--- a/src/page-modules/departures/details/index.tsx
+++ b/src/page-modules/departures/details/index.tsx
@@ -16,7 +16,6 @@ import {
   GlobalMessages,
 } from '@atb/modules/global-messages';
 import { ServiceJourneyType } from '@atb/page-modules/departures/types.ts';
-import { useEffect } from 'react';
 
 export type DeparturesDetailsProps = {
   fromQuayId?: string;

--- a/src/page-modules/departures/layout.tsx
+++ b/src/page-modules/departures/layout.tsx
@@ -48,8 +48,6 @@ function DeparturesLayout({ children, fromQuery }: DeparturesLayoutProps) {
   const onSelectFeature = (feature: GeocoderFeature) =>
     doSearch({ from: feature });
 
-  const { orgId } = getOrgData();
-
   return (
     <div>
       <form className={style.container} onSubmit={onSubmitHandler}>


### PR DESCRIPTION
And also clean up unused imports.

`useSWRImmutable` is the equivalent of using `useSWR` and passing the revalidate options with all of them set to `false`.


## 📋 Acceptance criteria

- [ ] No API calls are performed when refocusing (e.g. switching tabs) TPW