### PR TITLE
feat: load more until new results

### DIFF
--- a/src/page-modules/assistant/client/journey-planner/index.ts
+++ b/src/page-modules/assistant/client/journey-planner/index.ts
@@ -7,12 +7,13 @@ import {
 import { swrFetcher } from '@atb/modules/api-browser';
 import useSWRInfinite from 'swr/infinite';
 import { createTripQuery, tripQueryToQueryString } from '../../utils';
-import { useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { fromLocalTimeToCET } from '@atb/utils/date';
 import { LineData } from '../../server/journey-planner/validators';
 import useSWRImmutable from 'swr/immutable';
 
 const MAX_NUMBER_OF_INITIAL_SEARCH_ATTEMPTS = 5;
+const MAX_LOAD_MORE_ATTEMPTS = 3;
 const INITIAL_NUMBER_OF_WANTED_TRIP_PATTERNS = 8;
 
 export type TripApiReturnType = TripsType['trip'];
@@ -64,8 +65,7 @@ export function useTripPatterns(
       },
     );
 
-  const numberOfTripPatterns =
-    data?.reduce((acc, curr) => acc + curr.tripPatterns.length, 0) ?? 0;
+  const numberOfTripPatterns = getTripPatternCount(data);
 
   useEffect(() => {
     if (isLoading || isValidating) {
@@ -80,20 +80,31 @@ export function useTripPatterns(
     setSize(size + 1);
   }, [numberOfTripPatterns, size, setSize, isLoading, isValidating]);
 
+  const { loadMore, isLoadingMore } = useLoadMore(
+    numberOfTripPatterns,
+    size,
+    setSize,
+    isValidating,
+  );
+
   const isLoadingFirstTrip =
     isLoading ||
     (isValidating && !data?.some((page) => page.tripPatterns.length > 0));
-  const isLoadingMore = isValidating && size > 1;
 
   return {
     trips: data,
     isLoadingFirstTrip,
     isError: Boolean(error),
-    loadMore: () => setSize(size + 1),
+    loadMore,
     isLoadingMore,
     size,
     setSize,
   };
+  9;
+}
+
+function getTripPatternCount(data: TripApiReturnType[] | undefined) {
+  return data?.reduce((acc, curr) => acc + curr.tripPatterns.length, 0) ?? 0;
 }
 
 export function useNonTransitTrip(tripQuery: FromToTripQuery) {
@@ -109,5 +120,95 @@ export function useNonTransitTrip(tripQuery: FromToTripQuery) {
     nonTransitTrips: data,
     isLoading,
     isError: Boolean(error),
+  };
+}
+
+/**
+ * A hook that manages loading more trip patterns with automatic retry
+ * capabilities.
+ *
+ * This hook handles the logic for incrementally loading more trip patterns by
+ * increasing the 'size' parameter. It includes built-in retry logic that will
+ * automatically attempt to load more patterns up to a maximum number of times
+ * when no new patterns are found.
+ *
+ * @param numberOfTripPatterns - The current number of trip patterns loaded
+ * @param size - The current page size 
+ * @param setSize - Function to update the page size
+ * @param isValidating - Boolean indicating if data is currently being fetched
+ *
+ * @returns An object containing:
+ *   - loadMore: Function to trigger loading more trip patterns
+ *   - isLoadingMore: Boolean state indicating if more patterns are currently
+ *     being loaded
+ */
+function useLoadMore(
+  numberOfTripPatterns: number,
+  size: number,
+  setSize: (size: number) => void,
+  isValidating: boolean,
+) {
+  // Track previous values with refs to detect changes
+  const previousSize = useRef(size);
+  const previousNumberOfTripPatterns = useRef(numberOfTripPatterns);
+  const hasBeenClicked = useRef(false);
+  const loadMoreAttempts = useRef(0);
+
+  // State to track loading status (this is what gets returned to the component)
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+
+  useEffect(() => {
+    // If no load more has been clicked, just update references
+    if (!hasBeenClicked.current) {
+      previousNumberOfTripPatterns.current = numberOfTripPatterns;
+      previousSize.current = size;
+      return;
+    }
+
+    // Don't continue if data is still being fetched
+    if (isValidating) {
+      return;
+    }
+
+    // Case 1: New trip patterns found - success scenario
+    if (numberOfTripPatterns > previousNumberOfTripPatterns.current) {
+      // Update references and reset state
+      previousNumberOfTripPatterns.current = numberOfTripPatterns;
+      previousSize.current = size;
+      loadMoreAttempts.current = 0;
+      hasBeenClicked.current = false;
+      setIsLoadingMore(false);
+      return;
+    }
+
+    // Always update trip patterns reference
+    previousNumberOfTripPatterns.current = numberOfTripPatterns;
+
+    // Case 2: Size increased but no new patterns - potential retry scenario
+    if (size > previousSize.current) {
+      previousSize.current = size;
+
+      // If we haven't received new data but are under the attempt limit, try again
+      if (loadMoreAttempts.current < MAX_LOAD_MORE_ATTEMPTS) {
+        loadMoreAttempts.current++;
+        setSize(size + 1);
+      } else {
+        // We've reached the maximum attempts, stop loading more
+        setIsLoadingMore(false);
+      }
+      return;
+    }
+  }, [numberOfTripPatterns, size, setSize, isValidating, setIsLoadingMore]);
+
+  const loadMore = () => {
+    hasBeenClicked.current = true;
+    loadMoreAttempts.current = 0;
+    setIsLoadingMore(true);
+    setSize(size + 1);
+  };
+
+  return {
+    loadMore,
+    isLoadingMore,
   };
 }


### PR DESCRIPTION
Experimental implementation of a hook that allows us to keep loading more pages until we get a new trip pattern. Instead of clicking "Load more" and nothing happens, the goal is to keep loading until something is received.

## 📋 Acceptance criteria

- [ ] Loading more results does not stop until new results have been fetched, unless the max limit is met (set to 3)
- [ ] Loading more is not eternally loading