### PR TITLE
test: open accordion and then details

### DIFF
--- a/e2e-tests/k6/conf/env.ts
+++ b/e2e-tests/k6/conf/env.ts
@@ -9,7 +9,7 @@ export const env: EnvType = {
       host: 'https://atb-staging.planner-web.mittatb.no',
     },
     prod: {
-      host: 'https://atb.planner-web.mittatb.no',
+      host: 'https://reise.atb.no/',
     },
   },
 };

--- a/e2e-tests/k6/conf/env.ts
+++ b/e2e-tests/k6/conf/env.ts
@@ -9,7 +9,7 @@ export const env: EnvType = {
       host: 'https://atb-staging.planner-web.mittatb.no',
     },
     prod: {
-      host: 'https://reise.atb.no/',
+      host: 'https://reise.atb.no',
     },
   },
 };

--- a/e2e-tests/k6/measurements/measures.ts
+++ b/e2e-tests/k6/measurements/measures.ts
@@ -34,6 +34,16 @@ export class Measures {
           window.performance.mark('assistant-details-opened');
         });
         break;
+      case 'assistant-summary-open':
+        await this.page.evaluate(() => {
+          window.performance.mark('assistant-summary-open');
+        });
+        break;
+      case 'assistant-summary-opened':
+        await this.page.evaluate(() => {
+          window.performance.mark('assistant-summary-opened');
+        });
+        break;
       case 'departures-details-open':
         await this.page.evaluate(() => {
           window.performance.mark('departures-details-open');
@@ -81,6 +91,24 @@ export class Measures {
               JSON.stringify(
                 window.performance.getEntriesByName(
                   'measure-search-lastResult',
+                ),
+              ),
+            )[0].duration,
+        );
+      case 'measure-assistant-summary-open':
+        await this.page.evaluate(() =>
+          window.performance.measure(
+            'measure-assistant-summary-open',
+            'assistant-summary-open',
+            'assistant-summary-opened',
+          ),
+        );
+        return await this.page.evaluate(
+          () =>
+            JSON.parse(
+              JSON.stringify(
+                window.performance.getEntriesByName(
+                  'measure-assistant-summary-open',
                 ),
               ),
             )[0].duration,

--- a/e2e-tests/k6/measurements/metrics.ts
+++ b/e2e-tests/k6/measurements/metrics.ts
@@ -3,9 +3,11 @@ import { Trend } from 'k6/metrics';
 export class Metrics {
   private metric_assistant_firstResult: Trend;
   private metric_assistant_lastResult: Trend;
+  private metric_assistant_summary_open: Trend;
   private metric_assistant_details_open: Trend;
   private metric_assistant_region_firstResult: Trend;
   private metric_assistant_region_lastResult: Trend;
+  private metric_assistant_region_summary_open: Trend;
   private metric_assistant_region_details_open: Trend;
   private metric_departures_show: Trend;
   private metric_departures_details_open: Trend;
@@ -19,6 +21,10 @@ export class Metrics {
       'metric_assistant_lastResult',
       true,
     );
+    this.metric_assistant_summary_open = new Trend(
+      'metric_assistant_summary_open',
+      true,
+    );
     this.metric_assistant_details_open = new Trend(
       'metric_assistant_details_open',
       true,
@@ -29,6 +35,10 @@ export class Metrics {
     );
     this.metric_assistant_region_lastResult = new Trend(
       'metric_assistant_region_lastResult',
+      true,
+    );
+    this.metric_assistant_region_summary_open = new Trend(
+      'metric_assistant_region_summary_open',
       true,
     );
     this.metric_assistant_region_details_open = new Trend(
@@ -55,6 +65,14 @@ export class Metrics {
       this.metric_assistant_region_lastResult.add(value);
     } else {
       this.metric_assistant_lastResult.add(value);
+    }
+  }
+
+  metricAssistantSummaryOpen(value: number, region: boolean) {
+    if (region) {
+      this.metric_assistant_region_summary_open.add(value);
+    } else {
+      this.metric_assistant_summary_open.add(value);
     }
   }
 

--- a/e2e-tests/k6/pages/assistant.ts
+++ b/e2e-tests/k6/pages/assistant.ts
@@ -11,6 +11,7 @@ export class Assistant {
   private searchForTravelsButton: Locator;
   private swapButton: Locator;
   private tripDetails: Locator;
+  private moreDetails: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -22,6 +23,7 @@ export class Assistant {
     this.searchForTravelsButton = page.locator('[data-testid="findTravelsButton"]');
     this.swapButton = page.locator('[data-testid="swapButton"]');
     this.tripDetails = page.locator('[data-testid="tripDetails"]');
+    this.moreDetails = page.locator('[data-testid="moreDetailsButton"]');
   }
 
   async searchFrom(location: string) {
@@ -57,6 +59,10 @@ export class Assistant {
 
   getTripDetails(){
     return this.tripDetails;
+  }
+
+  getMoreDetails(){
+    return this.moreDetails;
   }
 
   // Fallback. Sometimes the search isn't started after to-location is entered.

--- a/e2e-tests/k6/scenario/assistant.ts
+++ b/e2e-tests/k6/scenario/assistant.ts
@@ -46,8 +46,21 @@ export async function assistant(
       'measure-search-lastResult',
     );
 
-    // Open trip details
+    // Open trip summary
     await trip.click();
+    await measures.mark('assistant-summary-open');
+    const tripSummary = assistant.getTripDetails();
+    await tripSummary.waitFor({
+      state: 'visible',
+    });
+    await measures.mark('assistant-summary-opened');
+    const openSummaryDetails = await measures.measure(
+      'measure-assistant-summary-open',
+    );
+
+    // Open trip details
+    const moreDetails = assistant.getMoreDetails();
+    await moreDetails.click()
     await measures.mark('assistant-details-open');
     const tripDetails = assistant.getTripDetails();
     await tripDetails.waitFor({
@@ -60,6 +73,7 @@ export async function assistant(
 
     metrics.metricAssistantFirstResult(searchToFirstResult, region);
     metrics.metricAssistantLastResult(searchToLastResult, region);
+    metrics.metricAssistantSummaryOpen(openSummaryDetails, region);
     metrics.metricAssistantDetailsOpen(openTripDetails, region);
 
     await screenshot(page, 'assistant');

--- a/src/page-modules/assistant/trip/trip-pattern/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/index.tsx
@@ -275,6 +275,7 @@ export default function TripPattern({
                 radiusSize="circular"
                 className={style.goToDetailsButton}
                 icon={{ right: <MonoIcon icon="navigation/ArrowRight" /> }}
+                testID="moreDetailsButton"
               />
             </div>
           </motion.div>


### PR DESCRIPTION
Update the k6-test with handling of accordion. Now, the tests open the details summary before opening the details through the _More details_ button.

NOTE! Added a test-id for the _More details_ button.