### PR TITLE
fix: update limit early booking condition

### DIFF
--- a/src/page-modules/assistant/details/trip-section/index.tsx
+++ b/src/page-modules/assistant/details/trip-section/index.tsx
@@ -70,7 +70,7 @@ export default function TripSection({
   );
 
   const flexBookingNumberOfDaysAvailable =
-    leg.authority?.id === 'ATB:Authority:2' ? 7 : undefined;
+    leg.line?.publicCode === 'AtB Bestill' ? 7 : undefined;
 
   const bookingStatus = getBookingStatus(
     leg.bookingArrangements,

--- a/src/page-modules/assistant/journey-gql/trip-with-details.gql
+++ b/src/page-modules/assistant/journey-gql/trip-with-details.gql
@@ -162,10 +162,6 @@ fragment legWithDetails on Leg {
       furtherDetails
     }
   }
-  authority {
-    id
-    name
-  }
 }
 
 fragment notice on Notice {


### PR DESCRIPTION
Related to: https://github.com/AtB-AS/planner-web/pull/588

After talking with Nordland and Troms, I suggest changing the condition `flexBookingNumberOfDaysAvailable` from ` leg.authority?.id === 'ATB:Authority:2' ? 7 : undefined` to `leg.line?.publicCode === 'AtB Bestill' ? 7 : undefined`, as both AtB always want to use AtB Bestill, and Nordland sometimes want to use AtB Bestill.   

Criteria:
- **ATB:** Uses only AtB Bestill. Should continue using existing rules with 7-days early booking limit. 
- **Nordland:** Uses both AtB Bestill and other types of order transport. Should continue using existing rules with 7-days early booking limit for AtB Bestill, and not use any limit for other order transport.
- **FRAM:** Does not use AtB Bestill. Does not want the 7-days limit.  
- **TROMS:** Does not use AtB Bestill. Does not want the 7-days limit.