### PR TITLE
fix: parse onlyStopPlaces as boolean instead of string

### DIFF
--- a/src/pages/api/departures/autocomplete.ts
+++ b/src/pages/api/departures/autocomplete.ts
@@ -16,6 +16,7 @@ export default handlerWithBffClient<AutocompleteApiReturnType>(
       const onlyStopPlaces = z
         .string()
         .optional()
+        .transform((val) => val === 'true')
         .safeParse(req.query.onlyStopPlaces);
 
       if (


### PR DESCRIPTION
This fixes a bug where autocomplete never returned addresses, just venues. This was because `onlyStopPlaces.data` never was falsy, since it was parsed to the strings `"true"` or `"false"`.

fixes https://github.com/AtB-AS/kundevendt/issues/21163