### PR TITLE
chore: deny missing consents in analytics.ts

### DIFF
--- a/src/modules/firebase/analytics.ts
+++ b/src/modules/firebase/analytics.ts
@@ -14,6 +14,8 @@ export async function init() {
   // Default all consents to denied.
   setConsent({
     ad_storage: 'denied',
+    ad_personalization: 'denied',
+    ad_user_data: 'denied',
     functionality_storage: 'denied',
     security_storage: 'denied',
     personalization_storage: 'denied',


### PR DESCRIPTION
There was a couple of consents missing 'denied' in analytics.ts