### PR TITLE
feat: extend fieldset component title with optional requierd indicator

### DIFF
--- a/src/page-modules/contact/components/form/fieldset/fieldset.module.css
+++ b/src/page-modules/contact/components/form/fieldset/fieldset.module.css
@@ -18,3 +18,9 @@
   position: absolute;
   top: token('spacing.medium');
 }
+
+.required::after {
+  content: '*';
+  color: token('color.status.error.primary.background');
+  margin-left: token('spacing.small');
+}

--- a/src/page-modules/contact/components/form/fieldset/index.tsx
+++ b/src/page-modules/contact/components/form/fieldset/index.tsx
@@ -1,17 +1,32 @@
 import style from './fieldset.module.css';
 import { PropsWithChildren } from 'react';
 import { Typo } from '@atb/components/typography';
+import { andIf } from '@atb/utils/css';
 
 export type FieldsetProps = PropsWithChildren<{
-  title: string;
+  title?: string;
+  isRequired?: boolean;
 }>;
 
-export const Fieldset = ({ title, children }: FieldsetProps) => {
+export const Fieldset = ({
+  title,
+  isRequired = false,
+  children,
+}: FieldsetProps) => {
   return (
     <fieldset className={style.fieldset}>
-      <legend className={style.legend}>
-        <Typo.h3 textType="heading__component">{title}</Typo.h3>
-      </legend>
+      {title && (
+        <legend className={style.legend}>
+          <Typo.h3
+            textType="heading__component"
+            className={andIf({
+              [style.required]: isRequired,
+            })}
+          >
+            {title}
+          </Typo.h3>
+        </legend>
+      )}
       {children}
     </fieldset>
   );

--- a/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/delayForm.tsx
@@ -166,7 +166,7 @@ export const DelayForm = ({ state, send }: DelayFormProps) => {
         />
       </Fieldset>
 
-      <Fieldset title={t(PageText.Contact.input.feedback.title)}>
+      <Fieldset title={t(PageText.Contact.input.feedback.title)} isRequired>
         <Textarea
           id="feedback"
           description={t(PageText.Contact.input.feedback.description)}

--- a/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/driverForm.tsx
@@ -166,7 +166,7 @@ export const DriverForm = ({ state, send }: DriverFormProps) => {
         />
       </Fieldset>
 
-      <Fieldset title={t(PageText.Contact.input.feedback.title)}>
+      <Fieldset title={t(PageText.Contact.input.feedback.title)} isRequired>
         <Textarea
           id="feedback"
           description={t(PageText.Contact.input.feedback.description)}

--- a/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/injuryForm.tsx
@@ -165,7 +165,7 @@ export const InjuryForm = ({ state, send }: InjuryFormProps) => {
         />
       </Fieldset>
 
-      <Fieldset title={t(PageText.Contact.input.feedback.title)}>
+      <Fieldset title={t(PageText.Contact.input.feedback.title)} isRequired>
         <Textarea
           id="feedback"
           description={t(PageText.Contact.input.feedback.description)}

--- a/src/page-modules/contact/means-of-transport/forms/serviceOfferingForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/serviceOfferingForm.tsx
@@ -96,7 +96,7 @@ export const ServiceOfferingForm = ({
         />
       </Fieldset>
 
-      <Fieldset title={t(PageText.Contact.input.feedback.title)}>
+      <Fieldset title={t(PageText.Contact.input.feedback.title)} isRequired>
         <Textarea
           id="feedback"
           description={t(PageText.Contact.input.feedback.description)}

--- a/src/page-modules/contact/means-of-transport/forms/stopForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/stopForm.tsx
@@ -125,7 +125,7 @@ export const StopForm = ({ state, send }: StopFormProps) => {
         />
       </Fieldset>
 
-      <Fieldset title={t(PageText.Contact.input.feedback.title)}>
+      <Fieldset title={t(PageText.Contact.input.feedback.title)} isRequired>
         <Textarea
           id="feedback"
           description={t(PageText.Contact.input.feedback.description)}

--- a/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
+++ b/src/page-modules/contact/means-of-transport/forms/transportationForm.tsx
@@ -174,7 +174,7 @@ export const TransportationForm = ({
         />
       </Fieldset>
 
-      <Fieldset title={t(PageText.Contact.input.feedback.title)}>
+      <Fieldset title={t(PageText.Contact.input.feedback.title)} isRequired>
         <Textarea
           description={t(PageText.Contact.input.feedback.description)}
           id="feedback"

--- a/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundCarForm.tsx
+++ b/src/page-modules/contact/refund/forms/refund-and-travel-guarantee/refundCarForm.tsx
@@ -255,10 +255,6 @@ export const RefundCarForm = ({ state, send }: RefundCarFormProps) => {
               value: e.target.value,
             })
           }
-          error={
-            state.context.errorMessages['feedback']?.[0] &&
-            t(state.context.errorMessages['feedback']?.[0])
-          }
           fileInputProps={{
             id: 'attachments',
             name: 'attachments',

--- a/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feeComplaintForm.tsx
@@ -226,7 +226,7 @@ const FormContent = ({ state, send }: FormProps) => {
           />
         )}
       </Fieldset>
-      <Fieldset title={t(PageText.Contact.input.feedback.title)}>
+      <Fieldset title={t(PageText.Contact.input.feedback.title)} isRequired>
         <Textarea
           id="feedback"
           value={state.context.feedback || ''}

--- a/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
@@ -149,7 +149,7 @@ export const FeedbackForm = ({ state, send }: FeedbackFormProps) => {
           }
         />
       </Fieldset>
-      <Fieldset title={t(PageText.Contact.input.feedback.title)}>
+      <Fieldset title={t(PageText.Contact.input.feedback.title)} isRequired>
         <Textarea
           id="feedback"
           value={state.context.feedback || ''}

--- a/src/page-modules/contact/ticketing/forms/app/appAccountForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/app/appAccountForm.tsx
@@ -13,7 +13,7 @@ export const AppAccountForm = ({ state, send }: AppAccountFormProps) => {
 
   return (
     <>
-      <Fieldset title={t(PageText.Contact.input.question.title)}>
+      <Fieldset title={t(PageText.Contact.input.question.title)} isRequired>
         <Textarea
           id="question"
           description={t(PageText.Contact.input.question.info)}

--- a/src/page-modules/contact/ticketing/forms/app/appTicketingForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/app/appTicketingForm.tsx
@@ -39,7 +39,7 @@ export const AppTicketingForm = ({ state, send }: AppTicketingFormProps) => {
           }}
         />
       </Fieldset>
-      <Fieldset title={t(PageText.Contact.input.question.title)}>
+      <Fieldset title={t(PageText.Contact.input.question.title)} isRequired>
         <Textarea
           id="question"
           description={t(PageText.Contact.input.question.info)}

--- a/src/page-modules/contact/ticketing/forms/app/appTravelSuggestionForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/app/appTravelSuggestionForm.tsx
@@ -16,7 +16,7 @@ export const AppTravelSuggestionForm = ({
 
   return (
     <>
-      <Fieldset title={t(PageText.Contact.input.question.title)}>
+      <Fieldset title={t(PageText.Contact.input.question.title)} isRequired>
         <Textarea
           id="question"
           description={t(PageText.Contact.input.question.info)}

--- a/src/page-modules/contact/ticketing/forms/priceAndTicketTypesForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/priceAndTicketTypesForm.tsx
@@ -16,7 +16,7 @@ export const PriceAndTicketTypesForm = ({
 
   return (
     <>
-      <Fieldset title={t(PageText.Contact.input.question.title)}>
+      <Fieldset title={t(PageText.Contact.input.question.title)} isRequired>
         <Textarea
           id="question"
           description={t(PageText.Contact.input.question.info)}

--- a/src/page-modules/contact/ticketing/forms/travel-card/travelCardQuestionForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/travel-card/travelCardQuestionForm.tsx
@@ -45,7 +45,7 @@ export const TravelCardQuestionForm = ({
           }
         />
       </Fieldset>
-      <Fieldset title={t(PageText.Contact.input.question.title)}>
+      <Fieldset title={t(PageText.Contact.input.question.title)} isRequired>
         <Textarea
           id="question"
           description={t(PageText.Contact.input.question.info)}

--- a/src/page-modules/contact/ticketing/forms/webshop/webshopAccountForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/webshop/webshopAccountForm.tsx
@@ -16,7 +16,7 @@ export const WebshopAccountForm = ({
 
   return (
     <>
-      <Fieldset title={t(PageText.Contact.input.question.title)}>
+      <Fieldset title={t(PageText.Contact.input.question.title)} isRequired>
         <Textarea
           id="question"
           description={t(PageText.Contact.input.question.info)}

--- a/src/page-modules/contact/ticketing/forms/webshop/webshopTicketingForm.tsx
+++ b/src/page-modules/contact/ticketing/forms/webshop/webshopTicketingForm.tsx
@@ -44,7 +44,7 @@ export const WebshopTicketingForm = ({
         />
       </Fieldset>
 
-      <Fieldset title={t(PageText.Contact.input.question.title)}>
+      <Fieldset title={t(PageText.Contact.input.question.title)} isRequired>
         <Textarea
           id="question"
           description={t(PageText.Contact.input.question.info)}


### PR DESCRIPTION
This PR extends the `Fieldset` component used in the contact form to optionally display a "required" indicator after the fieldset title. All fieldsets in the contact form that contain only mandatory textareas are updated to show this indicator. Lastly, an unused `error` parameter is removed.
   
 ### Before
<img width="975" height="266" alt="Skjermbilde 2025-07-29 kl  11 15 41" src="https://github.com/user-attachments/assets/7ab2503a-6bf1-404c-9b3e-3991a9ebe4e5" />

 
 ### After
<img width="957" height="295" alt="Skjermbilde 2025-07-29 kl  11 14 59" src="https://github.com/user-attachments/assets/ebf6ea02-d817-4013-8aa2-1a1fd1d82859" />
