### PR TITLE
feat: feedback ticket control - remove ferry from transportation options

### DIFF
--- a/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
+++ b/src/page-modules/contact/ticket-control/forms/feedbackForm.tsx
@@ -57,7 +57,7 @@ export const FeedbackForm = ({ state, send }: FeedbackFormProps) => {
               ],
             )
           }
-          options={['bus', 'expressboat', 'ferry']}
+          options={['bus', 'expressboat']}
           placeholder={t(PageText.Contact.input.transportMode.optionLabel)}
         />
 


### PR DESCRIPTION
In this PR, ferry is removed from options, as there currently are none ticket controls on ferries.