### PR TITLE
fix: remove unexpected input property

### DIFF
--- a/src/page-modules/contact/means-of-transport/means-of-transport-form-machine.ts
+++ b/src/page-modules/contact/means-of-transport/means-of-transport-form-machine.ts
@@ -80,7 +80,6 @@ const setInputsToValidate = (context: MeansOfTransportContextProps) => {
         line,
         fromStop,
         toStop,
-        stop,
         date,
         plannedDepartureTime,
         feedback,


### PR DESCRIPTION
Remove unexpected input property, causing an unexpected  validation error on submit.  