### PR TITLE
fix: Decreased the threshold for significant difference

### DIFF
--- a/src/components/departure-time/__tests__/departure-time.test.tsx
+++ b/src/components/departure-time/__tests__/departure-time.test.tsx
@@ -26,7 +26,7 @@ describe('departure time component', function () {
     const output = render(
       <DepartureTime
         aimedDepartureTime="2021-09-01T12:00:00+02:00"
-        expectedDepartureTime="2021-09-01T12:00:30+02:00"
+        expectedDepartureTime="2021-09-01T12:00:14+02:00"
         realtime
       />,
     );

--- a/src/modules/time-representation/index.ts
+++ b/src/modules/time-representation/index.ts
@@ -1,6 +1,6 @@
 import { secondsBetween } from '@atb/utils/date';
 
-const DEFAULT_THRESHOLD_AIMED_EXPECTED_IN_SECONDS = 60;
+const DEFAULT_THRESHOLD_AIMED_EXPECTED_IN_SECONDS = 15;
 
 type TimeValues = {
   aimedTime: string;


### PR DESCRIPTION
Fixes https://github.com/AtB-AS/kundevendt/issues/20475

Changed such that a departure now only hides the strikethrough if it differs by less than 15 seconds. This means we basicly always have strikethroughs when we have realtime, but we don't get this error: 
<img width="406" height="85" alt="Skjermbilde 2025-07-30 kl  15 33 29" src="https://github.com/user-attachments/assets/7ffce02d-e8df-460d-8c70-9f99fd3af550" />
