### PR TITLE
chore: minor translation update

### DIFF
--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -1010,9 +1010,9 @@ const ContactInternal = {
     fromStop: {
       label: _('Fra holdeplass/kai', 'From stop/harbor', 'Frå haldeplass/kai'),
       optionalLabel: _(
-        'Velg holdeplass/kai (valgfritt)',
-        'Select stop/harbor (optinal)',
-        'Vel haldeplass/kai (valfritt)',
+        'Fra holdeplass/kai (valgfritt)',
+        'From stop/harbor (optinal)',
+        'Frå haldeplass/kai (valfritt)',
       ),
       optionLabel: _(
         'Velg holdeplass/kai',
@@ -1031,9 +1031,9 @@ const ContactInternal = {
     toStop: {
       label: _('Til holdeplass/kai', 'To stop/harbor', 'Til haldeplass/kai'),
       optionalLabel: _(
-        'Velg holdeplass/kai (valgfritt)',
-        'Select stop/harbor (optinal)',
-        'Vel haldeplass/kai (valfritt)',
+        'Til holdeplass/kai (valgfritt)',
+        'To stop/harbor (optinal)',
+        'Til haldeplass/kai (valfritt)',
       ),
       optionLabel: _(
         'Velg holdeplass/kai',


### PR DESCRIPTION
Update translation to be more descriptive for the user.


### Before
<img width="1035" height="579" alt="Skjermbilde 2025-07-31 kl  09 58 16" src="https://github.com/user-attachments/assets/9e04ef45-0527-44c9-9da6-ec63389d8445" />

### After
<img width="995" height="385" alt="Skjermbilde 2025-07-31 kl  10 53 45" src="https://github.com/user-attachments/assets/958e9262-3145-4ea5-8ef6-ed9c240c43a0" />
