### PR TITLE
fix: Double load problem when navigating from widget

### DIFF
--- a/src/page-modules/assistant/__tests__/assistant.test.tsx
+++ b/src/page-modules/assistant/__tests__/assistant.test.tsx
@@ -97,6 +97,7 @@ describe('assistant page', function () {
         toLayer: 'venue',
         searchMode: 'departBy',
         searchTime: 123,
+        filter: 'bus,metro',
       },
     };
 
@@ -114,7 +115,7 @@ describe('assistant page', function () {
           mode: 'departBy',
           dateTime: 123,
         },
-        transportModeFilter: null,
+        transportModeFilter: ['bus', 'metro'],
         cursor: null,
         lineFilter: null,
       },
@@ -296,7 +297,7 @@ describe('assistant page', function () {
         mode: 'departBy',
         dateTime: 123,
       },
-      transportModeFilter: null,
+      transportModeFilter: ['bus', 'metro'],
       cursor: null,
       lineFilter: null,
       via: null,
@@ -345,6 +346,7 @@ describe('assistant page', function () {
         toLayer: 'venue',
         searchMode: 'departBy',
         searchTime: 123,
+        filter: 'bus,metro',
       },
     };
 

--- a/src/page-modules/assistant/client/journey-planner/index.ts
+++ b/src/page-modules/assistant/client/journey-planner/index.ts
@@ -100,7 +100,6 @@ export function useTripPatterns(
     size,
     setSize,
   };
-  9;
 }
 
 function getTripPatternCount(data: TripApiReturnType[] | undefined) {
@@ -133,7 +132,7 @@ export function useNonTransitTrip(tripQuery: FromToTripQuery) {
  * when no new patterns are found.
  *
  * @param numberOfTripPatterns - The current number of trip patterns loaded
- * @param size - The current page size 
+ * @param size - The current page size
  * @param setSize - Function to update the page size
  * @param isValidating - Boolean indicating if data is currently being fetched
  *

--- a/src/page-modules/assistant/layout.tsx
+++ b/src/page-modules/assistant/layout.tsx
@@ -12,15 +12,10 @@ import { PageText, useTranslation } from '@atb/translations';
 import { FocusScope } from '@react-aria/focus';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useRouter } from 'next/router';
-import {
-  FormEventHandler,
-  PropsWithChildren,
-  useEffect,
-  useState,
-} from 'react';
+import { FormEventHandler, PropsWithChildren, useState } from 'react';
 import style from './assistant.module.css';
 import { FromToTripQuery } from './types';
-import { createTripQuery, setTransportModeFilters } from './utils';
+import { createTripQuery } from './utils';
 import { TabLink } from '@atb/components/tab-link';
 import { logSpecificEvent } from '@atb/modules/firebase';
 import { getTransportModeFilter } from '@atb/modules/firebase/transport-mode-filter';
@@ -118,19 +113,6 @@ function AssistantLayout({ children, tripQuery }: AssistantLayoutProps) {
       setValuesWithLoading({ lineFilter }, true),
     750,
   );
-
-  const isTripQueryTransportModeFilterNull =
-    tripQuery.transportModeFilter === null;
-
-  useEffect(() => {
-    if (isTripQueryTransportModeFilterNull) {
-      onTransportFilterChanged(setTransportModeFilters(transportModeFilter));
-    }
-  }, [
-    onTransportFilterChanged,
-    transportModeFilter,
-    isTripQueryTransportModeFilterNull,
-  ]);
 
   return (
     <div>

--- a/src/page-modules/assistant/trip/index.tsx
+++ b/src/page-modules/assistant/trip/index.tsx
@@ -44,6 +44,7 @@ export default function Trip({ tripQuery, fallback }: TripProps) {
   if (isLoadingFirstTrip) {
     return <EmptySearch isSearching={isLoadingFirstTrip} type="trip" />;
   }
+
   if (
     (!trips ||
       trips?.length === 0 ||

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -18,7 +18,7 @@ vi.stubEnv('NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN', 'aaaaaaaaaaaaaaaaaaaaaaa');
 vi.stubEnv('NEXT_PUBLIC_FIREBASE_PROJECT_ID', 'aaaaaaaaaaaaaaaaaaaaaaa');
 vi.stubEnv('NEXT_PUBLIC_FIREBASE_APP_ID', 'aaaaaaaaaaaaaaaaaaaaaaa');
 
-vi.stubEnv('NEXT_PUBLIC_BFF_URL', 'https://test.api.mittatb.no/bff');
+vi.stubEnv('NEXT_PUBLIC_BFF_URL', 'https://test.api.mittatb.no');
 
 vi.mock('mapbox-gl/dist/mapbox-gl.js', () => {
   return {


### PR DESCRIPTION
When navigating from the widget you would always get a double load, i.e. the results appeared pretty quickly, disappeared for a new load and then reappeared. This happened because of the removed `useEffect` in [/page-modules/assistant/layout.tsx](https://github.com/AtB-AS/planner-web/compare/strandlie/fix-double-search-bug?expand=1#diff-2272ca10f53868366f6e029fd3c7f06dccd13c9a6871b567534c7e0085104976) which added the filters to the URL, which then triggered a hard navigation and a reload. 

I solved this by better utilizing the server part of Next. Now when the URL does not have filters, just send a redirect to the correct URL with the correct filters for the county. 

[Link to video before](https://github.com/user-attachments/assets/c4446bcd-1cee-48dc-adab-10f1b3b1110b). Now the double load is gone. 

## Acceptance criteria
- [ ] No double load when navigating from https://atb-staging.planner-web.mittatb.no/widget and into the travel planner
- [ ] Toggling of filters still works
- [ ] The default filters are applied correctly for all counties


