### PR TITLE
fix(trip-pattern-header): duplicate cancelled/situation icon

### DIFF
--- a/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/index.tsx
+++ b/src/page-modules/assistant/trip/trip-pattern/trip-pattern-header/index.tsx
@@ -33,19 +33,20 @@ export function TripPatternHeader({
 
   return (
     <header className={style.header}>
-      {isCancelled && (
+      {isCancelled ? (
         <ColorIcon
           icon="status/Error"
           className={style.situationIcon}
           alt={t(PageText.Assistant.trip.tripPattern.isCancelled.label)}
         />
+      ) : (
+        <SituationOrNoticeIcon
+          situations={flatMap(tripPattern.legs, (leg) => leg.situations)}
+          notices={tripPattern.legs.flatMap(getNoticesForLeg)}
+          cancellation={isCancelled}
+          iconSize="large"
+        />
       )}
-      <SituationOrNoticeIcon
-        situations={flatMap(tripPattern.legs, (leg) => leg.situations)}
-        notices={tripPattern.legs.flatMap(getNoticesForLeg)}
-        cancellation={isCancelled}
-        iconSize="large"
-      />
       <RailReplacementBusMessage tripPattern={tripPattern} />
       <Typo.span textType="body__secondary--bold">
         {startModeAndPlaceText}


### PR DESCRIPTION
If a trip has both a cancellation and a situation/notice, there will be two icons. Changed to only show situation/notice icon if not also a cancellation (which already shows a red alert icon).

### Before
<img width="2956" height="1870" alt="image" src="https://github.com/user-attachments/assets/a3a6a987-71ba-4d6e-bbb2-9278a549bb1c" />


### After
<img width="2956" height="1870" alt="image" src="https://github.com/user-attachments/assets/32598c7b-4db6-45c6-a3cd-e83c90fd0295" />
