### PR TITLE
feat: extend textarea component with required indicator.

### DIFF
--- a/src/page-modules/contact/components/form/form.module.css
+++ b/src/page-modules/contact/components/form/form.module.css
@@ -577,3 +577,9 @@
   input[type='time']::-webkit-calendar-picker-indicator {
   filter: invert(1);
 }
+
+.required::after {
+  content: '*';
+  color: token('color.status.error.primary.background');
+  margin-left: token('spacing.small');
+}

--- a/src/page-modules/contact/components/form/textarea.tsx
+++ b/src/page-modules/contact/components/form/textarea.tsx
@@ -2,11 +2,13 @@ import { ErrorMessage } from '@atb/components/error-message';
 import style from './form.module.css';
 import FileInput, { FileInputProps } from './file-input';
 import { Typo } from '@atb/components/typography';
+import { andIf } from '@atb/utils/css';
 
 export type CheckboxProps = {
   description?: string;
   value: string;
   error?: string;
+  isRequired?: boolean;
   fileInputProps?: FileInputProps;
   onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
 } & JSX.IntrinsicElements['textarea'];
@@ -16,12 +18,22 @@ export default function Textarea({
   description,
   onChange,
   error,
+  isRequired = false,
   value,
   fileInputProps,
 }: CheckboxProps) {
   return (
     <div className={style.textarea_container}>
-      {description && <Typo.p textType="body__primary">{description}</Typo.p>}
+      {description && (
+        <Typo.p
+          textType="body__primary"
+          className={andIf({
+            [style.required]: isRequired,
+          })}
+        >
+          {description}
+        </Typo.p>
+      )}
       <textarea
         id={`textarea__${id}`}
         className={style.textarea}

--- a/src/page-modules/contact/refund/forms/refund-ticket/appTicketRefund.tsx
+++ b/src/page-modules/contact/refund/forms/refund-ticket/appTicketRefund.tsx
@@ -92,6 +92,7 @@ export const AppTicketRefund = ({ state, send }: AppTicketRefundProps) => {
         id="refundReason"
         description={t(PageText.Contact.input.refundReason.question)}
         value={state.context.refundReason || ''}
+        isRequired
         onChange={(e) =>
           send({
             type: 'ON_INPUT_CHANGE',

--- a/src/page-modules/contact/refund/forms/refund-ticket/otherTicketRefund.tsx
+++ b/src/page-modules/contact/refund/forms/refund-ticket/otherTicketRefund.tsx
@@ -150,6 +150,7 @@ const RefundSection = ({ state, send }: RefundSectionProps) => {
         id="refundReason"
         description={t(PageText.Contact.input.refundReason.question)}
         value={state.context.refundReason || ''}
+        isRequired
         onChange={(e) =>
           send({
             type: 'ON_INPUT_CHANGE',


### PR DESCRIPTION
Extend textarea component with optional required indicator.


### Before 
<img width="957" height="208" alt="Skjermbilde 2025-08-05 kl  14 05 32" src="https://github.com/user-attachments/assets/87cab224-61d8-41c8-8bf2-fe3a8be6216b" />


### After 
<img width="953" height="204" alt="Skjermbilde 2025-08-05 kl  14 04 55" src="https://github.com/user-attachments/assets/0070bed0-fffb-416d-beaf-da19f57df56c" />

