### PR TITLE
feat: adds custom title to all contact pages

### DIFF
--- a/src/layouts/base/index.tsx
+++ b/src/layouts/base/index.tsx
@@ -15,7 +15,7 @@ import style from './base.module.css';
 import { I18nProvider } from 'react-aria-components';
 
 export type BaseLayoutProps = PropsWithChildren<{
-  title?: TranslatedString | string;
+  title?: TranslatedString | TranslatedString[] | string;
 }>;
 
 export function BaseLayout({ children, title }: BaseLayoutProps) {

--- a/src/layouts/shared/utils.ts
+++ b/src/layouts/shared/utils.ts
@@ -1,16 +1,27 @@
-import {CommonText, TranslatedString, useTranslation} from '@atb/translations';
-import {isTranslatedString} from '@atb/translations/commons';
+import {
+  CommonText,
+  TranslatedString,
+  useTranslation,
+} from '@atb/translations';
+import { isTranslatedString } from '@atb/translations/commons';
 
-export function usePageTitle(title: TranslatedString | string | undefined) {
-  const {t} = useTranslation();
+export function usePageTitle(
+  title: TranslatedString | TranslatedString[] | string | undefined,
+) {
+  const { t } = useTranslation();
   const siteTitle = t(CommonText.Titles.siteTitle);
   if (!title) {
     return siteTitle;
   }
 
-  if (isTranslatedString(title)) {
-    return `${t(title)} - ${siteTitle}`;
+  let path: string[] = [];
+  if (Array.isArray(title)) {
+    path = title.map(t);
+  } else if (isTranslatedString(title)) {
+    path = [t(title)];
+  } else if (typeof title === 'string') {
+    path = [title];
   }
 
-  return `${title} - ${siteTitle}`;
+  return [...path, siteTitle].join(' - ');
 }

--- a/src/page-modules/contact/utils.ts
+++ b/src/page-modules/contact/utils.ts
@@ -2,6 +2,15 @@ import { TransportModeType } from './types';
 import { Line } from '.';
 import { FormEvent } from 'react';
 import { InputErrorMessages } from './validation';
+import { PageText, TranslatedString } from '@atb/translations';
+
+export const getContactPageTitle = (
+  subtitle?: TranslatedString,
+): TranslatedString[] => {
+  return subtitle
+    ? [subtitle, PageText.Contact.pageTitle]
+    : [PageText.Contact.pageTitle];
+};
 
 export const shouldShowContactPage = (): boolean => {
   return process.env.NEXT_PUBLIC_CONTACT_API_URL ? true : false;

--- a/src/pages/contact/error.tsx
+++ b/src/pages/contact/error.tsx
@@ -4,12 +4,13 @@ import { ErrorContent } from '@atb/page-modules/contact/error-content/error-cont
 import { NextPage } from 'next';
 import { withAccessLogging } from '@atb/modules/logging';
 import { withGlobalData, type WithGlobalData } from '@atb/modules/global-data';
+import { getContactPageTitle } from '@atb/page-modules/contact/utils';
 
 export type ContactErrorPageProps = WithGlobalData<{}>;
 
 const ContactErrorPage: NextPage<ContactErrorPageProps> = (props) => {
   return (
-    <DefaultLayout {...props}>
+    <DefaultLayout {...props} title={getContactPageTitle()}>
       <ErrorContent />
     </DefaultLayout>
   );

--- a/src/pages/contact/group-travel.tsx
+++ b/src/pages/contact/group-travel.tsx
@@ -7,12 +7,17 @@ import {
 import GroupTravelContent from '@atb/page-modules/contact/group-travel';
 import { withAccessLogging } from '@atb/modules/logging';
 import { withGlobalData, type WithGlobalData } from '@atb/modules/global-data';
+import { PageText } from '@atb/translations';
+import { getContactPageTitle } from '@atb/page-modules/contact/utils';
 
 export type GroupTravelPageProps = WithGlobalData<ContactPageLayoutProps>;
 
 const GroupTravelPage: NextPage<GroupTravelPageProps> = (props) => {
   return (
-    <DefaultLayout {...props}>
+    <DefaultLayout
+      {...props}
+      title={getContactPageTitle(PageText.Contact.groupTravel.title)}
+    >
       <ContactPageLayout {...props}>
         <GroupTravelContent />
       </ContactPageLayout>

--- a/src/pages/contact/index.tsx
+++ b/src/pages/contact/index.tsx
@@ -7,12 +7,14 @@ import {
 import { NextPage } from 'next';
 import { withAccessLogging } from '@atb/modules/logging';
 import { withGlobalData, type WithGlobalData } from '@atb/modules/global-data';
+import { PageText } from '@atb/translations';
+import { getContactPageTitle } from '@atb/page-modules/contact/utils';
 
 export type ContactPageProps = WithGlobalData<ContactPageLayoutProps>;
 
 const ContactPage: NextPage<ContactPageProps> = (props) => {
   return (
-    <DefaultLayout {...props}>
+    <DefaultLayout {...props} title={getContactPageTitle()}>
       <ContactPageLayout {...props} />
     </DefaultLayout>
   );

--- a/src/pages/contact/lost-property.tsx
+++ b/src/pages/contact/lost-property.tsx
@@ -7,12 +7,17 @@ import LostPropertyContent from '@atb/page-modules/contact/lost-property';
 import { NextPage } from 'next';
 import { withAccessLogging } from '@atb/modules/logging';
 import { withGlobalData, type WithGlobalData } from '@atb/modules/global-data';
+import { getContactPageTitle } from '@atb/page-modules/contact/utils';
+import { PageText } from '@atb/translations';
 
 export type LostPropertyPageProps = WithGlobalData<ContactPageLayoutProps>;
 
 const LostPropertyPage: NextPage<LostPropertyPageProps> = (props) => {
   return (
-    <DefaultLayout {...props}>
+    <DefaultLayout
+      {...props}
+      title={getContactPageTitle(PageText.Contact.lostProperty.title)}
+    >
       <ContactPageLayout {...props}>
         <LostPropertyContent />
       </ContactPageLayout>

--- a/src/pages/contact/means-of-transport/index.tsx
+++ b/src/pages/contact/means-of-transport/index.tsx
@@ -7,12 +7,17 @@ import {
 import { NextPage } from 'next';
 import { withAccessLogging } from '@atb/modules/logging';
 import { withGlobalData, type WithGlobalData } from '@atb/modules/global-data';
+import { getContactPageTitle } from '@atb/page-modules/contact/utils';
+import { PageText } from '@atb/translations';
 
 export type MeansOfTransportPageProps = WithGlobalData<ContactPageLayoutProps>;
 
 const MeansOfTransportPage: NextPage<MeansOfTransportPageProps> = (props) => {
   return (
-    <DefaultLayout {...props}>
+    <DefaultLayout
+      {...props}
+      title={getContactPageTitle(PageText.Contact.modeOfTransport.title)}
+    >
       <ContactPageLayout {...props}>
         <MeansOfTransportContent />
       </ContactPageLayout>

--- a/src/pages/contact/refund.tsx
+++ b/src/pages/contact/refund.tsx
@@ -7,12 +7,17 @@ import {
 } from '@atb/page-modules/contact';
 import { withAccessLogging } from '@atb/modules/logging';
 import { withGlobalData, type WithGlobalData } from '@atb/modules/global-data';
+import { getContactPageTitle } from '@atb/page-modules/contact/utils';
+import { PageText } from '@atb/translations';
 
 export type RefundPagePageProps = WithGlobalData<ContactPageLayoutProps>;
 
 const RefundPage: NextPage<RefundPagePageProps> = (props) => {
   return (
-    <DefaultLayout {...props}>
+    <DefaultLayout
+      {...props}
+      title={getContactPageTitle(PageText.Contact.refund.title)}
+    >
       <ContactPageLayout {...props}>
         <RefundContent />
       </ContactPageLayout>

--- a/src/pages/contact/success.tsx
+++ b/src/pages/contact/success.tsx
@@ -4,12 +4,13 @@ import { SuccessContent } from '@atb/page-modules/contact/success-content/succes
 import { NextPage } from 'next';
 import { withAccessLogging } from '@atb/modules/logging';
 import { withGlobalData, type WithGlobalData } from '@atb/modules/global-data';
+import { getContactPageTitle } from '@atb/page-modules/contact/utils';
 
 export type ContactSuccessPageProps = WithGlobalData<{}>;
 
 const ContactSuccessPage: NextPage<ContactSuccessPageProps> = (props) => {
   return (
-    <DefaultLayout {...props}>
+    <DefaultLayout {...props} title={getContactPageTitle()}>
       <SuccessContent />
     </DefaultLayout>
   );

--- a/src/pages/contact/ticket-control/index.tsx
+++ b/src/pages/contact/ticket-control/index.tsx
@@ -7,6 +7,8 @@ import {
 import { NextPage } from 'next';
 import { withAccessLogging } from '@atb/modules/logging';
 import { withGlobalData, type WithGlobalData } from '@atb/modules/global-data';
+import { PageText } from '@atb/translations';
+import { getContactPageTitle } from '@atb/page-modules/contact/utils';
 
 export type TicketControlAndFeePageProps =
   WithGlobalData<ContactPageLayoutProps>;
@@ -15,7 +17,10 @@ const TicketControlAndFeePage: NextPage<TicketControlAndFeePageProps> = (
   props,
 ) => {
   return (
-    <DefaultLayout {...props}>
+    <DefaultLayout
+      {...props}
+      title={getContactPageTitle(PageText.Contact.ticketControl.title)}
+    >
       <ContactPageLayout {...props}>
         <TicketControlPageContent />
       </ContactPageLayout>

--- a/src/pages/contact/ticketing/index.tsx
+++ b/src/pages/contact/ticketing/index.tsx
@@ -7,12 +7,17 @@ import {
 } from '@atb/page-modules/contact';
 import { withAccessLogging } from '@atb/modules/logging';
 import { withGlobalData, type WithGlobalData } from '@atb/modules/global-data';
+import { getContactPageTitle } from '@atb/page-modules/contact/utils';
+import { PageText } from '@atb/translations';
 
 export type TicketsAppPageProps = WithGlobalData<ContactPageLayoutProps>;
 
 const TicketsAppPage: NextPage<TicketsAppPageProps> = (props) => {
   return (
-    <DefaultLayout {...props}>
+    <DefaultLayout
+      {...props}
+      title={getContactPageTitle(PageText.Contact.ticketing.title)}
+    >
       <ContactPageLayout {...props}>
         <TicketingContent />
       </ContactPageLayout>

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -6,6 +6,7 @@ import { translation as _ } from '@atb/translations/commons';
 import { orgSpecificTranslations } from '../utils';
 
 const ContactInternal = {
+  pageTitle: _('Kontakt', 'Contact', 'Kontakt'),
   contactPageLayout: {
     title: _(
       'Hva kan vi hjelpe deg med?',


### PR DESCRIPTION
Adds title to all pages within contact space

Extends title in layout to support nested titles: `Subpage - Subpage - Main title`. Compatible with existing use