### PR TITLE
fix(contact): remove weird back button

### DIFF
--- a/src/page-modules/contact/success-content/success-content.tsx
+++ b/src/page-modules/contact/success-content/success-content.tsx
@@ -8,12 +8,6 @@ export function SuccessContent() {
   const { t } = useTranslation();
   return (
     <section className={style.container}>
-      <ButtonLink
-        mode="transparent"
-        href="/"
-        title={t(PageText.Contact.success.backButton)}
-        icon={{ left: <MonoIcon icon="navigation/ArrowLeft" /> }}
-      />
       <Typo.h2 textType="heading--big">
         {t(PageText.Contact.success.title)}
       </Typo.h2>

--- a/src/translations/pages/contact.ts
+++ b/src/translations/pages/contact.ts
@@ -1538,11 +1538,6 @@ const ContactInternal = {
     },
   },
   success: {
-    backButton: _(
-      'Tilbake til hovedsiden',
-      'Back to the main page',
-      'Tilbake til hovedsida',
-    ),
     title: _(
       'Takk for din henvendelse',
       'Thank you for your inquiry',


### PR DESCRIPTION
When navigating from PTA home page, it is odd after sending a contact form to say "back to main page" where the main page is not the PTA home page, but the travel planner.

Easiest solution here is to just remove the back button, as there are other ways to navigate (logo and button for home page).