### PR TITLE
fix: Removed wrong tooltip

### DIFF
--- a/src/layouts/shared/page-header.tsx
+++ b/src/layouts/shared/page-header.tsx
@@ -23,7 +23,6 @@ export default function PageHeader() {
             <Link
               href={'/'}
               className={style.pageHeader__logoLink}
-              title={t(CommonText.Layout.homeLink(urls.homePageUrl.name))}
               data-testid="homeButton"
             >
               {fylkeskommune?.replaceTitleWithLogoInHeader &&


### PR DESCRIPTION
This removes this tooltip, which is weird and not true any more: 

<img width="419" height="278" alt="Skjermbilde 2025-08-18 kl  09 37 26" src="https://github.com/user-attachments/assets/6ab3746c-1eda-4835-b5b2-a40a52c07bfd" />
