### PR TITLE
docs: Add API_BASE_URL example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,5 @@ NEXT_PUBLIC_FIREBASE_PROJECT_ID=atb-mobility-platform-staging
 NEXT_PUBLIC_FIREBASE_PUBLIC_API_KEY=AIzaSyDoat8ob5tewAXaPEhqbZKzx8e7LC5nuzQ
 NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=atb-mobility-platform-staging.firebaseapp.com
 NEXT_PUBLIC_FIREBASE_APP_ID="1:939812594010:web:0308b2a9cdc80b0d069363"
+
+API_BASE_URL=https://atb-staging.api.mittatb.no


### PR DESCRIPTION
After https://github.com/AtB-AS/planner-web/pull/604, this env variable must be set to avoid the app crashing.