### PR TITLE
fix: use serviceDate when navigating to departure details

### DIFF
--- a/src/page-modules/assistant/details/trip-section/index.tsx
+++ b/src/page-modules/assistant/details/trip-section/index.tsx
@@ -206,7 +206,7 @@ export default function TripSection({
           }
           duration={leg.duration}
           serviceJourneyId={leg.serviceJourney?.id ?? null}
-          date={leg.aimedStartTime.split('T')[0]}
+          date={leg.serviceDate}
           fromQuayId={leg.fromPlace.quay?.id ?? null}
         />
 

--- a/src/page-modules/assistant/journey-gql/trip-with-details.gql
+++ b/src/page-modules/assistant/journey-gql/trip-with-details.gql
@@ -70,6 +70,7 @@ fragment legWithDetails on Leg {
   expectedEndTime
   realtime
   duration
+  serviceDate
   pointsOnLink {
     points
     length

--- a/src/page-modules/departures/details/index.tsx
+++ b/src/page-modules/departures/details/index.tsx
@@ -32,7 +32,6 @@ export function DeparturesDetails({
   const focusedCall =
     serviceJourney.estimatedCalls.find((call) => call.quay.id === fromQuayId) ||
     serviceJourney.estimatedCalls[0];
-  const title = `${serviceJourney.line.publicCode} ${formatDestinationDisplay(t, focusedCall.destinationDisplay)}`;
   const realtimeText = useRealtimeText(
     serviceJourney.estimatedCalls.map((c) => ({
       actualDepartureTime: c.actualDepartureTime,
@@ -44,6 +43,19 @@ export function DeparturesDetails({
     })),
   );
 
+  if (!focusedCall)
+    return (
+      <section className={style.container}>
+        <div className={style.headerContainer}>
+          <MessageBox
+            type="error"
+            message={t(PageText.Departures.details.messages.noActiveItem)}
+          />
+        </div>
+      </section>
+    );
+
+  const title = `${serviceJourney.line.publicCode} ${formatDestinationDisplay(t, focusedCall.destinationDisplay)}`;
   const estimatedCallsWithMetadata = addMetadataToEstimatedCalls(
     serviceJourney.estimatedCalls,
     fromQuayId,


### PR DESCRIPTION
This fixes a crash reported [here](https://oms-yzc6053.slack.com/archives/C075ZMJHZJN/p1757061248027859) and [here](https://mittatb.slack.com/archives/CR75QKX6G/p1756900426769319?thread_ts=1754128626.331689&cid=CR75QKX6G), where departures that operated on a different date than their serviceDate crashed the page.

This PR makes planner-web use the correct service date when navigating, as well as handles the case where date is wrong more gracefully (shows an error message).

### Acceptance criteria

- [ ] When clicking on the "X mellomstopp" button for trips that depart after midnight, e.g. the first result of [this travel search](https://reise.atb.no/assistant?filter=bus%2Ctram%2Crail%2Cspeedboat%2Cferry%2Cflybus&searchMode=departBy&searchTime=1757109600000&fromId=NSR%3AStopPlace%3A59977&fromName=Trondheim+S&fromLon=10.399123&fromLat=63.436279&fromLayer=venue&toId=NSR%3AStopPlace%3A43583&toName=Orkanger+skysstasjon&toLon=9.847545&toLat=63.29835&toLayer=venue), you're shown the correct departure details.
