### PR TITLE
fix: prevent duplicate departures when loading more in departures

### DIFF
--- a/src/page-modules/departures/stop-place/index.tsx
+++ b/src/page-modules/departures/stop-place/index.tsx
@@ -120,8 +120,12 @@ export function EstimatedCallList({ quay }: EstimatedCallListProps) {
     const date = new Date(latestDeparture.aimedDepartureTime);
     const data = await nextDepartures(quay.id, date.toISOString());
 
-    const set = new Set(departures.map((departure) => departure));
-    const filteredDepartures = data.filter((departure) => !set.has(departure));
+    const getKey = (departure: ExtendedDepartureType) =>
+      `${departure.serviceJourney.id} - ${departure.aimedDepartureTime}`;
+    // Filter out departures we already have
+    const filteredDepartures = data.filter(
+      (departure) => !departures.find((d) => getKey(d) === getKey(departure)),
+    );
 
     setDepartures([...departures, ...filteredDepartures]);
     setIsFetchingDepartures(false);


### PR DESCRIPTION
The `set.has()` check used when loading more departures was unreliable, and caused the issue described in https://github.com/AtB-AS/kundevendt/issues/21567. Better to check against a custom key that should define unique estimated calls.

closes https://github.com/AtB-AS/kundevendt/issues/21567