### PR TITLE
fix(widget): Removed postCSS error if the file does not exist

### DIFF
--- a/scripts/build-widget.sh
+++ b/scripts/build-widget.sh
@@ -28,6 +28,9 @@ VERSION=$(node -p "require('./package.json').version")
 for FOLDER in "$BASE_DIR"/*/; do
   FOLDER_NAME=$(basename "$FOLDER")
   FILE_NAME="$BASE_DIR/$FOLDER_NAME/$VERSION/planner-web.css"
+  if [[ ! -f "$FILE_NAME" ]]; then
+    break
+  fi
   npx postcss "$FILE_NAME" -o "$FILE_NAME"
 done
 


### PR DESCRIPTION
When running `yarn generate-widget` for only one county, you got this error: 

```
Input Error: You must pass a valid list of files to parse
Input Error: You must pass a valid list of files to parse
Input Error: You must pass a valid list of files to parse
Input Error: You must pass a valid list of files to parse
Input Error: You must pass a valid list of files to parse
```

This removes that