### PR TITLE
fix: set correct background color for authority button

### DIFF
--- a/src/page-modules/assistant/details/trip-section/authority-section.tsx
+++ b/src/page-modules/assistant/details/trip-section/authority-section.tsx
@@ -34,7 +34,7 @@ export function AuthoritySection({ authority }: AuthoritySectionProps) {
           title={authority.name}
           icon={{ left: <MonoIcon icon="navigation/ExternalLink" /> }}
           mode="secondary"
-          backgroundColor={color.background.accent['4']}
+          backgroundColor={color.background.neutral[0]}
           display="block"
           radiusSize="circular"
           size="pill"


### PR DESCRIPTION
The authority button became white on white for e.g. Svipper, because the wrong backgroundColor was set. (https://github.com/AtB-AS/kundevendt/issues/20666)

<img width="283" height="256" alt="Screenshot 2025-09-11 at 10 43 38" src="https://github.com/user-attachments/assets/d2f44e13-c16e-4840-ab44-32789cab4be3" />

## Acceptance criteria

- [x] Correct button color for AtB and Svipper