### PR TITLE
fix: Fixed bug where only one venue icon was shown for multimodal stops

### DIFF
--- a/src/components/venue-icon/index.tsx
+++ b/src/components/venue-icon/index.tsx
@@ -1,17 +1,13 @@
 import { ComponentText, useTranslation } from '@atb/translations';
 import { MonoIcon, MonoIconProps } from '@atb/components/icon';
 import { FeatureCategory } from '@atb/modules/geocoder';
+import style from './venue-icon.module.css';
 
 export type VenueIconProps = {
   categories: FeatureCategory[] | string[];
-  multiple?: boolean;
 } & Omit<MonoIconProps, 'icon'>;
 
-export default function VenueIcon({
-  categories,
-  multiple,
-  ...props
-}: VenueIconProps) {
+export default function VenueIcon({ categories, ...props }: VenueIconProps) {
   let venueIconTypes: VenueIconType[] = [];
 
   if (isFeatureCategory(categories)) {
@@ -24,13 +20,13 @@ export default function VenueIcon({
     return <MonoIcon icon="map/Pin" key="unknown" {...props} />;
   }
 
-  if (multiple) {
+  if (venueIconTypes.length > 1) {
     return (
-      <>
+      <div className={style.multipleContainer}>
         {venueIconTypes.map((it) => (
           <IconComponent iconType={it} key={it} {...props} />
         ))}
-      </>
+      </div>
     );
   }
 

--- a/src/components/venue-icon/venue-icon.module.css
+++ b/src/components/venue-icon/venue-icon.module.css
@@ -1,0 +1,4 @@
+.multipleContainer {
+    display: flex;
+    flex-direction: column;
+}


### PR DESCRIPTION
Small bug reported here: https://oms-yzc6053.slack.com/archives/C075ZMJHZJN/p1758631174697979

<details>
<summary>Before and after screenshots</summary>

| Before | After |
|--------|-------|
| <img width="300" src="https://github.com/user-attachments/assets/29a2a365-183b-4e38-bbf1-c375bd9ac5f2" /> | <img width="300" src="https://github.com/user-attachments/assets/46f12751-39ab-4d80-b3ba-76cc1daff715" /> |
</details>