### PR TITLE
feat: add keyboard navigation to time selector

### DIFF
--- a/src/modules/search-time/selector/time-selector-dropdown.module.css
+++ b/src/modules/search-time/selector/time-selector-dropdown.module.css
@@ -25,6 +25,12 @@
   scrollbar-width: none;
 }
 
+/* Hide outline on the listbox container itself — focus indication is
+   shown on the active option via .numberItemFocused instead. */
+.scrollView:focus {
+  outline: none;
+}
+
 .scrollView::-webkit-scrollbar {
   display: none;
 }
@@ -36,6 +42,13 @@
 
 .numberItem:hover {
   background: token('color.interactive.0.active.background');
+}
+
+/* Visual focus indicator for the option highlighted via keyboard
+   navigation (aria-activedescendant pattern). */
+.numberItemFocused {
+  outline: 2px solid token('color.foreground.dynamic.primary');
+  outline-offset: -2px;
 }
 
 .numberItemSelected {

--- a/src/modules/search-time/selector/time-selector-dropdown.tsx
+++ b/src/modules/search-time/selector/time-selector-dropdown.tsx
@@ -4,7 +4,8 @@ import { parseTime } from '@internationalized/date';
 import style from './time-selector-dropdown.module.css';
 import { and } from '@atb/utils/css';
 import { Typo } from '@atb/components/typography';
-import { useEffect, useRef } from 'react';
+
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { useTheme } from '@atb/modules/theme';
 
 const numberItemRowHeight = 32; // px
@@ -14,7 +15,7 @@ const hours = getNumbers(24);
 const minutes = getNumbers(60);
 
 export type TimeSelectorDropdownProps = {
-  /** “HH:mm” (e.g. “08:30”). */
+  /** "HH:mm" (e.g. "08:30"). */
   selectedTime: string;
   onChange: (time: string) => void;
 };
@@ -44,12 +45,14 @@ export default function TimeSelectorDropdown({
             selectedValue={time.hour}
             onSelect={(hour) => selectTime('hour', hour)}
             testID="hours"
+            label="Hours"
           />
           <NumberSeriesScrollView
             numberSeries={minutes}
             selectedValue={time.minute}
             onSelect={(minute) => selectTime('minute', minute)}
             testID="minutes"
+            label="Minutes"
           />
         </div>
       </Dialog>
@@ -62,6 +65,7 @@ type NumberSeriesScrollViewProps = {
   selectedValue: number;
   onSelect: (number: number) => void;
   testID?: string;
+  label: string;
 };
 
 const NumberSeriesScrollView = ({
@@ -69,47 +73,121 @@ const NumberSeriesScrollView = ({
   selectedValue,
   onSelect,
   testID,
+  label,
 }: NumberSeriesScrollViewProps) => {
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const theme = useTheme();
   const initialSelectedValue = useRef(selectedValue);
+  const [focusedValue, setFocusedValue] = useState<number | null>(null);
+  const listboxId = useId();
+
+  const scrollToValue = useCallback(
+    (value: number, behavior: ScrollBehavior = 'instant') => {
+      if (!scrollContainerRef.current) return;
+      const index = numberSeries.findIndex((n) => n === value);
+      if (index !== -1) {
+        scrollContainerRef.current.scrollTo({
+          behavior,
+          top: (index + numberSeries.length) * numberItemRowHeight,
+        });
+      }
+    },
+    [numberSeries],
+  );
 
   useEffect(() => {
-    const initialNumberIndex = numberSeries.findIndex(
-      (number) => number === initialSelectedValue.current,
-    );
-    if (initialNumberIndex !== -1 && scrollContainerRef.current) {
-      scrollContainerRef.current.scrollTo({
-        behavior: 'instant',
-        top: (initialNumberIndex + numberSeries.length) * numberItemRowHeight, // the numbers are repeated 3 times, this selects from the one in the middle
-      });
+    scrollToValue(initialSelectedValue.current);
+  }, [scrollToValue, theme.spacing.small]);
+
+  const getOptionId = (value: number) => `${listboxId}-option-${value}`;
+
+  // Keyboard handler: Arrow Up/Down to navigate, Enter/Space to select.
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    const len = numberSeries.length;
+    const current = focusedValue ?? selectedValue;
+    let next = current;
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        next = (current + 1) % len;
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        next = (current - 1 + len) % len;
+        break;
+      case 'Enter':
+      case ' ':
+        e.preventDefault();
+        onSelect(current);
+        return;
+      default:
+        return;
     }
-  }, [initialSelectedValue, numberSeries, theme.spacing.small]);
+
+    setFocusedValue(next);
+    scrollToValue(next, 'smooth');
+  };
+
+  const handleFocus = () => {
+    setFocusedValue(selectedValue);
+    scrollToValue(selectedValue, 'smooth');
+  };
+
+  const handleBlur = () => {
+    setFocusedValue(null);
+  };
 
   // To ensure that the default value can always be selected and aligned on top, repeat the numbers 3 times and select a number in the middle.
+  // isMiddle marks the canonical copy used for aria IDs and test IDs.
   const numberItems = ['paddingBefore', 'default', 'paddingAfter'].flatMap(
     (_, i) =>
       numberSeries.map((num, index) => ({
         key: i * numberSeries.length + index,
         value: num,
+        isMiddle: i === 1,
       })),
   );
 
+  // Points to the ID of the currently focused option so screen readers
+  // announce it while DOM focus remains on the container.
+  const activeDescendant =
+    focusedValue !== null ? getOptionId(focusedValue) : undefined;
+
   return (
-    <div ref={scrollContainerRef} className={style.scrollView}>
+    <div
+      ref={scrollContainerRef}
+      className={style.scrollView}
+      role="listbox"
+      aria-label={label}
+      aria-activedescendant={activeDescendant}
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+    >
       {numberItems.map((numberItem) => {
         const isSelected = selectedValue === numberItem.value;
+        const isFocused = focusedValue === numberItem.value;
         return (
           <Typo.div
             key={numberItem.key}
+            role="option"
+            id={numberItem.isMiddle ? getOptionId(numberItem.value) : undefined}
+            aria-selected={isSelected}
             textType={isSelected ? 'body__m__strong' : 'body__m'}
             style={{ height: numberItemRowHeight + 'px' }}
             className={and(
               style.numberItem,
               isSelected && style.numberItemSelected,
+              isFocused && style.numberItemFocused,
             )}
             onClick={() => onSelect(numberItem.value)}
-            testID={`time-${testID}-${numberItem.value.toString().padStart(2, '0')}`}
+            testID={
+              numberItem.isMiddle
+                ? `time-${testID}-${numberItem.value.toString().padStart(2, '0')}`
+                : undefined
+            }
           >
             {numberItem.value.toString().padStart(2, '0')}
           </Typo.div>

--- a/src/modules/search-time/selector/time-selector-dropdown.tsx
+++ b/src/modules/search-time/selector/time-selector-dropdown.tsx
@@ -46,6 +46,7 @@ export default function TimeSelectorDropdown({
             onSelect={(hour) => selectTime('hour', hour)}
             testID="hours"
             label="Hours"
+            autoFocus
           />
           <NumberSeriesScrollView
             numberSeries={minutes}
@@ -66,6 +67,7 @@ type NumberSeriesScrollViewProps = {
   onSelect: (number: number) => void;
   testID?: string;
   label: string;
+  autoFocus?: boolean;
 };
 
 const NumberSeriesScrollView = ({
@@ -74,6 +76,7 @@ const NumberSeriesScrollView = ({
   onSelect,
   testID,
   label,
+  autoFocus,
 }: NumberSeriesScrollViewProps) => {
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const theme = useTheme();
@@ -98,6 +101,16 @@ const NumberSeriesScrollView = ({
   useEffect(() => {
     scrollToValue(initialSelectedValue.current);
   }, [scrollToValue, theme.spacing.small]);
+
+  const scrollContainerCallbackRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      scrollContainerRef.current = node;
+      if (node && autoFocus) {
+        node.focus();
+      }
+    },
+    [autoFocus],
+  );
 
   const getOptionId = (value: number) => `${listboxId}-option-${value}`;
 
@@ -156,7 +169,7 @@ const NumberSeriesScrollView = ({
 
   return (
     <div
-      ref={scrollContainerRef}
+      ref={scrollContainerCallbackRef}
       className={style.scrollView}
       role="listbox"
       aria-label={label}

--- a/src/modules/search-time/selector/time-selector.tsx
+++ b/src/modules/search-time/selector/time-selector.tsx
@@ -56,7 +56,6 @@ export default function TimeSelector({
 
         <DialogTrigger>
           <Button
-            excludeFromTabOrder
             className={style.timePickerButton}
             data-testid="timePickerButton"
           >


### PR DESCRIPTION
related to https://github.com/AtB-AS/kundevendt/issues/22865

The time selector wasn't selectable when using keyboard navigation, so this adds that functionality.