### PR TITLE
fix: round trip details arrival times up

### DIFF
--- a/src/components/departure-time/__tests__/departure-time.test.tsx
+++ b/src/components/departure-time/__tests__/departure-time.test.tsx
@@ -27,7 +27,7 @@ describe('departure time component', function () {
     const output = render(
       <DepartureTime
         aimedDepartureTime="2021-09-01T12:00:00+02:00"
-        expectedDepartureTime="2021-09-01T12:00:14+02:00"
+        expectedDepartureTime="2021-09-01T12:00:30+02:00"
         realtime
         roundingMethod="floor"
       />,

--- a/src/components/departure-time/__tests__/departure-time.test.tsx
+++ b/src/components/departure-time/__tests__/departure-time.test.tsx
@@ -16,6 +16,7 @@ describe('departure time component', function () {
       <DepartureTime
         aimedDepartureTime="2021-09-01T12:00:00+02:00"
         expectedDepartureTime="2021-09-01T12:00:00+02:00"
+        roundingMethod="floor"
       />,
     );
 
@@ -28,6 +29,7 @@ describe('departure time component', function () {
         aimedDepartureTime="2021-09-01T12:00:00+02:00"
         expectedDepartureTime="2021-09-01T12:00:14+02:00"
         realtime
+        roundingMethod="floor"
       />,
     );
     expect(output.getByLabelText('Sanntid 12:00')).toBeInTheDocument();
@@ -39,6 +41,7 @@ describe('departure time component', function () {
       <DepartureTime
         aimedDepartureTime="2021-09-01T12:00:00+02:00"
         expectedDepartureTime="2021-09-01T12:05:00+02:00"
+        roundingMethod="floor"
       />,
     );
 
@@ -52,6 +55,7 @@ describe('departure time component', function () {
         aimedDepartureTime="2021-09-01T12:00:00+02:00"
         expectedDepartureTime="2021-09-01T12:05:00+02:00"
         realtime
+        roundingMethod="floor"
       />,
     );
     expect(output.getByLabelText('Rutetid 12:00')).toBeInTheDocument();
@@ -68,6 +72,7 @@ describe('departure time component', function () {
         expectedDepartureTime="2021-09-01T12:05:00+02:00"
         realtime
         withRealtimeIndicator
+        roundingMethod="floor"
       />,
     );
     expect(output.queryByTestId('rt-indicator')).toBeInTheDocument();
@@ -80,6 +85,7 @@ describe('departure time component', function () {
         expectedDepartureTime="2021-09-01T12:05:00+02:00"
         realtime={false}
         withRealtimeIndicator
+        roundingMethod="floor"
       />,
     );
     expect(output.queryByTestId('rt-indicator')).toBeNull();
@@ -91,6 +97,7 @@ describe('departure time component', function () {
         aimedDepartureTime="2021-09-01T12:00:00+02:00"
         expectedDepartureTime="2021-09-01T12:05:00+02:00"
         realtime
+        roundingMethod="floor"
       />,
     );
     expect(output.queryByTestId('rt-indicator')).toBeNull();
@@ -103,6 +110,7 @@ describe('departure time component', function () {
         expectedDepartureTime="2021-09-01T12:05:00+02:00"
         cancelled
         realtime
+        roundingMethod="floor"
       />,
     );
     expect(output.getByText('12:00')).toHaveClass('typo-body__m__strike');
@@ -123,6 +131,7 @@ describe('departure time component', function () {
         aimedDepartureTime={data}
         expectedDepartureTime={data}
         relativeTime
+        roundingMethod="floor"
       />,
     );
 
@@ -144,6 +153,7 @@ describe('departure time component', function () {
           expectedDepartureTime={addMinutes(now, delayInMinutes).toISOString()}
           relativeTime
           realtime
+          roundingMethod="floor"
         />,
       );
 
@@ -174,6 +184,7 @@ describe('departure time component', function () {
         aimedDepartureTime={now.toISOString()}
         expectedDepartureTime={now.toISOString()}
         relativeTime
+        roundingMethod="floor"
       />,
     );
 
@@ -183,5 +194,17 @@ describe('departure time component', function () {
     )}`;
 
     expect(output.getByLabelText(expectedLabel)).toBeInTheDocument();
+  });
+
+  it('should round up if roundingMethod is ceil', () => {
+    const output = render(
+      <DepartureTime
+        aimedDepartureTime="2021-09-01T12:00:00+02:00"
+        expectedDepartureTime="2021-09-01T12:05:01+02:00"
+        realtime
+        roundingMethod="ceil"
+      />,
+    );
+    expect(output.getByLabelText('Sanntid 12:06')).toBeInTheDocument();
   });
 });

--- a/src/components/departure-time/__tests__/departure-time.test.tsx
+++ b/src/components/departure-time/__tests__/departure-time.test.tsx
@@ -207,4 +207,19 @@ describe('departure time component', function () {
     );
     expect(output.getByLabelText('Sanntid 12:06')).toBeInTheDocument();
   });
+
+  it('should not show both aimed and expected if they are the same', () => {
+    const output = render(
+      <DepartureTime
+        aimedDepartureTime="2021-09-01T16:10:00+02:00"
+        expectedDepartureTime="2021-09-01T16:10:49+02:00"
+        realtime
+        roundingMethod="floor"
+      />,
+    );
+    expect(output.queryByLabelText('Rutetid', { exact: false })).toBeNull();
+    expect(
+      output.getByLabelText('Sanntid', { exact: false }),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/components/departure-time/index.tsx
+++ b/src/components/departure-time/index.tsx
@@ -11,6 +11,7 @@ import {
   formatToClock,
   formatToClockOrRelativeMinutes,
   isInPast,
+  RoundingMethod,
 } from '@atb/utils/date';
 import style from './departure-time.module.css';
 import { ColorIcon } from '../icon';
@@ -20,6 +21,7 @@ type DepartureTimeProps = {
   aimedDepartureTime: string;
   expectedDepartureTime: string;
   realtime?: boolean;
+  roundingMethod: RoundingMethod;
   cancelled?: boolean;
   relativeTime?: boolean;
   withRealtimeIndicator?: boolean;
@@ -29,6 +31,7 @@ export function DepartureTime({
   aimedDepartureTime,
   expectedDepartureTime,
   realtime,
+  roundingMethod,
   cancelled = false,
   relativeTime = false,
   withRealtimeIndicator = false,
@@ -44,8 +47,13 @@ export function DepartureTime({
   const scheduled = useTimeOrRelative(
     aimedDepartureTime,
     representationType !== 'significant-difference' ? relativeTime : false,
+    roundingMethod,
   );
-  const expected = useTimeOrRelative(expectedDepartureTime, relativeTime);
+  const expected = useTimeOrRelative(
+    expectedDepartureTime,
+    relativeTime,
+    roundingMethod,
+  );
   const showRealtimeIndicator = Boolean(withRealtimeIndicator && realtime);
 
   switch (representationType) {
@@ -147,11 +155,15 @@ function TimeContainer({
   );
 }
 
-function useTimeOrRelative(time: string, relative: boolean) {
+function useTimeOrRelative(
+  time: string,
+  relative: boolean,
+  roundingMethod: RoundingMethod,
+) {
   const { t, language } = useTranslation();
 
   if (!relative) {
-    return formatToClock(time, language, 'floor');
+    return formatToClock(time, language, roundingMethod);
   }
 
   return isInPast(time)

--- a/src/modules/time-representation/index.ts
+++ b/src/modules/time-representation/index.ts
@@ -1,6 +1,6 @@
 import { secondsBetween } from '@atb/utils/date';
 
-const DEFAULT_THRESHOLD_AIMED_EXPECTED_IN_SECONDS = 15;
+const DEFAULT_THRESHOLD_AIMED_EXPECTED_IN_SECONDS = 60;
 
 type TimeValues = {
   aimedTime: string;

--- a/src/page-modules/assistant/details/trip-section/index.tsx
+++ b/src/page-modules/assistant/details/trip-section/index.tsx
@@ -93,6 +93,7 @@ export default function TripSection({
                 aimedDepartureTime={leg.aimedStartTime}
                 expectedDepartureTime={leg.expectedStartTime}
                 realtime={leg.realtime}
+                roundingMethod="floor"
               />
             }
             alignChildren="flex-start"
@@ -214,6 +215,7 @@ export default function TripSection({
                 aimedDepartureTime={leg.aimedEndTime}
                 expectedDepartureTime={leg.expectedEndTime}
                 realtime={leg.realtime}
+                roundingMethod="ceil"
               />
             }
             alignChildren="flex-start"

--- a/src/page-modules/departures/details/estimated-call-rows.tsx
+++ b/src/page-modules/departures/details/estimated-call-rows.tsx
@@ -162,6 +162,7 @@ function EstimatedCallRow({
             aimedDepartureTime={call.aimedDepartureTime}
             expectedDepartureTime={call.expectedDepartureTime}
             realtime={call.realtime}
+            roundingMethod="floor"
           />
         }
         alignChildren={

--- a/src/page-modules/departures/stop-place/index.tsx
+++ b/src/page-modules/departures/stop-place/index.tsx
@@ -290,6 +290,7 @@ export function EstimatedCallItem({
           relativeTime
           realtime={departure.realtime}
           withRealtimeIndicator
+          roundingMethod="floor"
         />
       </Link>
     </li>


### PR DESCRIPTION
fixes https://github.com/AtB-AS/kundevendt/issues/23035

Two changes here in essence + some updated tests:

- Reverts this change: https://github.com/AtB-AS/planner-web/pull/600
- Rounds arrival times up in TripSection to match trip details