### PR TITLE
feat: add missing box-shadow for accessibility

### DIFF
--- a/src/components/button/button.module.css
+++ b/src/components/button/button.module.css
@@ -92,6 +92,11 @@
 .button--primary.button--disabled {
   opacity: 0.2;
 }
+.button--primary:focus {
+  outline: 0;
+  box-shadow: inset 0 0 0 token('border.width.medium')
+    token('color.interactive.0.outline.background');
+}
 
 /* Secondary */
 .button--secondary,
@@ -110,6 +115,11 @@
 .button--secondary:disabled,
 .button--secondary.button--disabled {
   opacity: 0.2;
+}
+.button--secondary:focus {
+  outline: 0;
+  box-shadow: inset 0 0 0 token('border.width.medium')
+    token('color.interactive.0.outline.background');
 }
 
 /* Interactive button 0 */

--- a/src/components/search/search.module.css
+++ b/src/components/search/search.module.css
@@ -13,6 +13,8 @@
 }
 .container:focus-within {
   outline: 0;
+  box-shadow: inset 0 0 0 token('border.width.medium')
+    token('color.interactive.2.outline.background');
 }
 
 .container:not(:only-child):first-child {


### PR DESCRIPTION
related to https://github.com/AtB-AS/kundevendt/issues/22865

fulfills WCAG rule 2.4.7 : Synlig fokus by adding box-shadow on the focused items when navigating with keyboard. Most of the buttons already has it, just need to add the same box-shadow on button-primary, button-secondary, and search