### PR TITLE
fix: add missing alt on icons, add fallback alt on page-header

### DIFF
--- a/src/components/icon/color-icon.tsx
+++ b/src/components/icon/color-icon.tsx
@@ -26,7 +26,7 @@ export function ColorIcon({ icon, size = 'normal', ...props }: ColorIconProps) {
   if (!currentIcon.darkable) {
     const totalPath = `/assets/${currentIcon.relative}`;
     // eslint-disable-next-line
-    return <img width={wh} height={wh} src={totalPath} {...props} />;
+    return <img width={wh} height={wh} src={totalPath} role="none" alt="" {...props} />;
   } else {
     const totalPath = `/assets/${specifyDarkOrLight(
       currentIcon.relative,
@@ -34,7 +34,7 @@ export function ColorIcon({ icon, size = 'normal', ...props }: ColorIconProps) {
     )}`;
 
     // eslint-disable-next-line
-    return <img width={wh} height={wh} src={totalPath} {...props} />;
+    return <img width={wh} height={wh} src={totalPath} role="none" alt="" {...props} />;
   }
 }
 

--- a/src/components/icon/color-icon.tsx
+++ b/src/components/icon/color-icon.tsx
@@ -26,7 +26,16 @@ export function ColorIcon({ icon, size = 'normal', ...props }: ColorIconProps) {
   if (!currentIcon.darkable) {
     const totalPath = `/assets/${currentIcon.relative}`;
     // eslint-disable-next-line
-    return <img width={wh} height={wh} src={totalPath} role="none" alt="" {...props} />;
+    return (
+      <img
+        width={wh}
+        height={wh}
+        src={totalPath}
+        role="none"
+        alt=""
+        {...props}
+      />
+    );
   } else {
     const totalPath = `/assets/${specifyDarkOrLight(
       currentIcon.relative,
@@ -34,7 +43,16 @@ export function ColorIcon({ icon, size = 'normal', ...props }: ColorIconProps) {
     )}`;
 
     // eslint-disable-next-line
-    return <img width={wh} height={wh} src={totalPath} role="none" alt="" {...props} />;
+    return (
+      <img
+        width={wh}
+        height={wh}
+        src={totalPath}
+        role="none"
+        alt=""
+        {...props}
+      />
+    );
   }
 }
 

--- a/src/layouts/shared/page-header.tsx
+++ b/src/layouts/shared/page-header.tsx
@@ -33,7 +33,7 @@ export default function PageHeader() {
                   sizes="100vw"
                   style={{ width: '100%', height: 'auto' }}
                   src={fylkeskommuneLogo}
-                  alt={fylkeskommune?.name || ''}
+                  alt={fylkeskommune?.name || t(CommonText.Titles.siteTitle)}
                 />
               ) : (
                 <>


### PR DESCRIPTION
related to https://github.com/AtB-AS/kundevendt/issues/22865

Fulfills WCAG 1.1.1 so now there are no `<img>` without `alt`, also adds fallback `alt` to the logo in case `fylkeskommune` or `fylkeskommune.name` is undefined.