### PR TITLE
feat: show ticket purchase information for current authority

### DIFF
--- a/orgs/atb.json
+++ b/orgs/atb.json
@@ -36,7 +36,7 @@
       "name": "atb.no",
       "href": "https://atb.no/"
     },
-    "ticketsUrl": {
+    "ticketInfoUrl": {
       "en-US": "https://www.atb.no/en/fares/",
       "no": "https://www.atb.no/priser/",
       "default": "https://www.atb.no/priser/"
@@ -45,6 +45,11 @@
       "dev": "http://localhost:3000",
       "staging": "https://atb-staging.planner-web.mittatb.no/",
       "prod": "https://reise.atb.no/"
+    },
+    "purchaseTicketUrl": {
+      "en-US": "https://www.atb.no/en/ticket/",
+      "no": "https://www.atb.no/billett/",
+      "default": "https://www.atb.no/billett/"
     }
   },
   "journeyApiConfigurations": {

--- a/orgs/atb.json
+++ b/orgs/atb.json
@@ -50,6 +50,12 @@
       "en-US": "https://www.atb.no/en/ticket/",
       "no": "https://www.atb.no/billett/",
       "default": "https://www.atb.no/billett/"
+    },
+    "androidAppUrl": {
+      "default": "https://play.google.com/store/apps/details?id=no.mittatb.store"
+    },
+    "iosAppUrl": {
+      "default": "https://apps.apple.com/us/app/atb/id1502395251"
     }
   },
   "journeyApiConfigurations": {

--- a/orgs/farte.json
+++ b/orgs/farte.json
@@ -35,13 +35,25 @@
       "href": "https://www.farte.no/"
     },
     "ticketInfoUrl": {
-      "nn": "https://www.farte.no/kundeservice/billetter-og-priser/",
-      "default": "https://www.farte.no/kundeservice/billetter-og-priser/"
+      "en-US": "https://www.farte.no/english/",
+      "nn": "https://www.farte.no/reise/billetter-og-priser/",
+      "default": "https://www.farte.no/reise/billetter-og-priser/"
+    },
+    "purchaseTicketUrl": {
+      "en-US": "https://www.farte.no/english/",
+      "nn": "https://www.farte.no/reise/billetter-og-priser/",
+      "default": "https://www.farte.no/reise/billetter-og-priser/"
     },
     "sitemapUrls": {
       "dev": "http://localhost:3000",
       "staging": "https://farte-staging.planner-web.mittatb.no/",
       "prod": "https://reise.farte.no/"
+    },
+    "androidAppUrl": {
+      "default": "https://play.google.com/store/apps/details?id=no.trfylke.svipper.production"
+    },
+    "iosAppUrl": {
+      "default": "https://apps.apple.com/no/app/farte/id6479402566"
     }
   },
   "journeyApiConfigurations": {

--- a/orgs/farte.json
+++ b/orgs/farte.json
@@ -34,7 +34,7 @@
       "name": "farte.no",
       "href": "https://www.farte.no/"
     },
-    "ticketsUrl": {
+    "ticketInfoUrl": {
       "nn": "https://www.farte.no/kundeservice/billetter-og-priser/",
       "default": "https://www.farte.no/kundeservice/billetter-og-priser/"
     },

--- a/orgs/fram.json
+++ b/orgs/fram.json
@@ -35,7 +35,7 @@
       "name": "frammr.no",
       "href": "https://www.frammr.no/"
     },
-    "ticketsUrl": {
+    "ticketInfoUrl": {
       "en-US": "https://frammr.no/billettar/billettar-og-prisar/?sprak=3",
       "nn": "https://frammr.no/billettar/billettar-og-prisar/?sprak=11",
       "default": "https://frammr.no/billettar/billettar-og-prisar/"

--- a/orgs/fram.json
+++ b/orgs/fram.json
@@ -40,10 +40,21 @@
       "nn": "https://frammr.no/billettar/billettar-og-prisar/?sprak=11",
       "default": "https://frammr.no/billettar/billettar-og-prisar/"
     },
+    "purchaseTicketUrl": {
+      "en-US": "https://frammr.no/tickets/how-to-buy-a-ticket/?sprak=3",
+      "nn": "https://frammr.no/billettar/slik-kjoper-du-billett/",
+      "default": "https://frammr.no/billettar/slik-kjoper-du-billett/"
+    },
     "sitemapUrls": {
       "dev": "http://localhost:3000",
       "staging": "https://fram-staging.planner-web.mittatb.no/",
       "prod": "https://reise.frammr.no/"
+    },
+    "androidAppUrl": {
+      "default": "https://play.google.com/store/apps/details?id=no.mrfylke.fram.production"
+    },
+    "iosAppUrl": {
+      "default": "https://apps.apple.com/no/app/fram/id6447612651"
     }
   },
   "journeyApiConfigurations": {

--- a/orgs/nfk.json
+++ b/orgs/nfk.json
@@ -36,7 +36,7 @@
       "name": "reisnordland.no",
       "href": "https://www.reisnordland.no/"
     },
-    "ticketsUrl": {
+    "ticketInfoUrl": {
       "en-US": "https://www.reisnordland.no/priser-pa-buss",
       "no": "https://www.reisnordland.no/priser-pa-buss",
       "default": "https://www.reisnordland.no/priser-pa-buss"

--- a/orgs/nfk.json
+++ b/orgs/nfk.json
@@ -41,10 +41,21 @@
       "no": "https://www.reisnordland.no/priser-pa-buss",
       "default": "https://www.reisnordland.no/priser-pa-buss"
     },
+    "purchaseTicketUrl": {
+      "en-US": "https://www.reisnordland.no/kjop-bussbillett",
+      "no": "https://www.reisnordland.no/kjop-bussbillett",
+      "default": "https://www.reisnordland.no/kjop-bussbillett"
+    },
     "sitemapUrls": {
       "dev": "http://localhost:3000",
       "staging": "https://nfk-staging.planner-web.mittatb.no/",
       "prod": "https://reise.reisnordland.no/"
+    },
+    "androidAppUrl": {
+      "default": "https://play.google.com/store/apps/details?id=no.reisnordland.reis.production"
+    },
+    "iosAppUrl": {
+      "default": "https://apps.apple.com/no/app/reis/id1574137854"
     }
   },
   "journeyApiConfigurations": {

--- a/orgs/schema-validation.json
+++ b/orgs/schema-validation.json
@@ -87,6 +87,12 @@
             "purchaseTicketUrl": {
               "$ref": "#/definitions/TranslatableUrl"
             },
+            "androidAppUrl": {
+              "$ref": "#/definitions/TranslatableUrl"
+            },
+            "iosAppUrl": {
+              "$ref": "#/definitions/TranslatableUrl"
+            },
             "ticketInfoUrl": {
               "$ref": "#/definitions/TranslatableUrl"
             },

--- a/orgs/schema-validation.json
+++ b/orgs/schema-validation.json
@@ -84,7 +84,10 @@
                 }
               }
             },
-            "ticketsUrl": {
+            "purchaseTicketUrl": {
+              "$ref": "#/definitions/TranslatableUrl"
+            },
+            "ticketInfoUrl": {
               "$ref": "#/definitions/TranslatableUrl"
             },
             "sitemapUrls": {

--- a/orgs/troms.json
+++ b/orgs/troms.json
@@ -27,7 +27,7 @@
       "name": "svipper.no",
       "href": "https://www.svipper.no/"
     },
-    "ticketsUrl": {
+    "ticketInfoUrl": {
       "en-US": "https://svipper.no/meny/billetter-og-priser/?sprak=3",
       "no": "https://svipper.no/meny/billetter-og-priser/",
       "default": "https://svipper.no/meny/billetter-og-priser/"

--- a/orgs/troms.json
+++ b/orgs/troms.json
@@ -32,11 +32,21 @@
       "no": "https://svipper.no/meny/billetter-og-priser/",
       "default": "https://svipper.no/meny/billetter-og-priser/"
     },
-
+    "purchaseTicketUrl": {
+      "en-US": "https://svipper.no/menu/tickets/how-to-buy-tickets/",
+      "no": "https://svipper.no/meny/billetter-og-priser/slik-kjoper-du-billett/",
+      "default": "https://svipper.no/meny/billetter-og-priser/slik-kjoper-du-billett/"
+    },
     "sitemapUrls": {
       "dev": "http://localhost:3000",
       "staging": "https://troms-staging.planner-web.mittatb.no/",
       "prod": "https://reise.svipper.no/"
+    },
+    "androidAppUrl": {
+      "default": "https://play.google.com/store/apps/details?id=PLACEHOLDER_TROMS"
+    },
+    "iosAppUrl": {
+      "default": "https://apps.apple.com/no/app/svipper/id6502283055"
     }
   },
   "journeyApiConfigurations": {

--- a/orgs/vkt.json
+++ b/orgs/vkt.json
@@ -34,7 +34,7 @@
       "name": "vkt.no",
       "href": "https://vkt.no"
     },
-    "ticketsUrl": {
+    "ticketInfoUrl": {
       "en-US": "https://www.vkt.no/english/",
       "nn": "https://www.vkt.no/reise/billetter-og-priser/",
       "default": "https://www.vkt.no/reise/billetter-og-priser/"

--- a/orgs/vkt.json
+++ b/orgs/vkt.json
@@ -39,10 +39,21 @@
       "nn": "https://www.vkt.no/reise/billetter-og-priser/",
       "default": "https://www.vkt.no/reise/billetter-og-priser/"
     },
+    "purchaseTicketUrl": {
+      "en-US": "https://www.vkt.no/english/",
+      "nn": "https://www.vkt.no/reise/billetter-og-priser/",
+      "default": "https://www.vkt.no/reise/billetter-og-priser/"
+    },
     "sitemapUrls": {
       "dev": "http://localhost:3000",
       "staging": "https://vkt-staging.planner-web.mittatb.no/",
       "prod": "https://reise.vkt.no/"
+    },
+    "androidAppUrl": {
+      "default": "https://play.google.com/store/apps/details?id=no.vfk.travelassistant"
+    },
+    "iosAppUrl": {
+      "default": "https://apps.apple.com/no/app/vkt/id6673909689"
     }
   },
   "journeyApiConfigurations": {

--- a/src/layouts/shared/footer.tsx
+++ b/src/layouts/shared/footer.tsx
@@ -81,10 +81,10 @@ export default function Footer({ withoutSettings = false }: FooterProps) {
                   </a>
                 </li>
               )}
-              {urls.ticketsUrl && (
+              {urls.ticketInfoUrl && (
                 <li>
                   <a
-                    href={getConfigUrl(urls.ticketsUrl, language)}
+                    href={getConfigUrl(urls.ticketInfoUrl, language)}
                     target="_blank"
                     rel="noreferrer"
                   >

--- a/src/modules/org-data/index.tsx
+++ b/src/modules/org-data/index.tsx
@@ -52,6 +52,8 @@ export type OrgData = {
     };
     ticketInfoUrl?: TranslatableUrl;
     purchaseTicketUrl?: TranslatableUrl;
+    androidAppUrl?: TranslatableUrl;
+    iosAppUrl?: TranslatableUrl;
 
     sitemapUrls: {
       dev: string;

--- a/src/modules/org-data/index.tsx
+++ b/src/modules/org-data/index.tsx
@@ -50,7 +50,8 @@ export type OrgData = {
       name: string;
       href: string;
     };
-    ticketsUrl?: TranslatableUrl;
+    ticketInfoUrl?: TranslatableUrl;
+    purchaseTicketUrl?: TranslatableUrl;
 
     sitemapUrls: {
       dev: string;

--- a/src/page-modules/assistant/details/trip-section/authority-section.tsx
+++ b/src/page-modules/assistant/details/trip-section/authority-section.tsx
@@ -7,18 +7,28 @@ import { AuthorityFragment } from '../../journey-gql/trip-with-details.generated
 import { ButtonLink } from '@atb/components/button';
 import { MonoIcon } from '@atb/components/icon';
 import { useTheme } from '@atb/modules/theme';
-import { getOrgData } from '@atb/modules/org-data';
+import { getConfigUrl, getOrgData } from '@atb/modules/org-data';
 
 export type AuthoritySectionProps = {
   authority: AuthorityFragment;
 };
 
 export function AuthoritySection({ authority }: AuthoritySectionProps) {
-  const { t } = useTranslation();
+  const { language, t } = useTranslation();
   const { color } = useTheme();
-  const { authorityId } = getOrgData();
+  const { authorityId, urls } = getOrgData();
 
-  if (!authority.url || authority.id === authorityId) return null;
+  const isCurrentAuthority = authority.id == authorityId;
+
+  if (!isCurrentAuthority && !authority.url) return null;
+
+  const url = isCurrentAuthority
+    ? urls.purchaseTicketUrl
+      ? getConfigUrl(urls.purchaseTicketUrl, language)
+      : undefined
+    : authority.url;
+
+  if (!url) return null;
 
   return (
     <TripRow>
@@ -27,7 +37,7 @@ export function AuthoritySection({ authority }: AuthoritySectionProps) {
           {t(PageText.Assistant.details.tripSection.buyTicketFrom)}
         </Typo.p>
         <ButtonLink
-          href={authority.url || '#'}
+          href={url}
           title={authority.name}
           icon={{ left: <MonoIcon icon="navigation/ExternalLink" /> }}
           mode="secondary"

--- a/src/page-modules/assistant/details/trip-section/authority-section.tsx
+++ b/src/page-modules/assistant/details/trip-section/authority-section.tsx
@@ -8,6 +8,12 @@ import { ButtonLink } from '@atb/components/button';
 import { MonoIcon } from '@atb/components/icon';
 import { useTheme } from '@atb/modules/theme';
 import { getConfigUrl, getOrgData } from '@atb/modules/org-data';
+import type { OrgData } from '@atb/modules/org-data';
+import type { Language } from '@atb/translations';
+import {
+  useDevicePlatform,
+  type DevicePlatform,
+} from '@atb/utils/use-device-platform';
 
 export type AuthoritySectionProps = {
   authority: AuthorityFragment;
@@ -17,15 +23,14 @@ export function AuthoritySection({ authority }: AuthoritySectionProps) {
   const { language, t } = useTranslation();
   const { color } = useTheme();
   const { authorityId, urls } = getOrgData();
+  const devicePlatform = useDevicePlatform();
 
   const isCurrentAuthority = authority.id == authorityId;
 
   if (!isCurrentAuthority && !authority.url) return null;
 
   const url = isCurrentAuthority
-    ? urls.purchaseTicketUrl
-      ? getConfigUrl(urls.purchaseTicketUrl, language)
-      : undefined
+    ? getTicketUrlForPlatform(devicePlatform, urls, language)
     : authority.url;
 
   if (!url) return null;
@@ -50,4 +55,22 @@ export function AuthoritySection({ authority }: AuthoritySectionProps) {
       </div>
     </TripRow>
   );
+}
+
+function getTicketUrlForPlatform(
+  platform: DevicePlatform,
+  urls: OrgData['urls'],
+  language: Language,
+): string | undefined {
+  const resolve = (url: OrgData['urls']['purchaseTicketUrl']) =>
+    url ? getConfigUrl(url, language) : undefined;
+
+  switch (platform) {
+    case 'android':
+      return resolve(urls.androidAppUrl) ?? resolve(urls.purchaseTicketUrl);
+    case 'ios':
+      return resolve(urls.iosAppUrl) ?? resolve(urls.purchaseTicketUrl);
+    default:
+      return resolve(urls.purchaseTicketUrl);
+  }
 }

--- a/src/utils/use-device-platform.ts
+++ b/src/utils/use-device-platform.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+
+export type DevicePlatform = 'android' | 'ios' | 'desktop';
+
+export function useDevicePlatform(): DevicePlatform {
+  const [platform, setPlatform] = useState<DevicePlatform>('desktop');
+
+  useEffect(() => {
+    setPlatform(getDevicePlatform());
+  }, []);
+
+  return platform;
+}
+
+function getDevicePlatform(): DevicePlatform {
+  if (typeof navigator === 'undefined') return 'desktop';
+
+  const ua = navigator.userAgent;
+
+  if (
+    /iPhone|iPad/.test(ua) ||
+    (/Macintosh/.test(ua) && 'ontouchend' in document)
+  ) {
+    return 'ios';
+  }
+
+  if (/Android/.test(ua)) return 'android';
+
+  return 'desktop';
+}


### PR DESCRIPTION
solves https://github.com/AtB-AS/kundevendt/issues/22106

- Adds a new url entry for orgData, `purchaseTicketUrl` which points to where to buy tickets.
- Adds 2 new url entry for orgData, `androidAppUrl` and `iosAppUrl` which points to the app link in Android or iOS.
- Renames`ticketUrl` to `ticketInfoUrl` since it points to ticket information.
- Modifies `AuthoritySection`:
  - If `authority.id == authorityId`, show the component, and use the following alternatives as the link:
    - If user-agent is web browser (PC/Laptop/Mac), `purchaseTicketUrl`
    - If user-agent is Android device, `androidAppUrl` 
    - If user-agent is iOS device, `iosAppUrl`
  - if `authority.id != authorityId` and `authority.url` exists, show the component, use `authority.url` as link.
  - if `url == undefined` (uses `purchaseTicketUrl` if `authority.id == authorityId` OR uses `authority.url` if `authority.id != authorityId`) then don't show the component (return null early)
- Adds a hook to check the userAgent `use-device-platform.ts` 
- Added URL values to all OMS, feel free to suggest correct URL(s)!
 
When the OMS wants to update the URL, just edit the relevant JSON files with the correct link and create a new release.