### PR TITLE
feat: change the purchase link display to use app name instead of authority name

### DIFF
--- a/src/page-modules/assistant/details/trip-section/authority-section.tsx
+++ b/src/page-modules/assistant/details/trip-section/authority-section.tsx
@@ -43,7 +43,11 @@ export function AuthoritySection({ authority }: AuthoritySectionProps) {
         </Typo.p>
         <ButtonLink
           href={url}
-          title={authority.name}
+          title={
+            isCurrentAuthority && devicePlatform !== 'desktop'
+              ? t(PageText.Assistant.details.tripSection.appName)
+              : authority.name
+          }
           icon={{ left: <MonoIcon icon="navigation/ExternalLink" /> }}
           mode="secondary"
           backgroundColor={color.background.neutral[0]}

--- a/src/translations/pages/assistant.ts
+++ b/src/translations/pages/assistant.ts
@@ -547,6 +547,7 @@ const AssistantInternal = {
         'Ticket can be bought from',
         'Billett kan kjøpast frå',
       ),
+      appName: _('AtB-appen', 'AtB app', 'AtB-appen'),
     },
     ticketBooking: {
       globalMessage: _(
@@ -579,6 +580,9 @@ export const Assistant = orgSpecificTranslations(AssistantInternal, {
           'Reisa krev billett som ikkje er tilgjengeleg i denne appen, eller som må kjøpast frå eit anna selskap enn Reis Nordland.',
         ),
       },
+      tripSection: {
+        appName: _('Reis-appen', 'Reis app', 'Reis-appen'),
+      },
     },
   },
   fram: {
@@ -601,6 +605,9 @@ export const Assistant = orgSpecificTranslations(AssistantInternal, {
           'Reisa krev billett som ikkje er tilgjengeleg i denne appen, eller som må kjøpast frå eit anna selskap enn FRAM.',
         ),
       },
+      tripSection: {
+        appName: _('FRAM-appen', 'FRAM app', 'FRAM-appen'),
+      },
     },
   },
   farte: {
@@ -622,6 +629,9 @@ export const Assistant = orgSpecificTranslations(AssistantInternal, {
           'This journey requires a ticket that is not available from this app, or must be purchased from a provider other than Farte.',
           'Reisa krev billett som ikkje er tilgjengeleg i denne appen, eller som må kjøpast frå eit anna selskap enn Farte.',
         ),
+      },
+      tripSection: {
+        appName: _('Farte-appen', 'Farte app', 'Farte-appen'),
       },
     },
   },
@@ -646,10 +656,20 @@ export const Assistant = orgSpecificTranslations(AssistantInternal, {
           'Denne reisa inkluderer transport som ikkje vert tilbydd av VKT. VKT sel per i dag berre billettar til lokalbuss. Billett til annan transport må kjøpast via nettside/app til det aktuelle transportselskapet.',
         ),
       },
+      tripSection: {
+        appName: _('VKT-appen', 'VKT app', 'VKT-appen'),
+      },
     },
     trip: {
       tripPattern: {
         quayPublicCodePrefix: _(' - Spor ', ' - Track ', ' - Spor '),
+      },
+    },
+  },
+  troms: {
+    details: {
+      tripSection: {
+        appName: _('Svipper-appen', 'Svipper app', 'Svipper-appen'),
       },
     },
   },


### PR DESCRIPTION
Change display name of links to purchase ticket when opened from iOS/Android devices, instead of showing **Authority name**, it should now say **AppName**

<img width="350" alt="image" src="https://github.com/user-attachments/assets/9e88bc76-d224-470b-a697-5b9bddebba52" />

<img width="350" alt="image" src="https://github.com/user-attachments/assets/a5405ff3-600e-4510-bd75-75bc45a2f986" />
