### PR TITLE
chore: update default transfer slack FRAM to 2 minutes (120 seconds)

### DIFF
--- a/orgs/fram.json
+++ b/orgs/fram.json
@@ -61,6 +61,6 @@
     "waitReluctance": 1.0,
     "walkingReluctance": 4.0,
     "transferPenalty": 0,
-    "defaultTransferSlack": 2
+    "defaultTransferSlack": 120
   }
 }


### PR DESCRIPTION
Fix oopsie from https://github.com/AtB-AS/planner-web/pull/714