### PR TITLE
fix: empty referer when opening details pages

### DIFF
--- a/src/modules/cookies/index.tsx
+++ b/src/modules/cookies/index.tsx
@@ -15,7 +15,7 @@ export type { InitialCookieData };
 export type GlobalCookiesData = {
   initialCookies: InitialCookieData;
   headersAcceptLanguage: string;
-  referer: string;
+  referer: string | null;
 };
 export function getGlobalCookies(req?: {
   cookies: NextApiRequestCookies;
@@ -30,6 +30,6 @@ export function getGlobalCookies(req?: {
       language: req?.cookies[LANGUAGE_COOKIE_NAME] ?? null,
     },
     headersAcceptLanguage: req?.headers['accept-language'] ?? '',
-    referer: req?.headers.referer ?? '',
+    referer: req?.headers.referer ?? null,
   };
 }

--- a/src/page-modules/departures/__tests__/departure.test.tsx
+++ b/src/page-modules/departures/__tests__/departure.test.tsx
@@ -47,7 +47,7 @@ describe('departure page', function () {
         darkmode: null,
         language: null,
       },
-      referer: '',
+      referer: null,
     };
 
     const gqlClient: ExternalClient<


### PR DESCRIPTION
getGlobalCookies returned '' for a missing Referer header, which slipped
past the `referer ?? '/fallback'` checks in assistant and departures
detail pages and produced an empty href. Return null instead so the
nullish coalescing fallback fires.

This make hrefs like these (`assistant/details/index.tsx:27`) work as intended:
`href={referer ?? '/assistant'}`
