### PR TITLE
feat: Use browser back behaviour for in-app back button

### DIFF
--- a/src/modules/cookies/index.tsx
+++ b/src/modules/cookies/index.tsx
@@ -15,7 +15,6 @@ export type { InitialCookieData };
 export type GlobalCookiesData = {
   initialCookies: InitialCookieData;
   headersAcceptLanguage: string;
-  referer: string | null;
 };
 export function getGlobalCookies(req?: {
   cookies: NextApiRequestCookies;
@@ -30,6 +29,5 @@ export function getGlobalCookies(req?: {
       language: req?.cookies[LANGUAGE_COOKIE_NAME] ?? null,
     },
     headersAcceptLanguage: req?.headers['accept-language'] ?? '',
-    referer: req?.headers.referer ?? null,
   };
 }

--- a/src/page-modules/assistant/details/index.tsx
+++ b/src/page-modules/assistant/details/index.tsx
@@ -1,31 +1,30 @@
-import { PageText, useTranslation } from '@atb/translations';
+import { useTranslation } from '@atb/translations';
+import dictionary from '@atb/translations/dictionary';
 import { MonoIcon } from '@atb/components/icon';
 import style from './details.module.css';
-import { ButtonLink } from '@atb/components/button';
+import { Button } from '@atb/components/button';
 import { ExtendedTripPatternWithDetailsType } from '@atb/page-modules/assistant';
 import { AssistantDetailsHeader } from '@atb/page-modules/assistant/details/details-header';
 import { AssistantDetailsBody } from '@atb/page-modules/assistant/details-body';
+import { useGoBack } from '@atb/utils/use-go-back';
 
 export type AssistantDetailsProps = {
   tripPatterns: ExtendedTripPatternWithDetailsType[];
-  referer?: string;
 };
 
-export function AssistantDetails({
-  tripPatterns,
-  referer,
-}: AssistantDetailsProps) {
+export function AssistantDetails({ tripPatterns }: AssistantDetailsProps) {
   const { t } = useTranslation();
+  const goBack = useGoBack();
   if (!tripPatterns.length) return null;
   const tripPattern = tripPatterns[0];
 
   return (
     <div className={style.container}>
       <div className={style.headerContainer}>
-        <ButtonLink
+        <Button
           mode="transparent"
-          href={referer ?? '/assistant'}
-          title={t(PageText.Assistant.details.header.backLink)}
+          onClick={goBack}
+          title={t(dictionary.back)}
           icon={{ left: <MonoIcon icon="navigation/ArrowLeft" /> }}
         />
         <AssistantDetailsHeader tripPattern={tripPattern} />

--- a/src/page-modules/departures/__tests__/departure-details.test.tsx
+++ b/src/page-modules/departures/__tests__/departure-details.test.tsx
@@ -1,9 +1,11 @@
 import { serviceJourneyFixture } from './service-journey-data.fixture';
 import { cleanup, render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import { DeparturesDetails } from '../details';
 import { GlobalMessageContextProvider } from '@atb/modules/global-messages';
+
+vi.mock('next/router', () => require('next-router-mock'));
 
 afterEach(function () {
   cleanup();

--- a/src/page-modules/departures/__tests__/departure.test.tsx
+++ b/src/page-modules/departures/__tests__/departure.test.tsx
@@ -47,7 +47,6 @@ describe('departure page', function () {
         darkmode: null,
         language: null,
       },
-      referer: null,
     };
 
     const gqlClient: ExternalClient<

--- a/src/page-modules/departures/details/index.tsx
+++ b/src/page-modules/departures/details/index.tsx
@@ -1,4 +1,4 @@
-import { ButtonLink } from '@atb/components/button';
+import { Button } from '@atb/components/button';
 import { ColorIcon, MonoIcon } from '@atb/components/icon';
 import LineChip from '@atb/components/line-chip';
 import { Map } from '@atb/components/map';
@@ -7,6 +7,7 @@ import { Typo } from '@atb/components/typography';
 import { SituationMessageBox, filterNotices } from '@atb/modules/situations';
 import { useRealtimeText } from '@atb/modules/trip-details';
 import { PageText, useTranslation } from '@atb/translations';
+import dictionary from '@atb/translations/dictionary';
 import style from './details.module.css';
 import { EstimatedCallRows } from './estimated-call-rows';
 import { addMetadataToEstimatedCalls } from './utils';
@@ -17,19 +18,19 @@ import {
 } from '@atb/modules/global-messages';
 import { ServiceJourneyType } from '@atb/page-modules/departures/types.ts';
 import { TransportMode } from '@atb/modules/graphql-types/journeyplanner-types_v3.generated.ts';
+import { useGoBack } from '@atb/utils/use-go-back';
 
 export type DeparturesDetailsProps = {
   fromQuayId?: string;
   serviceJourney: ServiceJourneyType;
-  referer?: string;
 };
 
 export function DeparturesDetails({
   fromQuayId,
   serviceJourney,
-  referer,
 }: DeparturesDetailsProps) {
   const { t } = useTranslation();
+  const goBack = useGoBack();
   const focusedCall =
     serviceJourney.estimatedCalls.find((call) => call.quay.id === fromQuayId) ||
     serviceJourney.estimatedCalls[0];
@@ -71,21 +72,13 @@ export function DeparturesDetails({
     .map((s) => s.situationNumber)
     .filter((s): s is string => !!s);
 
-  const backLink = referer?.includes('departures/')
-    ? `/departures/${focusedCall.quay.stopPlace?.id}`
-    : referer;
-
   return (
     <section className={style.container}>
       <div className={style.headerContainer}>
-        <ButtonLink
+        <Button
           mode="transparent"
-          href={backLink ?? '/'}
-          title={
-            backLink?.includes('departures/')
-              ? t(PageText.Departures.details.backToDepartures)
-              : t(PageText.Departures.details.backToAssistant)
-          }
+          onClick={goBack}
+          title={t(dictionary.back)}
           icon={{ left: <MonoIcon icon="navigation/ArrowLeft" /> }}
         />
         <div className={style.header}>

--- a/src/translations/dictionary.ts
+++ b/src/translations/dictionary.ts
@@ -55,6 +55,7 @@ const dictionary = {
   a11yRouteTimePrefix: _('rutetid ', 'route time ', `rutetid `),
   missingRealTimePrefix: _('ca. ', 'ca. ', `ca. `),
   readMore: _('Les mer', 'Read more', `Les meir`),
+  back: _('Tilbake', 'Back', 'Tilbake'),
   close: _('Lukk', 'Close', 'Lukk'),
   listConcatWord: _('og', 'and', 'og'),
   via: _('via', 'via', 'via'),

--- a/src/translations/pages/assistant.ts
+++ b/src/translations/pages/assistant.ts
@@ -406,11 +406,6 @@ const AssistantInternal = {
       'Vi kunne ikkje oppdatere reiseforslaget ditt. Det kan hende reisa har endra seg eller er utdatert.',
     ),
     header: {
-      backLink: _(
-        'Tilbake til reiseforslag',
-        'Back to travel suggestions',
-        'Tilbake til reiseforslag',
-      ),
       title: _('Reisedetaljer', 'Trip details', 'Reisedetaljar'),
       titleFromTo: ({
         fromName,

--- a/src/translations/pages/departures.ts
+++ b/src/translations/pages/departures.ts
@@ -108,16 +108,6 @@ const DeparturesInternal = {
     },
   },
   details: {
-    backToDepartures: _(
-      'Tilbake til avganger',
-      'Back to departures',
-      'Tilbake til avgangar',
-    ),
-    backToAssistant: _(
-      'Tilbake til reiseforslag',
-      'Back to travel suggestion',
-      'Tilbake til reiseforslag',
-    ),
     quayPublicCodePrefix: _('', '', ''),
     lastPassedStop: (stopPlaceName: string, time: string) =>
       _(

--- a/src/utils/use-go-back.ts
+++ b/src/utils/use-go-back.ts
@@ -1,0 +1,12 @@
+import { useRouter } from 'next/router';
+
+export function useGoBack() {
+  const router = useRouter();
+  return () => {
+    if (window.history.length > 1) {
+      window.history.back();
+    } else {
+      router.push('/');
+    }
+  };
+}


### PR DESCRIPTION
There was some bugs with the current back behaviour in the app, and
it was decided to go for a good enough simple solution. The in-app
back button now just does a browser back action. If there is no
browser history, then it just goes to the root page.

The in-app back buttons now just say "back" since we don't evaluate
or know where they will actually go to.
