### PR TITLE
feat: Improve how transport mode descriptions are shown

### DIFF
--- a/src/modules/transport-mode/filter/filter.module.css
+++ b/src/modules/transport-mode/filter/filter.module.css
@@ -50,9 +50,15 @@
   cursor: pointer;
   display: flex;
   gap: token('spacing.small');
-  align-items: center;
+  align-items: flex-start;
   border: 1px solid token('color.background.neutral.3.background');
-  height: 2.25rem;
+  min-height: 2.25rem;
+}
+
+.labelTexts {
+  display: flex;
+  flex-direction: column;
+  gap: token('spacing.xSmall');
 }
 
 .transportMode input {
@@ -67,9 +73,7 @@
 }
 
 .infoText {
-  color: token('color.foreground.dynamic.disabled');
-  opacity: 0.75;
-  max-width: 10rem;
+  color: token('color.interactive.2.default.foreground.secondary');
 }
 
 .transportMode input:focus-visible ~ label {
@@ -84,12 +88,12 @@
   background-color: token('color.interactive.2.active.background');
   border: 1px solid token('color.interactive.2.outline.background');
 }
-.transportMode input:hover ~ label .checkboxBackground {
-  background-color: token('color.interactive.2.default.background');
+.transportMode input[type='checkbox']:checked ~ label .infoText {
+  color: token('color.interactive.2.active.foreground.secondary');
 }
 .transportMode input[type='checkbox']:checked:hover ~ label {
   background-color: token('color.interactive.2.hover.background');
 }
-.transportMode input[type='checkbox']:checked ~ label .checkboxBackground {
-  background-color: token('color.interactive.2.active.background');
+.transportMode input[type='checkbox']:hover ~ label .infoText {
+  color: token('color.interactive.2.hover.foreground.secondary');
 }

--- a/src/modules/transport-mode/filter/filter.tsx
+++ b/src/modules/transport-mode/filter/filter.tsx
@@ -18,7 +18,7 @@ export default function TransportModeFilter({
   onChange,
   data,
 }: TransportModeFilterProps) {
-  const { t, language } = useTranslation();
+  const { t } = useTranslation();
   const isFlexibleTransportEnabled = false; //remove when AtB-bestill will be enabled in tripPatterns
 
   // Local filter state used for updating the checkbox states before the URL
@@ -110,12 +110,6 @@ export default function TransportModeFilter({
                     }
                   }}
                 />
-
-                {option.description && (
-                  <Typo.p textType="body__xs" className={style.infoText}>
-                    {getTextForLanguage(option.description, language) ?? ''}
-                  </Typo.p>
-                )}
               </li>
             );
           })}
@@ -133,6 +127,7 @@ type FilterOptionProps = {
 function FilterOption({ option, selected, onChange }: FilterOptionProps) {
   const { language } = useTranslation();
   const text = getTextForLanguage(option.text, language);
+  const description = getTextForLanguage(option.description, language);
 
   return (
     <div className={style.transportModeContainer}>
@@ -159,7 +154,14 @@ function FilterOption({ option, selected, onChange }: FilterOptionProps) {
           isFlexible={option.id == 'flexibleTransport'}
           size="small"
         />
-        <span id={`label-${option.id}`}>{text}</span>
+        <span className={style.labelTexts}>
+          <span id={`label-${option.id}`}>{text}</span>
+          {description && (
+            <Typo.span textType="body__xs" className={style.infoText}>
+              {description}
+            </Typo.span>
+          )}
+        </span>
       </label>
     </div>
   );


### PR DESCRIPTION
**Before/After**

<img width="350" src="https://github.com/user-attachments/assets/e595d82f-30c2-4ae6-8114-6fd126dd8d21" />
<img width="350" src="https://github.com/user-attachments/assets/f99c3917-9ffa-4080-acab-f5bc3b620cbd" />
