### PR TITLE
fix: message box border type

### DIFF
--- a/src/components/message-box/message-box.module.css
+++ b/src/components/message-box/message-box.module.css
@@ -2,6 +2,7 @@
   display: flex;
   padding: token('spacing.large');
   gap: token('spacing.medium');
+  border: token('border.width.medium') solid;
   align-items: flex-start;
 }
 .borderRadius {


### PR DESCRIPTION
Fixes something that seems to be an regression in message box appearance after updating the theme, where they didn't have border anymore.

**Before/After**
<div>
<img width="350" src="https://github.com/user-attachments/assets/dda34031-b9a7-4352-9c6c-bc73f70f7640" />
<img width="350" src="https://github.com/user-attachments/assets/36c8c0a1-8c97-43da-9599-ad500a74815e" />
</div>

### Acceptance criteria
- [x] Message boxes have border (unless subtle)