### PR TITLE
fix: Transport mode filter centering

### DIFF
--- a/src/modules/transport-mode/filter/filter.module.css
+++ b/src/modules/transport-mode/filter/filter.module.css
@@ -55,10 +55,15 @@
   min-height: 2.25rem;
 }
 
+.checkBoxIcon {
+  margin-top: 0.125rem;
+}
+
 .labelTexts {
   display: flex;
   flex-direction: column;
   gap: token('spacing.xSmall');
+  margin-top: 0.125rem;
 }
 
 .transportMode input {

--- a/src/modules/transport-mode/filter/filter.tsx
+++ b/src/modules/transport-mode/filter/filter.tsx
@@ -146,7 +146,9 @@ function FilterOption({ option, selected, onChange }: FilterOptionProps) {
         aria-hidden
         className={style.transportModeElement}
       >
-        <CheckBoxIcon checked={selected} />
+        <span className={style.checkBoxIcon}>
+          <CheckBoxIcon checked={selected} />
+        </span>
 
         <TransportIcon
           transportMode={option.icon.transportMode}


### PR DESCRIPTION
Fixes this comment:
https://github.com/AtB-AS/planner-web/pull/724#issuecomment-4629110581

This was fixed by just adding top margins to icon and text. I tried to look into a more dynamic fix which automatically centered in relation to the transport icon height, but the resulting code changes was quite complex and not worth the effort.

**Before/After**
<img width="800" src="https://github.com/user-attachments/assets/c6bcc10d-2df0-44c9-b398-1ed2e061d6ed" />
<img width="800" src="https://github.com/user-attachments/assets/d465cc5b-5f7b-4e63-8f12-a5afcd43517d" />

