### PR TITLE
fix: Correct text color on buttons

### DIFF
--- a/src/components/button/button.module.css
+++ b/src/components/button/button.module.css
@@ -77,14 +77,14 @@
 /* Primary */
 .button--primary,
 .button--primary:visited {
-  color: token('color.foreground.inverse.primary');
+  color: token('color.interactive.0.default.foreground.primary');
   background-color: token('color.interactive.0.default.background');
 }
 
 .button--primary:not(:disabled):hover,
 .button--primary:not(:disabled):active,
 .button--primary.button--state_active {
-  color: token('color.foreground.dynamic.primary');
+  color: token('color.interactive.0.active.foreground.primary');
   background-color: token('color.interactive.0.active.background');
 }
 


### PR DESCRIPTION
InteractiveColor was not used correctly, which made the text color
on primary buttons for Fram not have acceptable contrast against
background.

**Before/After**
<img width="800" src="https://github.com/user-attachments/assets/9e40c6dd-ba4f-4d6e-be32-65e59b0df67e" />
<img width="800" src="https://github.com/user-attachments/assets/6f13a94f-f06d-4b05-9a22-a8a9091827ec" />

