### PR TITLE
feat: support for authority fare url

### DIFF
--- a/src/page-modules/assistant/details/trip-section/authority-section.tsx
+++ b/src/page-modules/assistant/details/trip-section/authority-section.tsx
@@ -26,12 +26,13 @@ export function AuthoritySection({ authority }: AuthoritySectionProps) {
   const devicePlatform = useDevicePlatform();
 
   const isCurrentAuthority = authority.id == authorityId;
+  const authorityFareUrl = authority.fareUrl ?? authority.url;
 
-  if (!isCurrentAuthority && !authority.url) return null;
+  if (!isCurrentAuthority && !authorityFareUrl) return null;
 
   const url = isCurrentAuthority
     ? getTicketUrlForPlatform(devicePlatform, urls, language)
-    : authority.url;
+    : authorityFareUrl;
 
   if (!url) return null;
 

--- a/src/page-modules/assistant/journey-gql/trip-with-details.gql
+++ b/src/page-modules/assistant/journey-gql/trip-with-details.gql
@@ -172,6 +172,7 @@ fragment authority on Authority {
   id
   name
   url
+  fareUrl
 }
 
 fragment notice on Notice {


### PR DESCRIPTION
In the original issue it was requested a link to a more ticket-related url. This is supported by Entur domain model with the fareUrl field on Authority. 

This fareUrl field [is documented](https://github.com/opentripplanner/OpenTripPlanner/blob/4718e3f26439f015812aae31161165b0d864323e/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls#L117) as "URL to a web page which has information of fares used by this agency", which can be translated to "URL til en nettside med informasjon om billettprisene til dette agentselskapet."

As of now the fareUrl fields isn't populated by any transport company from what I can see, but at least there is support now in planner-web if they populate it. If it isn't populated, the logic works as before, fallbacking to the transport company main url. 