### PR TITLE
fix: make trip duration rounding same as app

### DIFF
--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -374,18 +374,11 @@ export function formatTripDuration(
   originalArrivalTimeISO: string,
   language: Language,
 ) {
-  const regex = /T(\d{2}:\d{2}):\d{2}\+/;
   const departure = formatToClock(originalDepartureTimeISO, language, 'floor');
   const arrival = formatToClock(originalArrivalTimeISO, language, 'ceil');
 
-  const departureTime = originalDepartureTimeISO.replace(
-    regex,
-    `T${departure}:00+`,
-  );
-  const arrivalTime = originalArrivalTimeISO.replace(regex, `T${arrival}:00+`);
-
   const duration = secondsToDuration(
-    secondsBetween(departureTime, arrivalTime),
+    secondsBetween(originalDepartureTimeISO, originalArrivalTimeISO),
     language,
   );
 


### PR DESCRIPTION
In general, trip durations were slightly longer in TPW than in app. This change makes app logic the source of truth, and does the same calculation in TPW, which is just rounding the time between departure and arrival to the nearest minute without any flooring first.