### PR TITLE
fix: staging crash for non-AtB orgs caused by docker build silently shipping only atb

### DIFF
--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # This script prepares and builds the application for a organization
 # by setting up the environment, building the application, and organizing the output 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+set -e
 
-# This script prepares and organizes the application for different organizations 
+# This script prepares and organizes the application for different organizations
 # by setting up the environment, building the application, and organizing the output 
 # into the 'dist' directory with separate subdirectories for each organization.
 

--- a/src/components/map/dynamic-map.tsx
+++ b/src/components/map/dynamic-map.tsx
@@ -1,0 +1,10 @@
+import dynamic from 'next/dynamic';
+import MapLoading from './map-loading';
+
+// Mapbox GL can't run on the server, so the map must only be loaded on the
+// client. Kept in its own module so both the package index and internal
+// components (e.g. map-with-header) can use it without circular imports.
+export const Map = dynamic(() => import('./map'), {
+  ssr: false,
+  loading: () => <MapLoading />,
+});

--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -1,15 +1,9 @@
-import dynamic from 'next/dynamic';
-import MapLoading from './map-loading';
-
 export { MapWithHeader } from './map-with-header';
 export { MapHeader } from './map-header';
 
 export * from './utils';
 export * from './types';
 
-export const Map = dynamic(() => import('./map'), {
-  ssr: false,
-  loading: () => <MapLoading />,
-});
+export { Map } from './dynamic-map';
 
 export { getStaticMapUrl } from './static-map';

--- a/src/components/map/map-with-header.tsx
+++ b/src/components/map/map-with-header.tsx
@@ -1,7 +1,7 @@
 import style from './map.module.css';
 import { MapHeader, MapHeaderProps } from './map-header';
 import { MapProps } from './map';
-import { Map } from '.';
+import { Map } from './dynamic-map';
 
 export type MapWithHeaderProps = MapHeaderProps & MapProps;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,5 @@
     "types": ["node", "vite/client"]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules", "e2e-tests/k6"]
+  "exclude": ["node_modules", "e2e-tests/k6", "dist"]
 }


### PR DESCRIPTION
## What

All non-AtB tenants crash-loop in staging with `Cannot find module './dist/nfk/standalone/server.js'` — the Docker image has shipped with only `dist/atb` since #718, while CI stayed green.

## Root cause

1. Next's standalone file tracing copies the raw source of `next/dynamic` targets into the build output — #718 made it copy `src/components/map/map.tsx` into `dist/<org>/standalone/src/`, without its `./utils` import.
2. The Docker build compiles all six orgs sequentially in the same directory, and `tsconfig.json` didn't exclude `dist/`. From the second org on, the type check picked up the previous org's orphaned `map.tsx` and failed: `Cannot find module './utils'`. Only atb (built first, empty `dist/`) succeeded.
3. `build-docker.sh` has no `set -e` and ends with `cp` commands that succeed anyway — so the build failure was swallowed, CI stayed green, and the image shipped without the other orgs.

## Changes

- `tsconfig.json`: exclude `dist`. Build artifacts should never be type-checked; this decouples the sequential org builds and fixes the crash.
- `scripts/build-docker.sh` + `scripts/build.sh`: `set -e`, so a failed org build fails the Docker build instead of shipping a broken image.
- `src/components/map/dynamic-map.tsx`: the `dynamic(() => import('./map'), { ssr: false })` wrapper moved out of `index.tsx`, removing the circular `index ↔ map-with-header` import from #718. Behavior unchanged.

## Notes for reviewers

The tsconfig exclude is the load-bearing fix: any dynamic import produces the same orphaned source shard (verified — it still appears after the refactor), so fixing the import alone wouldn't prevent recurrence. Keeping `next/dynamic` is deliberate: mapbox-gl is a 1.5 MB chunk only used on detail views and must not be SSR'd. Verified locally by reproducing the CI sequence (atb then nfk build): the nfk build now succeeds and its standalone server boots.