### PR TITLE
feat: add trip inspector and authority filter to dev mode trip patterns

### DIFF
--- a/src/page-modules/dev/trip-inspector/index.tsx
+++ b/src/page-modules/dev/trip-inspector/index.tsx
@@ -1,0 +1,70 @@
+import type { ExtendedTripPatternWithDetailsType } from '@atb/page-modules/assistant';
+import { currentOrg } from '@atb/modules/org-data';
+import style from './trip-inspector.module.css';
+
+export type TripInspectorProps = {
+  tripPattern: ExtendedTripPatternWithDetailsType;
+  /** Entrance animation delay in seconds, matching the TripPattern stagger. */
+  delay?: number;
+};
+
+/**
+ * Dev-mode inspector panel showing the data behind a trip pattern. Add a
+ * new section (label + content) per future data point (fares, operators,
+ * ...).
+ */
+export function TripInspector({ tripPattern, delay = 0 }: TripInspectorProps) {
+  const zones = getTripPatternZones(tripPattern);
+
+  return (
+    <aside
+      className={style.tripInspector}
+      style={{ animationDelay: `${delay}s` }}
+    >
+      <span className={style.header}>Inspector</span>
+      <div className={style.section}>
+        <span className={style.sectionLabel}>Zones</span>
+        {zones.length > 0 ? (
+          <div className={style.chips}>
+            {zones.map((zone) => (
+              <span key={zone.id} className={style.zoneChip}>
+                {zone.name ? `${zone.name} (${zone.id})` : zone.id}
+              </span>
+            ))}
+          </div>
+        ) : (
+          <span className={style.empty}>none</span>
+        )}
+      </div>
+    </aside>
+  );
+}
+
+/**
+ * Collects the unique fare zones (ids containing "ATB:FareZone") the trip
+ * passes through, in the order they are first encountered, from the quays of
+ * each leg's from/to place. Deduped by zone id.
+ */
+function getTripPatternZones(
+  tripPattern: ExtendedTripPatternWithDetailsType,
+): { id: string; name?: string }[] {
+  const zones: { id: string; name?: string }[] = [];
+  const seen = new Set<string>();
+
+  for (const leg of tripPattern.legs) {
+    for (const place of [leg.fromPlace, leg.toPlace]) {
+      for (const zone of place?.quay?.tariffZones ?? []) {
+        if (
+          zone?.id &&
+          zone.id.includes(`${currentOrg.toUpperCase()}:FareZone`) &&
+          !seen.has(zone.id)
+        ) {
+          seen.add(zone.id);
+          zones.push({ id: zone.id, name: zone.name ?? undefined });
+        }
+      }
+    }
+  }
+
+  return zones;
+}

--- a/src/page-modules/dev/trip-inspector/trip-inspector.module.css
+++ b/src/page-modules/dev/trip-inspector/trip-inspector.module.css
@@ -1,0 +1,95 @@
+/* Inspector panel beside each trip pattern: a light "technical readout"
+   panel in the page's theme, set apart from the product card by its mono
+   typography and instrument detailing rather than by tone. Holds one
+   .section (sub-header + content) per data point; meant to grow with more
+   sections over time. */
+.tripInspector {
+  --dev-bg: var(--color-background-neutral-0-background, #ffffff);
+  --dev-line: var(--color-background-neutral-2-background, #e1e8eb);
+  --dev-text: var(--color-background-neutral-0-foreground-primary, #1a2326);
+  --dev-dim: var(--color-background-neutral-0-foreground-secondary, #415058);
+  --dev-accent: var(--color-border-focus-background, #0959aa);
+
+  flex: 0 0 220px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+  padding: 0.875rem 0.75rem 0.75rem;
+  border-radius: 2px;
+  border: 1px solid var(--dev-line);
+  color: var(--dev-text);
+  background-color: var(--dev-bg);
+  font-family:
+    ui-monospace, 'SF Mono', 'Cascadia Code', Menlo, Consolas, monospace;
+  font-size: 0.75rem;
+  animation: inspectorIn 0.35s ease both;
+  transition: border-color 0.15s ease;
+}
+
+.tripInspector:hover {
+  border-color: var(--dev-accent);
+}
+
+@keyframes inspectorIn {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tripInspector {
+    animation: none;
+  }
+}
+
+.header {
+  color: var(--dev-text);
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  padding-bottom: 0.3rem;
+  border-bottom: 1px solid var(--dev-line);
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.sectionLabel {
+  color: var(--dev-dim);
+  font-size: 0.65rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.empty {
+  color: var(--dev-dim);
+}
+
+.empty::before {
+  content: '— ';
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+
+.zoneChip {
+  padding: 0.2rem 0.5rem;
+  border-radius: 2px;
+  border: 1px solid color-mix(in srgb, var(--dev-accent) 35%, var(--dev-bg));
+  background: color-mix(in srgb, var(--dev-accent) 9%, var(--dev-bg));
+  color: color-mix(in srgb, var(--dev-accent) 70%, var(--dev-text));
+  letter-spacing: 0.02em;
+}

--- a/src/pages/dev/trip-pattern.module.css
+++ b/src/pages/dev/trip-pattern.module.css
@@ -7,28 +7,6 @@
   gap: 1.5rem;
 }
 
-.statusBar {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  padding: 0.75rem 1rem;
-  border-radius: 4px;
-  background: var(--color-background-neutral-1-background, #f5f5f5);
-  border: 1px solid var(--color-background-neutral-2-background, #e0e0e0);
-}
-
-.statusLabel {
-  font-weight: 600;
-}
-
-.statusEnabled {
-  color: green;
-}
-
-.statusDisabled {
-  color: #888;
-}
-
 .section {
   display: flex;
   flex-direction: column;
@@ -68,7 +46,26 @@
   box-sizing: border-box;
 }
 
-.transportModeFilter {
+.fieldBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+/* air between a white panel and the next block's title */
+.fieldBlock + .fieldBlock {
+  margin-top: 0.5rem;
+}
+
+.subLabel {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-background-neutral-0-foreground-secondary, #415058);
+}
+
+.fieldPanel {
   padding: 0.75rem 1rem;
   border: 1px solid var(--color-background-neutral-2-background, #e0e0e0);
   border-radius: 4px;
@@ -86,7 +83,7 @@
   font-size: 0.85rem;
 }
 
-.filterToggle {
+.fieldRow {
   display: flex;
   align-items: center;
   gap: 0.4rem;
@@ -95,18 +92,41 @@
   user-select: none;
 }
 
+.fieldRowLabel {
+  min-width: 5.5rem;
+}
+
+.select {
+  font: inherit;
+  font-size: 0.8rem;
+  padding: 0.25rem 0.4rem;
+  border: 1px solid var(--color-background-neutral-2-background, #ccc);
+  border-radius: 4px;
+  background: var(--color-background-neutral-0-background, #fff);
+  color: var(--color-background-neutral-0-foreground-primary, #000);
+}
+
 .tripPatterns {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
 }
 
-.zonesPassed {
+.tripPatternRow {
   display: flex;
-  flex-direction: column;
-  margin-top: 0.25rem;
-  font-size: 0.8rem;
-  color: var(--color-background-neutral-0-foreground, #555);
+  align-items: stretch;
+  gap: 0.75rem;
+}
+
+@media (max-width: 600px) {
+  .tripPatternRow {
+    flex-direction: column;
+  }
+}
+
+.tripPatternMain {
+  flex: 1;
+  min-width: 0;
 }
 
 .rawResponse {

--- a/src/pages/dev/trip-pattern.tsx
+++ b/src/pages/dev/trip-pattern.tsx
@@ -1,7 +1,6 @@
 import DefaultLayout from '@atb/layouts/default';
 import { withGlobalData, type WithGlobalData } from '@atb/modules/global-data';
 import type { GetServerSideProps, NextPage } from 'next';
-import { setCookie } from 'cookies-next';
 import { useState, useEffect } from 'react';
 import { DEV_MODE_COOKIE_NAME } from '@atb/modules/cookies/constants';
 import { TripsWithDetailsDocument } from '@atb/page-modules/assistant/journey-gql/trip-with-details.generated';
@@ -18,7 +17,14 @@ import useSWRImmutable from 'swr/immutable';
 import { uniq } from 'lodash';
 import dynamic from 'next/dynamic';
 import style from './trip-pattern.module.css';
-import { currentOrg, getOrgData } from '@atb/modules/org-data';
+import { currentOrg } from '@atb/modules/org-data';
+import { TripInspector } from '@atb/page-modules/dev/trip-inspector';
+import atb from '../../../orgs/atb.json';
+import fram from '../../../orgs/fram.json';
+import nfk from '../../../orgs/nfk.json';
+import troms from '../../../orgs/troms.json';
+import vkt from '../../../orgs/vkt.json';
+import farte from '../../../orgs/farte.json';
 
 const GraphQLEditor = dynamic(() => import('@atb/components/graphql-editor'), {
   ssr: false,
@@ -264,34 +270,12 @@ function buildDefaultInlinedQuery(fragments: string): string {
 ${fragments}`;
 }
 
-/**
- * Collects the unique fare zones (ids containing "ATB:FareZone") the trip
- * passes through, in the order they are first encountered, from the quays of
- * each leg's from/to place. Deduped by zone id.
- */
-function getTripPatternZones(
-  tripPattern: ExtendedTripPatternWithDetailsType,
-): { id: string; name?: string }[] {
-  const zones: { id: string; name?: string }[] = [];
-  const seen = new Set<string>();
-
-  for (const leg of tripPattern.legs) {
-    for (const place of [leg.fromPlace, leg.toPlace]) {
-      for (const zone of place?.quay?.tariffZones ?? []) {
-        if (
-          zone?.id &&
-          zone.id.includes(`${currentOrg.toUpperCase()}:FareZone`) &&
-          !seen.has(zone.id)
-        ) {
-          seen.add(zone.id);
-          zones.push({ id: zone.id, name: zone.name ?? undefined });
-        }
-      }
-    }
-  }
-
-  return zones;
-}
+// Authorities selectable in the dev config panel, the current org's first.
+const ALL_AUTHORITIES = [atb, nfk, fram, troms, vkt, farte]
+  .map((org) => ({ orgId: org.orgId, authorityId: org.authorityId }))
+  .sort((a, b) =>
+    a.orgId === currentOrg ? -1 : b.orgId === currentOrg ? 1 : 0,
+  );
 
 const DevTripPatternPage: NextPage<DevTripPatternPageProps> = (props) => {
   const { defaultGqlQuery, fragments } = props;
@@ -317,11 +301,12 @@ const DevTripPatternPage: NextPage<DevTripPatternPageProps> = (props) => {
   const [nextPageCursor, setNextPageCursor] = useState<string | null>(null);
   const [runCount, setRunCount] = useState(0);
   const [schema, setSchema] = useState<GraphQLSchema | undefined>(undefined);
-  // Server-side filter: whitelist the org's authority so the JourneyPlanner only
-  // returns own-operator trips (the ones the sales endpoint can price).
-  const [authorityOnly, setAuthorityOnly] = useState(false);
-
-  const { authorityId } = getOrgData();
+  // Server-side filter: whitelist a single authority so the JourneyPlanner
+  // only returns that operator's trips (e.g. the ones the sales endpoint can
+  // price).
+  const [authorityFilter, setAuthorityFilter] = useState<string | null>(null);
+  // Toggles the per-trip inspector panels in the results.
+  const [showInspector, setShowInspector] = useState(false);
 
   // Loaded the same way as the assistant layout so the available transport
   // modes match the real travel search filters.
@@ -413,11 +398,9 @@ const DevTripPatternPage: NextPage<DevTripPatternPageProps> = (props) => {
     setQueryText((prev) => patchQueryModes(prev, modesBlock));
   };
 
-  const onAuthorityOnlyChanged = (enabled: boolean) => {
-    setAuthorityOnly(enabled);
-    setQueryText((prev) =>
-      patchQueryAuthorities(prev, enabled ? authorityId : null),
-    );
+  const onAuthorityFilterChanged = (authority: string | null) => {
+    setAuthorityFilter(authority);
+    setQueryText((prev) => patchQueryAuthorities(prev, authority));
   };
 
   const onQueryTextChange = (text: string) => {
@@ -425,11 +408,6 @@ const DevTripPatternPage: NextPage<DevTripPatternPageProps> = (props) => {
     const { from, to } = parseLocationsFromQuery(text);
     setFromFeature(from);
     setToFeature(to);
-  };
-
-  const toggleDevMode = () => {
-    setCookie(DEV_MODE_COOKIE_NAME, 'false', { path: '/' });
-    window.location.reload();
   };
 
   const handleRun = () => runQuery(queryText);
@@ -441,7 +419,7 @@ const DevTripPatternPage: NextPage<DevTripPatternPageProps> = (props) => {
     setToFeature(locationToFeature(DEFAULT_TO));
     setTransportModeFilterState(null);
     setFilterResetNonce((n) => n + 1);
-    setAuthorityOnly(false);
+    setAuthorityFilter(null);
   };
 
   const handleLoadMore = async () => {
@@ -475,17 +453,6 @@ const DevTripPatternPage: NextPage<DevTripPatternPageProps> = (props) => {
   return (
     <DefaultLayout {...props} title="Dev: Trip Pattern">
       <div className={style.container}>
-        <div className={style.statusBar}>
-          <span className={style.statusLabel}>Dev mode:</span>
-          <span className={style.statusEnabled}>ENABLED</span>
-          <button
-            className={`${style.button} ${style.buttonSecondary}`}
-            onClick={toggleDevMode}
-          >
-            Disable
-          </button>
-        </div>
-
         <div className={style.section}>
           <span className={style.label}>Locations</span>
           <div className={style.searchRow}>
@@ -506,27 +473,56 @@ const DevTripPatternPage: NextPage<DevTripPatternPageProps> = (props) => {
           </div>
         </div>
 
-        {transportModeFilterData && (
-          <details className={style.section}>
-            <summary className={style.label}>Transport modes</summary>
-            <div className={style.transportModeFilter}>
-              <TransportModeFilter
-                key={filterResetNonce}
-                filterState={transportModeFilterState}
-                data={transportModeFilterData}
-                onChange={onTransportModeFilterChanged}
-              />
-            </div>
-          </details>
-        )}
-
-        <details className={style.section} open>
-          <summary className={style.label}>Query</summary>
+        <div className={style.section}>
+          <span className={style.label}>GraphQL</span>
           <GraphQLEditor
             value={queryText}
             onChange={onQueryTextChange}
             schema={schema}
           />
+        </div>
+
+        <details className={style.section}>
+          <summary className={style.label}>Query options</summary>
+          {transportModeFilterData && (
+            <div className={style.fieldBlock}>
+              <span className={style.subLabel}>Transport modes</span>
+              <div className={style.fieldPanel}>
+                <TransportModeFilter
+                  key={filterResetNonce}
+                  filterState={transportModeFilterState}
+                  data={transportModeFilterData}
+                  onChange={onTransportModeFilterChanged}
+                />
+              </div>
+            </div>
+          )}
+          <div className={style.fieldBlock}>
+            <span className={style.subLabel}>Authority</span>
+            <div
+              className={style.fieldPanel}
+              title="Injects whiteListed: { authorities: [...] } into the query — re-run to filter server-side"
+            >
+              <select
+                className={style.select}
+                value={authorityFilter ?? ''}
+                onChange={(e) =>
+                  onAuthorityFilterChanged(e.target.value || null)
+                }
+              >
+                <option value="">All authorities</option>
+                {ALL_AUTHORITIES.map((authority) => (
+                  <option
+                    key={authority.authorityId}
+                    value={authority.authorityId}
+                  >
+                    {authority.orgId.toUpperCase()} — {authority.authorityId}
+                    {authority.orgId === currentOrg ? ' (current)' : ''}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
         </details>
 
         <div className={style.controls}>
@@ -543,17 +539,20 @@ const DevTripPatternPage: NextPage<DevTripPatternPageProps> = (props) => {
           >
             Restore defaults
           </button>
-          <label
-            className={style.filterToggle}
-            title={`Injects whiteListed: { authorities: ["${authorityId}"] } into the query — re-run to filter server-side`}
-          >
-            <input
-              type="checkbox"
-              checked={authorityOnly}
-              onChange={(e) => onAuthorityOnlyChanged(e.target.checked)}
-            />
-            <span>Only {authorityId} trips (server-side)</span>
-          </label>
+        </div>
+
+        <div className={style.fieldBlock}>
+          <span className={style.subLabel}>View</span>
+          <div className={style.fieldPanel}>
+            <label className={style.fieldRow}>
+              <span className={style.fieldRowLabel}>Inspector</span>
+              <input
+                type="checkbox"
+                checked={showInspector}
+                onChange={(e) => setShowInspector(e.target.checked)}
+              />
+            </label>
+          </div>
         </div>
 
         {result && (
@@ -563,27 +562,23 @@ const DevTripPatternPage: NextPage<DevTripPatternPageProps> = (props) => {
                 <span className={style.label}>Trip patterns</span>
                 <div className={style.tripPatterns}>
                   {result.tripPatterns.map((tripPattern, i) => {
-                    const zones = getTripPatternZones(tripPattern);
                     return (
                       <div
                         key={`${runCount}-${i}-${tripPattern.compressedQuery}`}
+                        className={style.tripPatternRow}
                       >
-                        <TripPattern
-                          tripPattern={tripPattern}
-                          delay={i * 0.05}
-                          index={i}
-                        />
-                        {zones.length > 0 && (
-                          <div className={style.zonesPassed}>
-                            <span>Zones passed:</span>
-                            {zones.map((zone) => (
-                              <span key={zone.id}>
-                                {zone.name
-                                  ? `${zone.name} (${zone.id})`
-                                  : zone.id}
-                              </span>
-                            ))}
-                          </div>
+                        <div className={style.tripPatternMain}>
+                          <TripPattern
+                            tripPattern={tripPattern}
+                            delay={i * 0.05}
+                            index={i}
+                          />
+                        </div>
+                        {showInspector && (
+                          <TripInspector
+                            tripPattern={tripPattern}
+                            delay={i * 0.05}
+                          />
                         )}
                       </div>
                     );


### PR DESCRIPTION
## What

Adds an inspector panel to the dev trip-pattern page that exposes the data behind each trip pattern — starting with the fare zones the trip passes through — and reorganizes the page so query inputs and view options are clearly separated.

<img width="600" src="https://github.com/user-attachments/assets/208d0cb1-c03d-4c2f-80f2-44ff5fb31200" />

## Changes

- **New `TripInspector` component** (`page-modules/dev/trip-inspector`): a technical readout panel rendered beside each trip pattern, showing the unique fare zones (from the quays' `tariffZones`) as chips. Structured as labeled sections so more per-trip data (fares, operators, …) can be added over time. Toggled via a new **View → Inspector** checkbox below the Run button, off by default.
- **Authority filter as a dropdown**: replaces the "Only own-authority trips" checkbox. All org authorities from `orgs/*.json` are selectable (current org first, "All authorities" default); selecting one injects `whiteListed: { authorities: [...] }` into the query for server-side filtering, as before.
- **Page restructure**: the GraphQL editor now sits directly below Locations; Transport modes and Authority live together in a collapsed "Query options" section; the "Dev mode: ENABLED" status bar is removed.