### PR TITLE
feat: show affected stop places in situation message box

### DIFF
--- a/src/modules/situations/__tests__/stop-place.test.tsx
+++ b/src/modules/situations/__tests__/stop-place.test.tsx
@@ -23,6 +23,7 @@ const dummySituation: SituationFragment = {
     startTime: '2024-11-21T00:00:00+01:00',
     endTime: '2024-11-23T23:59:59+01:00',
   },
+  affects: [],
 };
 
 describe('isSituationValidAtDate', () => {

--- a/src/modules/situations/__tests__/utils.test.ts
+++ b/src/modules/situations/__tests__/utils.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { getAffectedStopNames } from '../utils';
+import { SituationFragment } from '@atb/page-modules/assistant/journey-gql/trip-with-details.generated.ts';
+
+type Affects = SituationFragment['affects'];
+
+describe('getAffectedStopNames', () => {
+  it('returns empty array when affects is empty', () => {
+    expect(getAffectedStopNames([])).toEqual([]);
+  });
+
+  it('extracts names from all stop-place variants, preferring stopPlace over quay', () => {
+    const affects: Affects = [
+      {
+        __typename: 'AffectedStopPlace',
+        stopPlace: { name: 'Stop' },
+        quay: { name: 'Quay' },
+      },
+      {
+        __typename: 'AffectedStopPlaceOnLine',
+        quay: { name: 'On line quay' },
+      },
+      {
+        __typename: 'AffectedStopPlaceOnServiceJourney',
+        stopPlace: { name: 'On journey stop' },
+      },
+    ];
+    expect(getAffectedStopNames(affects)).toEqual([
+      'Stop',
+      'On line quay',
+      'On journey stop',
+    ]);
+  });
+
+  it('skips non stop-place variants and entries without stopPlace or quay', () => {
+    const affects: Affects = [
+      { __typename: 'AffectedLine' },
+      { __typename: 'AffectedServiceJourney' },
+      { __typename: 'AffectedUnknown' },
+      { __typename: 'AffectedStopPlace' },
+      { __typename: 'AffectedStopPlace', stopPlace: { name: 'Kept' } },
+    ];
+    expect(getAffectedStopNames(affects)).toEqual(['Kept']);
+  });
+
+  it('deduplicates names', () => {
+    const affects: Affects = [
+      { __typename: 'AffectedStopPlace', stopPlace: { name: 'A' } },
+      { __typename: 'AffectedStopPlace', stopPlace: { name: 'B' } },
+      { __typename: 'AffectedStopPlaceOnLine', stopPlace: { name: 'A' } },
+    ];
+    expect(getAffectedStopNames(affects)).toEqual(['A', 'B']);
+  });
+});

--- a/src/modules/situations/situation-message-box.tsx
+++ b/src/modules/situations/situation-message-box.tsx
@@ -1,4 +1,5 @@
 import {
+  getAffectedStopNames,
   getMessageTypeForSituation,
   getSituationSummary,
   messageTypeToColorIcon,
@@ -34,6 +35,7 @@ export const SituationMessageBox = ({
   const messageType = getMessageTypeForSituation(situation);
   const text = getSituationSummary(situation, language);
   const validityPeriodText = useValidityPeriodText(situation.validityPeriod);
+  const affectedStopsText = useAffectedStopNamesText(situation.affects);
 
   if (!text) return null;
 
@@ -67,6 +69,10 @@ export const SituationMessageBox = ({
                 </Link>
               ))}
 
+            {affectedStopsText && (
+              <Typo.p textType="body__m">{affectedStopsText}</Typo.p>
+            )}
+
             {validityPeriodText && (
               <div className={style.dialog__validity}>
                 <MonoIcon icon="time/Time" />
@@ -97,6 +103,32 @@ export const SituationMessageBox = ({
       />
     </>
   );
+};
+
+/**
+ * Get a string which lists the affected stop places. Up to 10 names are shown
+ * in full; beyond that the list is truncated to 8 names followed by an "N other
+ * stops" tail. Returns undefined if no stop places affected.
+ */
+export const useAffectedStopNamesText = (
+  affects: SituationFragment['affects'],
+) => {
+  const { t, language } = useTranslation();
+  const names = getAffectedStopNames(affects);
+  if (names.length === 0) return undefined;
+
+  const displayItems =
+    names.length > 10
+      ? [
+          ...names.slice(0, 8),
+          t(SituationTexts.affectedStopPlaces.otherStops(names.length - 8)),
+        ]
+      : names;
+
+  const list = new Intl.ListFormat(language, { type: 'conjunction' }).format(
+    displayItems,
+  );
+  return `${t(SituationTexts.affectedStopPlaces.header)} ${list}`;
 };
 
 export const useValidityPeriodText = (

--- a/src/modules/situations/utils.ts
+++ b/src/modules/situations/utils.ts
@@ -2,7 +2,8 @@ import { ColorIcons, MonoIcons } from '@atb/components/icon';
 import { Language } from '@atb/translations';
 import { getTextForLanguage } from '@atb/translations/utils';
 import { daysBetween, isBetween } from '@atb/utils/date';
-import { onlyUniquesBasedOnField } from '@atb/utils/only-uniques';
+import { onlyUniques, onlyUniquesBasedOnField } from '@atb/utils/only-uniques';
+import { isDefined } from '@atb/utils/presence';
 import { StatusColorName } from '@atb/modules/theme';
 import { isAfter, isBefore } from 'date-fns';
 import {
@@ -107,6 +108,26 @@ export const getSituationSummary = (
  */
 export const validateEndTime = (endTime?: string) =>
   endTime && daysBetween(new Date(), endTime) <= 365 ? endTime : undefined;
+
+/**
+ * Extract unique stop place / quay names from a situation's affects list.
+ */
+export const getAffectedStopNames = (
+  affects: SituationFragment['affects'],
+): string[] =>
+  affects
+    .map((affect) => {
+      switch (affect.__typename) {
+        case 'AffectedStopPlace':
+        case 'AffectedStopPlaceOnServiceJourney':
+        case 'AffectedStopPlaceOnLine':
+          return affect.stopPlace?.name ?? affect.quay?.name;
+        default:
+          return undefined;
+      }
+    })
+    .filter(isDefined)
+    .filter(onlyUniques);
 
 /**
  * Check if a situation is valid at a specific date by comparing it to the

--- a/src/page-modules/assistant/__tests__/assistant-data.fixture.ts
+++ b/src/page-modules/assistant/__tests__/assistant-data.fixture.ts
@@ -435,6 +435,7 @@ export const tripPatternsViaTo: ViaTripsWithDetailsQuery['viaTrip']['tripPattern
                 startTime: '2024-01-31T10:12:39+01:00',
                 endTime: '2024-01-31T23:59:00+01:00',
               },
+              affects: [],
             },
           ],
           fromPlace: {
@@ -738,6 +739,7 @@ export const tripPatternsFromViaTo: ViaTripsWithDetailsQuery['viaTrip']['tripPat
                 startTime: '2024-01-31T10:12:39+01:00',
                 endTime: '2024-01-31T23:59:00+01:00',
               },
+              affects: [],
             },
           ],
           fromPlace: {

--- a/src/page-modules/assistant/journey-gql/trip-with-details.gql
+++ b/src/page-modules/assistant/journey-gql/trip-with-details.gql
@@ -215,6 +215,33 @@ fragment situation on PtSituationElement {
   validityPeriod {
     ...validityPeriod
   }
+  affects {
+    __typename
+    ... on AffectedStopPlace {
+      stopPlace {
+        name
+      }
+      quay {
+        name
+      }
+    }
+    ... on AffectedStopPlaceOnServiceJourney {
+      stopPlace {
+        name
+      }
+      quay {
+        name
+      }
+    }
+    ... on AffectedStopPlaceOnLine {
+      stopPlace {
+        name
+      }
+      quay {
+        name
+      }
+    }
+  }
 }
 
 fragment multilingualString on MultilingualString {

--- a/src/page-modules/assistant/journey-gql/via-trip-with-details.gql
+++ b/src/page-modules/assistant/journey-gql/via-trip-with-details.gql
@@ -108,29 +108,7 @@ query ViaTripsWithDetails(
             aimedDepartureTime
           }
           situations {
-            id
-            situationNumber
-            reportType
-            summary {
-              language
-              value
-            }
-            description {
-              language
-              value
-            }
-            advice {
-              language
-              value
-            }
-            infoLinks {
-              uri
-              label
-            }
-            validityPeriod {
-              startTime
-              endTime
-            }
+            ...situation
           }
           serviceJourneyEstimatedCalls {
             aimedDepartureTime

--- a/src/translations/modules/situation.ts
+++ b/src/translations/modules/situation.ts
@@ -18,16 +18,8 @@ export const Situation = {
       ),
   },
   affectedStopPlaces: {
-    header: _(
-      'Påvirker',
-      'Affects',
-      'Påverkar',
-    ),
+    header: _('Påvirker', 'Affects', 'Påverkar'),
     otherStops: (count: number) =>
-      _(
-        `${count} andre stopp`,
-        `${count} other stops`,
-        `${count} andre stopp`,
-      ),
+      _(`${count} andre stopp`, `${count} other stops`, `${count} andre stopp`),
   },
 };

--- a/src/translations/modules/situation.ts
+++ b/src/translations/modules/situation.ts
@@ -17,4 +17,17 @@ export const Situation = {
         `Gyldig frå ${fromDate} til ${toDate}`,
       ),
   },
+  affectedStopPlaces: {
+    header: _(
+      'Påvirker',
+      'Affects',
+      'Påverkar',
+    ),
+    otherStops: (count: number) =>
+      _(
+        `${count} andre stopp`,
+        `${count} other stops`,
+        `${count} andre stopp`,
+      ),
+  },
 };


### PR DESCRIPTION
Lists the affected stops in the situation message modal, deduplicated
and truncated to "8 + N other stops" when there are more than 10.

<img width="800" src="https://github.com/user-attachments/assets/ab32935b-5f60-480b-ad5f-1cde7ac95c03" />

