### PR TITLE
feat: (dev) add AtB tariff rule and zone connection

### DIFF
--- a/src/page-modules/dev/owned-tickets/index.tsx
+++ b/src/page-modules/dev/owned-tickets/index.tsx
@@ -9,19 +9,20 @@ export type OwnedTicketsEditorProps = {
   onChange: (next: OwnedTicket[]) => void;
 };
 
-const KINDS: OwnedTicket['kind'][] = ['day', 'single', 'period'];
-const KIND_LABELS: Record<OwnedTicket['kind'], string> = {
-  day: '24-hour',
-  single: 'Single',
-  period: 'Period',
-};
+// Quick-set presets for the validity-remaining input, in minutes.
+const DURATIONS: { minutes: number; label: string }[] = [
+  { minutes: 30, label: '30' },
+  { minutes: 60, label: '60' },
+  { minutes: 90, label: '90' },
+  { minutes: 24 * 60, label: '24h' },
+];
+const DEFAULT_DURATION_MIN = 24 * 60;
 
 /**
- * Dev-mode editor for the tickets a traveller already holds. Each row is a
- * ticket kind (labelling only), the zones it's valid in, and how many minutes
- * of validity remain at the trip's start (blank = valid the whole trip). The
- * ticket plan subtracts these from every trip's route. Renders nothing for orgs
- * without a tariff config (no zones to pick).
+ * Dev-mode editor for the tickets a traveller already holds. Each row is the
+ * zones the ticket is valid in plus how long it stays valid from the trip's
+ * start. The ticket plan subtracts these from every trip's route. Renders
+ * nothing for orgs without a tariff config (no zones to pick).
  */
 export function OwnedTicketsEditor({
   value,
@@ -36,10 +37,7 @@ export function OwnedTicketsEditor({
     onChange(value.filter((_, i) => i !== index));
 
   const add = () =>
-    onChange([
-      ...value,
-      { kind: 'period', zones: [], remainingMinutes: undefined },
-    ]);
+    onChange([...value, { zones: [], remainingMinutes: DEFAULT_DURATION_MIN }]);
 
   const toggleZone = (index: number, zone: string) => {
     const zones = value[index].zones.includes(zone)
@@ -57,19 +55,6 @@ export function OwnedTicketsEditor({
       )}
       {value.map((ticket, index) => (
         <div key={index} className={style.row}>
-          <select
-            className={style.kindSelect}
-            value={ticket.kind}
-            onChange={(e) =>
-              update(index, { kind: e.target.value as OwnedTicket['kind'] })
-            }
-          >
-            {KINDS.map((kind) => (
-              <option key={kind} value={kind}>
-                {KIND_LABELS[kind]}
-              </option>
-            ))}
-          </select>
           <div className={style.zones}>
             {ACTIVE_ZONE_NAMES.map((zone) => (
               <button
@@ -84,8 +69,10 @@ export function OwnedTicketsEditor({
               </button>
             ))}
           </div>
-          <label className={style.minutes}>
+          <div className={style.minutes}>
+            <span>valid</span>
             <input
+              className={style.minutesInput}
               type="number"
               min={0}
               placeholder="∞"
@@ -97,8 +84,26 @@ export function OwnedTicketsEditor({
                 })
               }
             />
-            <span>min left</span>
-          </label>
+            <span>min</span>
+            <div className={style.presets}>
+              {DURATIONS.map((duration) => (
+                <button
+                  key={duration.minutes}
+                  type="button"
+                  className={`${style.zoneChip} ${
+                    ticket.remainingMinutes === duration.minutes
+                      ? style.zoneChipOn
+                      : ''
+                  }`}
+                  onClick={() =>
+                    update(index, { remainingMinutes: duration.minutes })
+                  }
+                >
+                  {duration.label}
+                </button>
+              ))}
+            </div>
+          </div>
           <button
             type="button"
             className={style.remove}

--- a/src/page-modules/dev/owned-tickets/index.tsx
+++ b/src/page-modules/dev/owned-tickets/index.tsx
@@ -1,0 +1,117 @@
+import {
+  ACTIVE_ZONE_NAMES,
+  type OwnedTicket,
+} from '@atb/page-modules/dev/trip-pattern/utils';
+import style from './owned-tickets.module.css';
+
+export type OwnedTicketsEditorProps = {
+  value: OwnedTicket[];
+  onChange: (next: OwnedTicket[]) => void;
+};
+
+const KINDS: OwnedTicket['kind'][] = ['day', 'single', 'period'];
+const KIND_LABELS: Record<OwnedTicket['kind'], string> = {
+  day: '24-hour',
+  single: 'Single',
+  period: 'Period',
+};
+
+/**
+ * Dev-mode editor for the tickets a traveller already holds. Each row is a
+ * ticket kind (labelling only), the zones it's valid in, and how many minutes
+ * of validity remain at the trip's start (blank = valid the whole trip). The
+ * ticket plan subtracts these from every trip's route. Renders nothing for orgs
+ * without a tariff config (no zones to pick).
+ */
+export function OwnedTicketsEditor({
+  value,
+  onChange,
+}: OwnedTicketsEditorProps) {
+  if (ACTIVE_ZONE_NAMES.length === 0) return null;
+
+  const update = (index: number, patch: Partial<OwnedTicket>) =>
+    onChange(value.map((t, i) => (i === index ? { ...t, ...patch } : t)));
+
+  const remove = (index: number) =>
+    onChange(value.filter((_, i) => i !== index));
+
+  const add = () =>
+    onChange([
+      ...value,
+      { kind: 'period', zones: [], remainingMinutes: undefined },
+    ]);
+
+  const toggleZone = (index: number, zone: string) => {
+    const zones = value[index].zones.includes(zone)
+      ? value[index].zones.filter((z) => z !== zone)
+      : [...value[index].zones, zone];
+    update(index, { zones });
+  };
+
+  return (
+    <div className={style.ownedTickets}>
+      {value.length === 0 && (
+        <span className={style.empty}>
+          No owned tickets — the plan bills the whole trip.
+        </span>
+      )}
+      {value.map((ticket, index) => (
+        <div key={index} className={style.row}>
+          <select
+            className={style.kindSelect}
+            value={ticket.kind}
+            onChange={(e) =>
+              update(index, { kind: e.target.value as OwnedTicket['kind'] })
+            }
+          >
+            {KINDS.map((kind) => (
+              <option key={kind} value={kind}>
+                {KIND_LABELS[kind]}
+              </option>
+            ))}
+          </select>
+          <div className={style.zones}>
+            {ACTIVE_ZONE_NAMES.map((zone) => (
+              <button
+                key={zone}
+                type="button"
+                className={`${style.zoneChip} ${
+                  ticket.zones.includes(zone) ? style.zoneChipOn : ''
+                }`}
+                onClick={() => toggleZone(index, zone)}
+              >
+                {zone}
+              </button>
+            ))}
+          </div>
+          <label className={style.minutes}>
+            <input
+              type="number"
+              min={0}
+              placeholder="∞"
+              value={ticket.remainingMinutes ?? ''}
+              onChange={(e) =>
+                update(index, {
+                  remainingMinutes:
+                    e.target.value === '' ? undefined : Number(e.target.value),
+                })
+              }
+            />
+            <span>min left</span>
+          </label>
+          <button
+            type="button"
+            className={style.remove}
+            onClick={() => remove(index)}
+            aria-label="Remove ticket"
+          >
+            ×
+          </button>
+        </div>
+      ))}
+      <button type="button" className={style.add} onClick={add}>
+        + Add owned ticket
+      </button>
+    </div>
+  );
+}

--- a/src/page-modules/dev/owned-tickets/owned-tickets.module.css
+++ b/src/page-modules/dev/owned-tickets/owned-tickets.module.css
@@ -1,0 +1,96 @@
+.ownedTickets {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.empty {
+  font-size: 0.8rem;
+  color: var(--color-background-neutral-0-foreground-secondary, #415058);
+}
+
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.kindSelect {
+  font: inherit;
+  font-size: 0.8rem;
+  padding: 0.25rem 0.4rem;
+  border: 1px solid var(--color-background-neutral-2-background, #ccc);
+  border-radius: 4px;
+  background: var(--color-background-neutral-0-background, #fff);
+  color: var(--color-background-neutral-0-foreground-primary, #000);
+}
+
+.zones {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.zoneChip {
+  min-width: 2rem;
+  padding: 0.2rem 0.4rem;
+  font: inherit;
+  font-size: 0.75rem;
+  cursor: pointer;
+  border-radius: 4px;
+  border: 1px solid var(--color-background-neutral-2-background, #ccc);
+  background: var(--color-background-neutral-0-background, #fff);
+  color: var(--color-background-neutral-0-foreground-primary, #000);
+}
+
+.zoneChipOn {
+  border-color: var(--color-interactive-0-default-background, #007aff);
+  background: var(--color-interactive-0-default-background, #007aff);
+  color: var(--color-interactive-0-default-foreground, #fff);
+  font-weight: 600;
+}
+
+.minutes {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.75rem;
+  color: var(--color-background-neutral-0-foreground-secondary, #415058);
+}
+
+.minutes input {
+  width: 4rem;
+  font: inherit;
+  font-size: 0.8rem;
+  padding: 0.2rem 0.4rem;
+  border: 1px solid var(--color-background-neutral-2-background, #ccc);
+  border-radius: 4px;
+  background: var(--color-background-neutral-0-background, #fff);
+  color: var(--color-background-neutral-0-foreground-primary, #000);
+}
+
+.remove {
+  margin-left: auto;
+  width: 1.6rem;
+  height: 1.6rem;
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: 4px;
+  border: 1px solid var(--color-background-neutral-2-background, #ccc);
+  background: var(--color-background-neutral-1-background, #f5f5f5);
+  color: var(--color-background-neutral-0-foreground-primary, #000);
+}
+
+.add {
+  align-self: flex-start;
+  padding: 0.3rem 0.75rem;
+  font: inherit;
+  font-size: 0.8rem;
+  cursor: pointer;
+  border-radius: 4px;
+  border: 1px dashed var(--color-background-neutral-2-background, #ccc);
+  background: transparent;
+  color: var(--color-background-neutral-0-foreground-primary, #000);
+}

--- a/src/page-modules/dev/owned-tickets/owned-tickets.module.css
+++ b/src/page-modules/dev/owned-tickets/owned-tickets.module.css
@@ -16,16 +16,6 @@
   gap: 0.5rem;
 }
 
-.kindSelect {
-  font: inherit;
-  font-size: 0.8rem;
-  padding: 0.25rem 0.4rem;
-  border: 1px solid var(--color-background-neutral-2-background, #ccc);
-  border-radius: 4px;
-  background: var(--color-background-neutral-0-background, #fff);
-  color: var(--color-background-neutral-0-foreground-primary, #000);
-}
-
 .zones {
   display: flex;
   flex-wrap: wrap;
@@ -59,7 +49,7 @@
   color: var(--color-background-neutral-0-foreground-secondary, #415058);
 }
 
-.minutes input {
+.minutesInput {
   width: 4rem;
   font: inherit;
   font-size: 0.8rem;
@@ -68,6 +58,11 @@
   border-radius: 4px;
   background: var(--color-background-neutral-0-background, #fff);
   color: var(--color-background-neutral-0-foreground-primary, #000);
+}
+
+.presets {
+  display: flex;
+  gap: 0.25rem;
 }
 
 .remove {

--- a/src/page-modules/dev/ticket-plan/index.tsx
+++ b/src/page-modules/dev/ticket-plan/index.tsx
@@ -1,0 +1,73 @@
+import type { ExtendedTripPatternWithDetailsType } from '@atb/page-modules/assistant';
+import {
+  computeTicketPlan,
+  formatOsloTime,
+} from '@atb/page-modules/dev/trip-pattern/utils';
+import style from './ticket-plan.module.css';
+
+export type TicketPlanPanelProps = {
+  tripPattern: ExtendedTripPatternWithDetailsType;
+};
+
+/**
+ * Dev-mode panel showing the single tickets a traveller must buy for a trip
+ * (zone span, price, validity window and the boardings each covers) and, when
+ * cheaper, a 24-hour ticket suggestion. Renders nothing when the org has no
+ * tariff config or the trip has no transit legs (`computeTicketPlan` → null).
+ */
+export function TicketPlanPanel({ tripPattern }: TicketPlanPanelProps) {
+  const plan = computeTicketPlan(tripPattern);
+  if (!plan) return null;
+
+  return (
+    <div
+      className={`${style.ticketPlan} ${
+        plan.recommendDayTicket ? style.ticketPlanWarn : ''
+      }`}
+    >
+      <span className={style.ticketPlanHeader}>
+        {plan.tickets.length > 1
+          ? `${plan.recommendDayTicket ? '⚠ ' : ''}${
+              plan.tickets.length
+            } single tickets · ${plan.singleTotalKr} kr`
+          : `1 ticket covers this trip · ${plan.singleTotalKr} kr`}
+      </span>
+      {plan.tickets.map((ticket, ti) => (
+        <div key={ti} className={style.ticketRow}>
+          <span>
+            {`Ticket ${ti + 1}: ${ticket.fromZone}→${ticket.toZone} · ${
+              ticket.zoneCount
+            } ${ticket.zoneCount === 1 ? 'zone' : 'zones'} · ${
+              ticket.priceKr
+            } kr · ${ticket.validityMinutes} min · ${formatOsloTime(
+              ticket.activatedAtMs,
+            )}–${formatOsloTime(ticket.expiresAtMs)}`}
+          </span>
+          <span className={style.ticketBoardings}>
+            {`covers: ${ticket.boardings
+              .map((b) => `${formatOsloTime(b.timeMs)} (${b.label})`)
+              .join(', ')}`}
+          </span>
+          {ti > 0 && (
+            <span className={style.ticketTrigger}>
+              {`new ticket — previous expired ${formatOsloTime(
+                plan.tickets[ti - 1].expiresAtMs,
+              )}`}
+            </span>
+          )}
+        </div>
+      ))}
+      {plan.recommendDayTicket && (
+        <span className={style.ticketRecommendation}>
+          {`💡 Buy a 24-hour ticket (${plan.dayTicketKr} kr, valid 24h in zone ${
+            plan.tickets[0].fromZone
+          }) instead — ${
+            plan.singleTotalKr > plan.dayTicketKr
+              ? `saves ${plan.singleTotalKr - plan.dayTicketKr} kr`
+              : 'same price but valid all day'
+          }`}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/page-modules/dev/ticket-plan/index.tsx
+++ b/src/page-modules/dev/ticket-plan/index.tsx
@@ -2,22 +2,33 @@ import type { ExtendedTripPatternWithDetailsType } from '@atb/page-modules/assis
 import {
   computeTicketPlan,
   formatOsloTime,
+  type OwnedTicket,
 } from '@atb/page-modules/dev/trip-pattern/utils';
 import style from './ticket-plan.module.css';
 
 export type TicketPlanPanelProps = {
   tripPattern: ExtendedTripPatternWithDetailsType;
+  /** Tickets the traveller already holds; the plan only bills the rest. */
+  ownedTickets?: OwnedTicket[];
 };
 
 /**
  * Dev-mode panel showing the single tickets a traveller must buy for a trip
  * (zone span, price, validity window and the boardings each covers) and, when
- * cheaper, a 24-hour ticket suggestion. Renders nothing when the org has no
- * tariff config or the trip has no transit legs (`computeTicketPlan` → null).
+ * cheaper, a 24-hour ticket suggestion. Tickets the traveller already holds are
+ * subtracted from the route, so spans they cover show as "covered" and partial
+ * spans are billed for the un-owned zones only. Renders nothing when the org
+ * has no tariff config or the trip has no transit legs.
  */
-export function TicketPlanPanel({ tripPattern }: TicketPlanPanelProps) {
-  const plan = computeTicketPlan(tripPattern);
+export function TicketPlanPanel({
+  tripPattern,
+  ownedTickets,
+}: TicketPlanPanelProps) {
+  const plan = computeTicketPlan(tripPattern, { ownedTickets });
   if (!plan) return null;
+
+  const bought = plan.tickets.filter((ticket) => !ticket.fullyCovered);
+  const firstBought = bought[0];
 
   return (
     <div
@@ -26,41 +37,54 @@ export function TicketPlanPanel({ tripPattern }: TicketPlanPanelProps) {
       }`}
     >
       <span className={style.ticketPlanHeader}>
-        {plan.tickets.length > 1
-          ? `${plan.recommendDayTicket ? '⚠ ' : ''}${
-              plan.tickets.length
-            } single tickets · ${plan.singleTotalKr} kr`
-          : `1 ticket covers this trip · ${plan.singleTotalKr} kr`}
+        {bought.length === 0
+          ? 'Fully covered by your tickets · 0 kr'
+          : bought.length > 1
+            ? `${plan.recommendDayTicket ? '⚠ ' : ''}${
+                bought.length
+              } single tickets · ${plan.singleTotalKr} kr`
+            : `1 ticket covers this trip · ${plan.singleTotalKr} kr`}
       </span>
-      {plan.tickets.map((ticket, ti) => (
-        <div key={ti} className={style.ticketRow}>
-          <span>
-            {`Ticket ${ti + 1}: ${ticket.fromZone}→${ticket.toZone} · ${
-              ticket.zoneCount
-            } ${ticket.zoneCount === 1 ? 'zone' : 'zones'} · ${
-              ticket.priceKr
-            } kr · ${ticket.validityMinutes} min · ${formatOsloTime(
-              ticket.activatedAtMs,
-            )}–${formatOsloTime(ticket.expiresAtMs)}`}
-          </span>
-          <span className={style.ticketBoardings}>
-            {`covers: ${ticket.boardings
-              .map((b) => `${formatOsloTime(b.timeMs)} (${b.label})`)
-              .join(', ')}`}
-          </span>
-          {ti > 0 && (
-            <span className={style.ticketTrigger}>
-              {`new ticket — previous expired ${formatOsloTime(
-                plan.tickets[ti - 1].expiresAtMs,
+      {plan.tickets.map((ticket, ti) =>
+        ticket.fullyCovered ? (
+          <div key={ti} className={style.ticketRow}>
+            <span className={style.ticketCovered}>
+              {`✓ covered by owned ${ticket.coveredZones.join(', ') || 'ticket'}`}
+            </span>
+            <span className={style.ticketBoardings}>
+              {`${ticket.boardings
+                .map((b) => `${formatOsloTime(b.timeMs)} (${b.label})`)
+                .join(', ')}`}
+            </span>
+          </div>
+        ) : (
+          <div key={ti} className={style.ticketRow}>
+            <span>
+              {`${ticket.fromZone}→${ticket.toZone} · ${ticket.zoneCount} ${
+                ticket.zoneCount === 1 ? 'zone' : 'zones'
+              } · ${ticket.priceKr} kr · ${
+                ticket.validityMinutes
+              } min · ${formatOsloTime(ticket.activatedAtMs)}–${formatOsloTime(
+                ticket.expiresAtMs,
               )}`}
             </span>
-          )}
-        </div>
-      ))}
-      {plan.recommendDayTicket && (
+            {ticket.coveredZones.length > 0 && (
+              <span className={style.ticketTrigger}>
+                {`${ticket.coveredZones.join(', ')} on your owned ticket`}
+              </span>
+            )}
+            <span className={style.ticketBoardings}>
+              {`covers: ${ticket.boardings
+                .map((b) => `${formatOsloTime(b.timeMs)} (${b.label})`)
+                .join(', ')}`}
+            </span>
+          </div>
+        ),
+      )}
+      {plan.recommendDayTicket && firstBought && (
         <span className={style.ticketRecommendation}>
           {`💡 Buy a 24-hour ticket (${plan.dayTicketKr} kr, valid 24h in zone ${
-            plan.tickets[0].fromZone
+            firstBought.fromZone
           }) instead — ${
             plan.singleTotalKr > plan.dayTicketKr
               ? `saves ${plan.singleTotalKr - plan.dayTicketKr} kr`

--- a/src/page-modules/dev/ticket-plan/ticket-plan.module.css
+++ b/src/page-modules/dev/ticket-plan/ticket-plan.module.css
@@ -1,4 +1,7 @@
 .ticketPlan {
+  /* Cap the width so the per-ticket lines wrap instead of stretching the row
+     (only constrains width, so it still stacks cleanly on narrow screens). */
+  max-width: 19rem;
   display: flex;
   flex-direction: column;
   gap: 0.25rem;

--- a/src/page-modules/dev/ticket-plan/ticket-plan.module.css
+++ b/src/page-modules/dev/ticket-plan/ticket-plan.module.css
@@ -1,7 +1,7 @@
 .ticketPlan {
   /* Cap the width so the per-ticket lines wrap instead of stretching the row
      (only constrains width, so it still stacks cleanly on narrow screens). */
-  max-width: 19rem;
+  max-width: 15rem;
   display: flex;
   flex-direction: column;
   gap: 0.25rem;

--- a/src/page-modules/dev/ticket-plan/ticket-plan.module.css
+++ b/src/page-modules/dev/ticket-plan/ticket-plan.module.css
@@ -1,0 +1,41 @@
+.ticketPlan {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-top: 0.25rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.8rem;
+  border-radius: 4px;
+  border: 1px solid var(--color-background-neutral-2-background, #e0e0e0);
+  background: var(--color-background-neutral-1-background, #f5f5f5);
+}
+
+.ticketPlanWarn {
+  border-color: #d9a400;
+  background: #fff8e6;
+}
+
+.ticketPlanHeader {
+  font-weight: 600;
+}
+
+.ticketRow {
+  display: flex;
+  flex-direction: column;
+}
+
+.ticketBoardings,
+.ticketTrigger {
+  color: var(--color-background-neutral-0-foreground, #555);
+  font-size: 0.75rem;
+}
+
+.ticketTrigger {
+  font-style: italic;
+}
+
+.ticketRecommendation {
+  margin-top: 0.25rem;
+  font-weight: 600;
+  color: #8a6d00;
+}

--- a/src/page-modules/dev/ticket-plan/ticket-plan.module.css
+++ b/src/page-modules/dev/ticket-plan/ticket-plan.module.css
@@ -42,3 +42,8 @@
   font-weight: 600;
   color: #8a6d00;
 }
+
+.ticketCovered {
+  color: #2e7d32;
+  font-weight: 600;
+}

--- a/src/page-modules/dev/trip-inspector/index.tsx
+++ b/src/page-modules/dev/trip-inspector/index.tsx
@@ -1,5 +1,6 @@
 import type { ExtendedTripPatternWithDetailsType } from '@atb/page-modules/assistant';
 import { currentOrg } from '@atb/modules/org-data';
+import { Mode } from '@atb/modules/graphql-types';
 import style from './trip-inspector.module.css';
 
 export type TripInspectorProps = {
@@ -15,6 +16,7 @@ export type TripInspectorProps = {
  */
 export function TripInspector({ tripPattern, delay = 0 }: TripInspectorProps) {
   const zones = getTripPatternZones(tripPattern);
+  const path = getTripPatternPath(tripPattern);
 
   return (
     <aside
@@ -36,8 +38,99 @@ export function TripInspector({ tripPattern, delay = 0 }: TripInspectorProps) {
           <span className={style.empty}>none</span>
         )}
       </div>
+      <div className={style.section}>
+        {path.length > 0 ? (
+          <details className={style.pathDetails}>
+            <summary className={style.pathSummary}>
+              <span className={style.sectionLabel}>Path</span>
+              <span className={style.pathCount}>{path.length} stops</span>
+            </summary>
+            <ol className={style.path}>
+              {path.map((stop, i) => (
+                <li key={i} className={style.pathStop}>
+                  {stop.via && (
+                    <span className={style.pathConnector}>↓ {stop.via}</span>
+                  )}
+                  <span className={style.pathStopName}>
+                    <span className={style.pathStopLabel}>{stop.name}</span>
+                    {stop.zone ? (
+                      <span className={style.pathZone}>{stop.zone}</span>
+                    ) : (
+                      <span className={style.pathZoneEmpty}>—</span>
+                    )}
+                  </span>
+                </li>
+              ))}
+            </ol>
+          </details>
+        ) : (
+          <>
+            <span className={style.sectionLabel}>Path</span>
+            <span className={style.empty}>none</span>
+          </>
+        )}
+      </div>
     </aside>
   );
+}
+
+type PlaceLike = {
+  name?: string | null;
+  quay?: { tariffZones?: { id: string; name?: string | null }[] | null } | null;
+};
+
+/** The org-specific fare zone (name, else id) of a place, if any. */
+function zoneOfPlace(place: PlaceLike | undefined | null): string | undefined {
+  const zone = place?.quay?.tariffZones?.find((z) =>
+    z?.id?.includes(`${currentOrg.toUpperCase()}:FareZone`),
+  );
+  return zone?.name ?? zone?.id ?? undefined;
+}
+
+type TripLeg = ExtendedTripPatternWithDetailsType['legs'][number];
+
+/**
+ * Human-readable label for the leg connecting two stops: the transport mode
+ * (and submode when present) plus the line's public code/name, e.g.
+ * `bus · localBus 3`. Foot legs are just `walk`.
+ */
+function legLabel(leg: TripLeg): string {
+  if (leg.mode === Mode.Foot) return 'walk';
+  const mode = leg.transportSubmode
+    ? `${leg.mode} · ${leg.transportSubmode}`
+    : leg.mode;
+  const line = leg.line?.publicCode ?? leg.line?.name;
+  return line ? `${mode} ${line}` : mode;
+}
+
+type PathStop = { name: string; zone?: string; via?: string };
+
+/**
+ * Builds the ordered list of stops the trip traverses — the first leg's origin
+ * followed by each leg's destination — annotating every stop with its fare zone
+ * and the leg (`via`) that arrives there, so the zone changes are visible
+ * along the route.
+ */
+function getTripPatternPath(
+  tripPattern: ExtendedTripPatternWithDetailsType,
+): PathStop[] {
+  const legs = tripPattern?.legs ?? [];
+  if (legs.length === 0) return [];
+
+  const stops: PathStop[] = [
+    {
+      name: legs[0].fromPlace?.name ?? '?',
+      zone: zoneOfPlace(legs[0].fromPlace),
+    },
+  ];
+  for (const leg of legs) {
+    stops.push({
+      name: leg.toPlace?.name ?? '?',
+      zone: zoneOfPlace(leg.toPlace),
+      via: legLabel(leg),
+    });
+  }
+  return stops;
 }
 
 /**

--- a/src/page-modules/dev/trip-inspector/trip-inspector.module.css
+++ b/src/page-modules/dev/trip-inspector/trip-inspector.module.css
@@ -93,3 +93,92 @@
   color: color-mix(in srgb, var(--dev-accent) 70%, var(--dev-text));
   letter-spacing: 0.02em;
 }
+
+/* Collapsible Path section: a summary row (label + stop count) that toggles
+   the ordered stop list. */
+.pathDetails {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.pathSummary {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  cursor: pointer;
+  list-style: none;
+}
+
+.pathSummary::-webkit-details-marker {
+  display: none;
+}
+
+.pathSummary::before {
+  content: '▸';
+  color: var(--dev-dim);
+  font-size: 0.6rem;
+}
+
+.pathDetails[open] .pathSummary::before {
+  content: '▾';
+}
+
+.pathCount {
+  color: var(--dev-dim);
+  font-size: 0.6rem;
+  letter-spacing: 0.08em;
+}
+
+/* Ordered stop list: each stop name with its fare zone, the leg that arrives
+   there shown as a connector above it. */
+.path {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.pathStop {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.pathConnector {
+  color: var(--dev-dim);
+  font-size: 0.65rem;
+  letter-spacing: 0.02em;
+}
+
+.pathStopName {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.pathStopLabel {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pathZone {
+  flex: none;
+  margin-left: auto;
+  padding: 0.05rem 0.4rem;
+  border-radius: 2px;
+  border: 1px solid color-mix(in srgb, var(--dev-accent) 35%, var(--dev-bg));
+  background: color-mix(in srgb, var(--dev-accent) 9%, var(--dev-bg));
+  color: color-mix(in srgb, var(--dev-accent) 70%, var(--dev-text));
+  font-size: 0.65rem;
+  letter-spacing: 0.02em;
+}
+
+.pathZoneEmpty {
+  flex: none;
+  margin-left: auto;
+  color: var(--dev-dim);
+}

--- a/src/page-modules/dev/trip-pattern/__tests__/utils.test.ts
+++ b/src/page-modules/dev/trip-pattern/__tests__/utils.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { computeTicketPlan, type OwnedTicket } from '../utils';
+import type { ExtendedTripPatternWithDetailsType } from '@atb/page-modules/assistant';
+import { Mode } from '@atb/modules/graphql-types';
+
+// FareZone ids → names for AtB (mirrors tariff/atb.ts).
+const ZONE_ID: Record<string, string> = {
+  A: 'ATB:FareZone:10',
+  B1: 'ATB:FareZone:6',
+  C6: 'ATB:FareZone:7',
+  D: 'ATB:FareZone:2',
+};
+
+function place(zone: keyof typeof ZONE_ID) {
+  return {
+    name: zone,
+    quay: { tariffZones: [{ id: ZONE_ID[zone], name: zone }] },
+  };
+}
+
+/** Minimal transit leg between two zones at a given Oslo wall-clock time. */
+function leg(
+  from: keyof typeof ZONE_ID,
+  to: keyof typeof ZONE_ID,
+  startIso: string,
+  publicCode = 'bus',
+) {
+  return {
+    mode: Mode.Bus,
+    expectedStartTime: startIso,
+    line: { publicCode },
+    fromPlace: place(from),
+    toPlace: place(to),
+  };
+}
+
+function trip(legs: unknown[]): ExtendedTripPatternWithDetailsType {
+  return { legs } as unknown as ExtendedTripPatternWithDetailsType;
+}
+
+const T = (hhmm: string) => `2026-06-15T${hhmm}:00+02:00`;
+
+describe('computeTicketPlan — owned tickets', () => {
+  it('bills the un-owned remainder of the route (A→C6→D with a period-A ticket)', () => {
+    const pattern = trip([
+      leg('A', 'C6', T('08:00')),
+      leg('C6', 'D', T('08:20')),
+    ]);
+    const owned: OwnedTicket[] = [{ kind: 'period', zones: ['A'] }];
+
+    const plan = computeTicketPlan(pattern, { ownedTickets: owned });
+    const bought = plan!.tickets.filter((t) => !t.fullyCovered);
+
+    expect(bought).toHaveLength(1);
+    expect(bought[0].fromZone).toBe('C6');
+    expect(bought[0].toZone).toBe('D');
+    expect(bought[0].zoneCount).toBe(2);
+    expect(bought[0].priceKr).toBe(100);
+    expect(bought[0].validityMinutes).toBe(150);
+    expect(plan!.singleTotalKr).toBe(100);
+  });
+
+  it('without owned tickets bills the whole A→C6→D route (3 zones)', () => {
+    const pattern = trip([
+      leg('A', 'C6', T('08:00')),
+      leg('C6', 'D', T('08:20')),
+    ]);
+
+    const plan = computeTicketPlan(pattern);
+    const bought = plan!.tickets.filter((t) => !t.fullyCovered);
+
+    expect(bought).toHaveLength(1);
+    expect(bought[0].fromZone).toBe('A');
+    expect(bought[0].toZone).toBe('D');
+    expect(bought[0].zoneCount).toBe(3);
+    expect(bought[0].priceKr).toBe(150);
+    expect(plan!.singleTotalKr).toBe(150);
+  });
+
+  it('marks a trip fully covered when the owned ticket spans every zone', () => {
+    const pattern = trip([leg('A', 'C6', T('08:00'))]);
+    const owned: OwnedTicket[] = [{ kind: 'period', zones: ['A', 'C6'] }];
+
+    const plan = computeTicketPlan(pattern, { ownedTickets: owned });
+    const bought = plan!.tickets.filter((t) => !t.fullyCovered);
+
+    expect(bought).toHaveLength(0);
+    expect(plan!.singleTotalKr).toBe(0);
+    expect(plan!.tickets[0].fullyCovered).toBe(true);
+    expect(plan!.tickets[0].coveredZones).toEqual(['A', 'C6']);
+  });
+
+  it('forces a re-buy once the owned ticket expires mid-trip', () => {
+    // Two same-zone (A) boardings 2h apart; owned A ticket has 30 min left.
+    const pattern = trip([
+      leg('A', 'A', T('08:00')),
+      leg('A', 'A', T('10:00')),
+    ]);
+    const owned: OwnedTicket[] = [
+      { kind: 'day', zones: ['A'], remainingMinutes: 30 },
+    ];
+
+    const plan = computeTicketPlan(pattern, { ownedTickets: owned });
+
+    // First boarding (08:00) covered; second (10:00, past 08:30 expiry) bought.
+    expect(plan!.tickets[0].fullyCovered).toBe(true);
+    const bought = plan!.tickets.filter((t) => !t.fullyCovered);
+    expect(bought).toHaveLength(1);
+    expect(bought[0].zoneCount).toBe(1);
+    expect(bought[0].priceKr).toBe(50);
+  });
+
+  it('returns null when there are no transit legs', () => {
+    const pattern = trip([
+      {
+        mode: Mode.Foot,
+        expectedStartTime: T('08:00'),
+        fromPlace: place('A'),
+        toPlace: place('A'),
+      },
+    ]);
+    expect(computeTicketPlan(pattern)).toBeNull();
+  });
+});

--- a/src/page-modules/dev/trip-pattern/__tests__/utils.test.ts
+++ b/src/page-modules/dev/trip-pattern/__tests__/utils.test.ts
@@ -46,7 +46,7 @@ describe('computeTicketPlan — owned tickets', () => {
       leg('A', 'C6', T('08:00')),
       leg('C6', 'D', T('08:20')),
     ]);
-    const owned: OwnedTicket[] = [{ kind: 'period', zones: ['A'] }];
+    const owned: OwnedTicket[] = [{ zones: ['A'] }];
 
     const plan = computeTicketPlan(pattern, { ownedTickets: owned });
     const bought = plan!.tickets.filter((t) => !t.fullyCovered);
@@ -79,7 +79,7 @@ describe('computeTicketPlan — owned tickets', () => {
 
   it('marks a trip fully covered when the owned ticket spans every zone', () => {
     const pattern = trip([leg('A', 'C6', T('08:00'))]);
-    const owned: OwnedTicket[] = [{ kind: 'period', zones: ['A', 'C6'] }];
+    const owned: OwnedTicket[] = [{ zones: ['A', 'C6'] }];
 
     const plan = computeTicketPlan(pattern, { ownedTickets: owned });
     const bought = plan!.tickets.filter((t) => !t.fullyCovered);
@@ -96,9 +96,7 @@ describe('computeTicketPlan — owned tickets', () => {
       leg('A', 'A', T('08:00')),
       leg('A', 'A', T('10:00')),
     ]);
-    const owned: OwnedTicket[] = [
-      { kind: 'day', zones: ['A'], remainingMinutes: 30 },
-    ];
+    const owned: OwnedTicket[] = [{ zones: ['A'], remainingMinutes: 30 }];
 
     const plan = computeTicketPlan(pattern, { ownedTickets: owned });
 

--- a/src/page-modules/dev/trip-pattern/tariff/atb.ts
+++ b/src/page-modules/dev/trip-pattern/tariff/atb.ts
@@ -1,0 +1,42 @@
+import type { TariffConfig } from './types';
+
+// AtB (Trøndelag) tariff. Connection graph verified against the official
+// "Relasjoner" relation table; prices/validity per AtB's single-ticket rules.
+export const atbTariff: TariffConfig = {
+  zoneNames: {
+    'ATB:FareZone:10': 'A',
+    'ATB:FareZone:6': 'B1',
+    'ATB:FareZone:11': 'B2',
+    'ATB:FareZone:9': 'B3',
+    'ATB:FareZone:4': 'C1',
+    'ATB:FareZone:5': 'C2',
+    'ATB:FareZone:12': 'C3',
+    'ATB:FareZone:13': 'C4',
+    'ATB:FareZone:8': 'C5',
+    'ATB:FareZone:7': 'C6',
+    'ATB:FareZone:2': 'D',
+    'ATB:FareZone:3': 'E1',
+    'ATB:FareZone:1': 'E2',
+  },
+  connections: {
+    A: ['B1', 'B2', 'B3', 'C2', 'C3', 'C5', 'C6'],
+    B1: ['A', 'B2', 'B3', 'C1', 'C6'],
+    B2: ['A', 'B1', 'B3', 'C3', 'C4'],
+    B3: ['A', 'B1', 'B2', 'C5'],
+    C1: ['B1', 'D'],
+    C2: ['A'],
+    C3: ['A', 'B2'],
+    C4: ['B2'],
+    C5: ['A', 'B3'],
+    C6: ['A', 'B1', 'D'],
+    D: ['C1', 'C6', 'E1', 'E2'],
+    E1: ['D'],
+    E2: ['D'],
+  },
+  baseValidityMin: 90,
+  extraZoneValidityMin: 60,
+  singleTicketBaseKr: 50,
+  extraZoneKr: 50,
+  dayTicketKr: 150,
+  maxSingleTicketsBeforeDayTicket: 2,
+};

--- a/src/page-modules/dev/trip-pattern/tariff/index.ts
+++ b/src/page-modules/dev/trip-pattern/tariff/index.ts
@@ -1,0 +1,10 @@
+import type { TariffConfig } from './types';
+import { atbTariff } from './atb';
+
+export type { TariffConfig } from './types';
+
+// Tariff config per org, keyed by `currentOrg`. Register a new org here after
+// adding its file (e.g. `nfk: nfkTariff`). Orgs not listed get no ticket plan.
+export const TARIFF_CONFIGS: Record<string, TariffConfig> = {
+  atb: atbTariff,
+};

--- a/src/page-modules/dev/trip-pattern/tariff/types.ts
+++ b/src/page-modules/dev/trip-pattern/tariff/types.ts
@@ -1,0 +1,31 @@
+/**
+ * Per-organization tariff rules for the dev ticket calculator. Everything here
+ * is org-specific — zone names, the fare-zone connection graph, validity windows
+ * and prices — so only orgs with a config get a ticket plan; others yield none
+ * rather than wrong numbers. Add an org by creating a new file in this folder
+ * and registering it in `index.ts`.
+ */
+export type TariffConfig = {
+  // FareZone id (e.g. "ATB:FareZone:7") -> readable zone name (e.g. "C6").
+  zoneNames: Record<string, string>;
+  // Two-way fare-zone connection graph, keyed by zone name. Travel between two
+  // connected zones is billed as 2 zones regardless of any zone passed through;
+  // the billed count between any two zones is the shortest hops along this graph
+  // + 1.
+  connections: Record<string, string[]>;
+  // A single ticket is valid `baseValidityMin` for the first zone plus
+  // `extraZoneValidityMin` per additional zone, and only needs to be valid at
+  // boarding (not for the whole journey).
+  baseValidityMin: number;
+  extraZoneValidityMin: number;
+  // A single ticket costs `singleTicketBaseKr` for the first zone plus
+  // `extraZoneKr` per additional zone.
+  singleTicketBaseKr: number;
+  extraZoneKr: number;
+  // A day (24h) ticket is valid in a single zone only and costs a flat
+  // `dayTicketKr`. It's suggested only for single-zone trips that need more than
+  // `maxSingleTicketsBeforeDayTicket` single tickets (by then the singles cost at
+  // least as much, and the day ticket is valid 24h rather than 90 min each).
+  dayTicketKr: number;
+  maxSingleTicketsBeforeDayTicket: number;
+};

--- a/src/page-modules/dev/trip-pattern/utils.ts
+++ b/src/page-modules/dev/trip-pattern/utils.ts
@@ -330,22 +330,42 @@ function fareZoneIdOfPlace(place: PlaceWithZones | undefined): string | null {
   );
 }
 
+// Sorted unique zone names for the active org — drives the dev "owned tickets"
+// editor. Empty when the org has no tariff config.
+export const ACTIVE_ZONE_NAMES: string[] = ACTIVE_TARIFF
+  ? Object.keys(ACTIVE_TARIFF.connections).sort()
+  : [];
+
 /**
- * Billed number of zones between two fare zones, via the active org's connection
- * graph (neighbours = 2 zones, same zone = 1). Returns null when either zone is
- * unknown, so callers can fall back to counting zones travelled.
+ * Billed number of zones between two zone *names* via the active org's
+ * connection graph (neighbours = 2 zones, same zone = 1). Null when either name
+ * is unknown.
  */
-function zoneCountBetween(
-  fromId: string | null,
-  toId: string | null,
-  t: TariffConfig,
-): number | null {
-  if (!fromId || !toId) return null;
-  const a = t.zoneNames[fromId];
-  const b = t.zoneNames[toId];
-  if (!a || !b) return null;
+function zoneCountBetweenNames(a: string, b: string): number | null {
   const count = ACTIVE_ZONE_COUNT[a]?.[b];
   return Number.isFinite(count) ? count : null;
+}
+
+/**
+ * Ordered list of the org's fare-zone *names* the legs traverse, deduped (first
+ * occurrence wins), e.g. [A, C6, D]. This is the real route, used to bill the
+ * un-owned remainder of a journey.
+ */
+function traversedZoneNames(legs: TripLeg[], t: TariffConfig): string[] {
+  const names: string[] = [];
+  const seen = new Set<string>();
+  for (const leg of legs) {
+    for (const place of [leg.fromPlace, leg.toPlace]) {
+      const id = fareZoneIdOfPlace(place);
+      if (!id) continue;
+      const name = t.zoneNames[id] ?? id;
+      if (!seen.has(name)) {
+        seen.add(name);
+        names.push(name);
+      }
+    }
+  }
+  return names;
 }
 
 const osloTimeFormatter = new Intl.DateTimeFormat('no-NO', {
@@ -363,6 +383,8 @@ function legLabel(leg: TripLeg): string {
 }
 
 export type TicketSegment = {
+  // For a bought ticket: the un-owned span it pays for (e.g. C6→D). For a
+  // covered segment: the boarding's own from/to zones.
   fromZone: string;
   toZone: string;
   zoneCount: number;
@@ -371,7 +393,46 @@ export type TicketSegment = {
   activatedAtMs: number;
   expiresAtMs: number;
   boardings: { timeMs: number; label: string }[];
+  // True when an owned, still-valid ticket already covers the whole span, so
+  // nothing is bought for it.
+  fullyCovered: boolean;
+  // Zone names within this span an owned ticket covers (dropped from the billed
+  // count). Empty when the traveller owns nothing along it.
+  coveredZones: string[];
 };
+
+/**
+ * A ticket the traveller already holds. `kind` is for labelling only — the
+ * calculation uses `zones` (the zone names it's valid in) and `remainingMinutes`
+ * (validity left at the trip's start; undefined = valid for the whole trip).
+ */
+export type OwnedTicket = {
+  kind: 'day' | 'single' | 'period';
+  zones: string[];
+  remainingMinutes?: number;
+};
+
+/**
+ * Zone names covered by owned tickets still valid at `timeMs`, where each
+ * ticket's validity is measured from the trip's first boarding.
+ */
+function ownedValidNamesAt(
+  timeMs: number,
+  firstBoardingMs: number,
+  owned: OwnedTicket[],
+): Set<string> {
+  const set = new Set<string>();
+  for (const ticket of owned) {
+    const expiry =
+      ticket.remainingMinutes == null
+        ? Infinity
+        : firstBoardingMs + ticket.remainingMinutes * 60_000;
+    if (timeMs <= expiry) {
+      for (const zone of ticket.zones) set.add(zone);
+    }
+  }
+  return set;
+}
 
 export type TicketPlan = {
   tickets: TicketSegment[];
@@ -389,22 +450,29 @@ export type TicketPlan = {
  * count between two zones comes from the connection graph (pass-through zones
  * aren't charged — neighbours are 2 zones).
  *
- * Each ticket is activated at a boarding and billed `origin → the destination of
- * the last leg it actually covers` (not the journey's final zone), so a
- * force-split trip pays only for the zones ridden on each ticket. A ticket is
- * extended to the next boarding only while a ticket spanning origin → that
- * boarding's destination would still be valid at that boarding's time
- * (`90 + 60·(zones − 1)` min); the first boarding that no longer fits starts the
- * next ticket. Returns null when the org has no tariff config or the trip has no
- * transit legs.
+ * When the traveller already holds tickets (`options.ownedTickets`), each
+ * span's billed zones are computed on the **un-owned remainder of the real
+ * route**: collect the traversed zone names, drop the zones an owned, still-
+ * valid ticket covers, then bill `zoneCountBetween(firstRemaining,
+ * lastRemaining)`. A span whose remainder is empty is fully covered and bought
+ * nothing — it's recorded as a covered segment. With no owned tickets the
+ * remainder is the whole route, so this reduces to billing origin → the
+ * destination of the last leg the ticket covers.
+ *
+ * Each ticket is activated at a boarding and extended to the next boarding only
+ * while it would still be valid at that boarding's time (`90 + 60·(zones − 1)`
+ * min) and that boarding isn't itself fully covered by an owned ticket. Returns
+ * null when the org has no tariff config or the trip has no transit legs.
  */
 export function computeTicketPlan(
   tripPattern: ExtendedTripPatternWithDetailsType,
+  options: { ownedTickets?: OwnedTicket[] } = {},
 ): TicketPlan | null {
   const tariff = ACTIVE_TARIFF;
   // No tariff config for this org → no ticket plan (rather than wrong numbers).
   if (!tariff) return null;
 
+  const owned = options.ownedTickets ?? [];
   const legs = tripPattern.legs;
   // Index of each transit leg (a "boarding"); walk legs need no ticket.
   const boardingLegs = legs
@@ -413,21 +481,52 @@ export function computeTicketPlan(
 
   if (boardingLegs.length === 0) return null;
 
-  // Billed zones between two fare zones via the connection graph, falling back
-  // to the literal zones travelled across the covered legs if a zone id can't
-  // be resolved.
-  const billedZones = (
-    fromId: string | null,
-    toId: string | null,
+  const firstBoardingMs = new Date(
+    boardingLegs[0].leg.expectedStartTime,
+  ).getTime();
+
+  // Bill legs[fromLegIndex..toLegIndex] for a ticket activated at `atMs`, after
+  // dropping zones an owned, still-valid ticket covers. Returns the billed zone
+  // count (0 = fully covered), the un-owned span endpoints, and the owned zones
+  // it absorbed.
+  const billSpan = (
     fromLegIndex: number,
     toLegIndex: number,
-  ): number => {
-    const connection = zoneCountBetween(fromId, toId, tariff);
-    if (connection != null) return connection;
-    return Math.max(
-      1,
-      collectFareZones(legs.slice(fromLegIndex, toLegIndex + 1)).length,
+    atMs: number,
+  ): {
+    zoneCount: number;
+    fromZone: string;
+    toZone: string;
+    coveredZones: string[];
+  } => {
+    const chain = traversedZoneNames(
+      legs.slice(fromLegIndex, toLegIndex + 1),
+      tariff,
     );
+    const ownedZones = ownedValidNamesAt(atMs, firstBoardingMs, owned);
+    const remaining = chain.filter((zone) => !ownedZones.has(zone));
+    const coveredZones = chain.filter((zone) => ownedZones.has(zone));
+
+    if (remaining.length === 0) {
+      return {
+        zoneCount: 0,
+        fromZone: chain[0] ?? '?',
+        toZone: chain[chain.length - 1] ?? '?',
+        coveredZones,
+      };
+    }
+
+    const first = remaining[0];
+    const last = remaining[remaining.length - 1];
+    // Fall back to the count of distinct un-owned zones if the graph can't
+    // resolve a span between the endpoints.
+    const span = zoneCountBetweenNames(first, last);
+    return {
+      zoneCount: span ?? remaining.length,
+      fromZone: first,
+      toZone: last,
+      coveredZones,
+    };
   };
 
   const tickets: TicketSegment[] = [];
@@ -435,78 +534,81 @@ export function computeTicketPlan(
 
   while (cursor < boardingLegs.length) {
     const start = boardingLegs[cursor];
-    const originZoneId = fareZoneIdOfPlace(start.leg.fromPlace);
     const activatedAtMs = new Date(start.leg.expectedStartTime).getTime();
 
-    // Extend to cover the next boarding only while a ticket spanning origin →
-    // that boarding's destination would still be valid at its boarding time.
+    // A boarding whose own span is fully owned needs no ticket — record it as a
+    // covered segment and move on.
+    const startSelf = billSpan(start.index, start.index, activatedAtMs);
+    if (startSelf.zoneCount === 0) {
+      tickets.push({
+        fromZone: startSelf.fromZone,
+        toZone: startSelf.toZone,
+        zoneCount: 0,
+        validityMinutes: 0,
+        priceKr: 0,
+        activatedAtMs,
+        expiresAtMs: activatedAtMs,
+        boardings: [{ timeMs: activatedAtMs, label: legLabel(start.leg) }],
+        fullyCovered: true,
+        coveredZones: startSelf.coveredZones,
+      });
+      cursor += 1;
+      continue;
+    }
+
+    // Extend one new ticket to cover later boardings while it stays valid and
+    // those boardings aren't independently covered by an owned ticket.
     let last = cursor;
     while (last + 1 < boardingLegs.length) {
       const next = boardingLegs[last + 1];
-      const candidateDestId = fareZoneIdOfPlace(next.leg.toPlace);
-      const candidateZones = billedZones(
-        originZoneId,
-        candidateDestId,
-        start.index,
-        next.index,
-      );
+      const nextTimeMs = new Date(next.leg.expectedStartTime).getTime();
+      const nextSelf = billSpan(next.index, next.index, nextTimeMs);
+      if (nextSelf.zoneCount === 0) break; // covered separately
+      const candidate = billSpan(start.index, next.index, activatedAtMs);
       const candidateExpiry =
-        activatedAtMs + zoneValidityMinutes(candidateZones, tariff) * 60_000;
-      if (new Date(next.leg.expectedStartTime).getTime() > candidateExpiry) {
-        break;
-      }
+        activatedAtMs +
+        zoneValidityMinutes(candidate.zoneCount, tariff) * 60_000;
+      if (nextTimeMs > candidateExpiry) break;
       last += 1;
     }
 
-    // The ticket is billed origin → the last leg it actually covers.
     const lastEntry = boardingLegs[last];
-    const destZoneId = fareZoneIdOfPlace(lastEntry.leg.toPlace);
-    const zoneCount = billedZones(
-      originZoneId,
-      destZoneId,
-      start.index,
-      lastEntry.index,
-    );
-    const validityMinutes = zoneValidityMinutes(zoneCount, tariff);
-    const priceKr = singleTicketPriceKr(zoneCount, tariff);
-    const expiresAtMs = activatedAtMs + validityMinutes * 60_000;
-
-    const covered = collectFareZones(
-      legs.slice(start.index, lastEntry.index + 1),
-    );
-    const boardings = boardingLegs.slice(cursor, last + 1).map((entry) => ({
-      timeMs: new Date(entry.leg.expectedStartTime).getTime(),
-      label: legLabel(entry.leg),
-    }));
+    const final = billSpan(start.index, lastEntry.index, activatedAtMs);
+    const validityMinutes = zoneValidityMinutes(final.zoneCount, tariff);
+    const priceKr = singleTicketPriceKr(final.zoneCount, tariff);
 
     tickets.push({
-      fromZone: originZoneId
-        ? (tariff.zoneNames[originZoneId] ?? originZoneId)
-        : (covered[0]?.name ?? '?'),
-      toZone: destZoneId
-        ? (tariff.zoneNames[destZoneId] ?? destZoneId)
-        : (covered[covered.length - 1]?.name ?? '?'),
-      zoneCount,
+      fromZone: final.fromZone,
+      toZone: final.toZone,
+      zoneCount: final.zoneCount,
       validityMinutes,
       priceKr,
       activatedAtMs,
-      expiresAtMs,
-      boardings,
+      expiresAtMs: activatedAtMs + validityMinutes * 60_000,
+      boardings: boardingLegs.slice(cursor, last + 1).map((entry) => ({
+        timeMs: new Date(entry.leg.expectedStartTime).getTime(),
+        label: legLabel(entry.leg),
+      })),
+      fullyCovered: false,
+      coveredZones: final.coveredZones,
     });
 
     cursor = last + 1;
   }
 
-  const singleTotalKr = tickets.reduce((sum, t) => sum + t.priceKr, 0);
+  // Only bought tickets count toward the total and the day-ticket suggestion.
+  const bought = tickets.filter((ticket) => !ticket.fullyCovered);
+  const singleTotalKr = bought.reduce((sum, ticket) => sum + ticket.priceKr, 0);
 
   // The day ticket is valid in a single zone only, so it can replace the single
-  // tickets just when the whole trip stays within one zone (every ticket is one
-  // zone). It's the better buy once more than `maxSingleTicketsBeforeDayTicket`
-  // single tickets are needed — at 3 the price ties at 150 kr, but the day
-  // ticket is valid 24h instead of 3 × 90 min.
-  const singleZoneTrip = tickets.every((t) => t.zoneCount === 1);
+  // tickets just when every bought ticket stays within one zone. It's the
+  // better buy once more than `maxSingleTicketsBeforeDayTicket` are needed — at
+  // 3 the price ties at 150 kr, but the day ticket is valid 24h instead of
+  // 3 × 90 min.
+  const singleZoneTrip =
+    bought.length > 0 && bought.every((ticket) => ticket.zoneCount === 1);
   const recommendDayTicket =
-    singleZoneTrip && tickets.length > tariff.maxSingleTicketsBeforeDayTicket;
+    singleZoneTrip && bought.length > tariff.maxSingleTicketsBeforeDayTicket;
 
   return {
     tickets,

--- a/src/page-modules/dev/trip-pattern/utils.ts
+++ b/src/page-modules/dev/trip-pattern/utils.ts
@@ -402,12 +402,12 @@ export type TicketSegment = {
 };
 
 /**
- * A ticket the traveller already holds. `kind` is for labelling only — the
- * calculation uses `zones` (the zone names it's valid in) and `remainingMinutes`
- * (validity left at the trip's start; undefined = valid for the whole trip).
+ * A ticket the traveller already holds, described by the zone names it's valid
+ * in and the validity left at the trip's start (`remainingMinutes`; undefined =
+ * valid for the whole trip). The ticket "kind" doesn't matter to the maths —
+ * only its zones and how long it stays valid.
  */
 export type OwnedTicket = {
-  kind: 'day' | 'single' | 'period';
   zones: string[];
   remainingMinutes?: number;
 };

--- a/src/page-modules/dev/trip-pattern/utils.ts
+++ b/src/page-modules/dev/trip-pattern/utils.ts
@@ -1,0 +1,518 @@
+import type { GeocoderFeature } from '@atb/modules/geocoder';
+import type { TransportModeFilterOptionType } from '@atb-as/config-specs';
+import { uniq } from 'lodash';
+import type { ExtendedTripPatternWithDetailsType } from '@atb/page-modules/assistant';
+import type { LegWithDetailsFragment } from '@atb/page-modules/assistant/journey-gql/trip-with-details.generated';
+import { Mode } from '@atb/modules/graphql-types';
+import { currentOrg } from '@atb/modules/org-data';
+import { TARIFF_CONFIGS, type TariffConfig } from './tariff';
+
+export type VariablesLocation = {
+  place: string;
+  coordinates: { latitude: number; longitude: number };
+  name: string;
+};
+
+export function featureToLocation(feature: GeocoderFeature): VariablesLocation {
+  return {
+    place: feature.id,
+    coordinates: {
+      latitude: feature.geometry.coordinates[1],
+      longitude: feature.geometry.coordinates[0],
+    },
+    name: feature.name,
+  };
+}
+
+export function locationToFeature(loc: VariablesLocation): GeocoderFeature {
+  return {
+    id: loc.place,
+    name: loc.name,
+    locality: null,
+    category: [],
+    layer: 'venue',
+    geometry: {
+      coordinates: [loc.coordinates.longitude, loc.coordinates.latitude],
+    },
+  };
+}
+
+function locationToGraphQL(loc: VariablesLocation): string {
+  return `{
+      place: "${loc.place}"
+      coordinates: {
+        latitude: ${loc.coordinates.latitude}
+        longitude: ${loc.coordinates.longitude}
+      }
+      name: "${loc.name}"
+    }`;
+}
+
+const FROM_PATTERN = /from:\s*\{[\s\S]*?coordinates:\s*\{[\s\S]*?\}[\s\S]*?\}/;
+const TO_PATTERN = /to:\s*\{[\s\S]*?coordinates:\s*\{[\s\S]*?\}[\s\S]*?\}/;
+// Matches the `modes: { ... }` block injected by the transport mode filter.
+// The `transportModes` list is always rendered inline (single line), so the
+// first newline-indented `}` is the closing brace of the modes block.
+const MODES_PATTERN = /\n\s*modes:\s*\{[\s\S]*?\n\s*\}/;
+
+/**
+ * Builds the inline GraphQL `modes: { ... }` block from the selected transport
+ * mode filter options, mirroring how the assistant maps the filter to the
+ * JourneyPlanner `Modes` input (see server/journey-planner/mappers.ts).
+ *
+ * Returns `null` when no filter should be applied (nothing selected yet, or
+ * every option selected — both mean "all modes", same as the assistant).
+ */
+export function buildModesGraphQL(
+  options: TransportModeFilterOptionType[],
+  filterState: string[] | null,
+): string | null {
+  // `null` means no filter; all options selected is equivalent to no filter.
+  if (!filterState) return null;
+  if (filterState.length === options.length) return null;
+
+  const selectedModes = options
+    .filter((option) => filterState.includes(option.id))
+    .flatMap((option) => option.modes);
+
+  const transportModes = uniq(
+    selectedModes.map((mode) => {
+      const subModes =
+        mode.transportSubModes && mode.transportSubModes.length > 0
+          ? `, transportSubModes: [${mode.transportSubModes.join(', ')}]`
+          : '';
+      return `{ transportMode: ${mode.transportMode}${subModes} }`;
+    }),
+  );
+
+  return `    modes: {
+      accessMode: foot
+      egressMode: foot
+      transportModes: [${transportModes.join(', ')}]
+    }`;
+}
+
+/**
+ * Removes any existing `modes` block from the query and, when a block is
+ * provided, injects it as the first argument of the `trip(...)` call.
+ */
+export function patchQueryModes(
+  query: string,
+  modesBlock: string | null,
+): string {
+  const withoutModes = query.replace(MODES_PATTERN, '');
+  if (!modesBlock) return withoutModes;
+  return withoutModes.replace(/trip\s*\(/, `trip(\n${modesBlock}`);
+}
+
+// Matches the single-line `whiteListed: { authorities: [...] }` block injected
+// by the authority toggle, so it can be removed/replaced idempotently.
+const WHITELISTED_AUTHORITIES_PATTERN =
+  /\n\s*whiteListed:\s*\{\s*authorities:[^}]*\}/;
+
+/**
+ * Removes any injected authority whitelist and, when an authority id is given,
+ * injects `whiteListed: { authorities: [...] }` as the first argument of
+ * `trip(...)`. This filters server-side: the JourneyPlanner only returns trips
+ * operated by the whitelisted authority — i.e. the ones the sales endpoint can
+ * price.
+ */
+export function patchQueryAuthorities(
+  query: string,
+  authorityId: string | null,
+): string {
+  const without = query.replace(WHITELISTED_AUTHORITIES_PATTERN, '');
+  if (!authorityId) return without;
+  return without.replace(
+    /trip\s*\(/,
+    `trip(\n    whiteListed: { authorities: ["${authorityId}"] }`,
+  );
+}
+
+function parseLocationFromMatch(match: string): VariablesLocation | undefined {
+  try {
+    const place = match.match(/place:\s*"([^"]+)"/)?.[1] ?? '';
+    const lat = match.match(/latitude:\s*([\d.-]+)/)?.[1];
+    const lon = match.match(/longitude:\s*([\d.-]+)/)?.[1];
+    const name = match.match(/name:\s*"([^"]+)"/)?.[1];
+    if (name) {
+      return {
+        place,
+        coordinates: {
+          latitude: lat ? parseFloat(lat) : 0,
+          longitude: lon ? parseFloat(lon) : 0,
+        },
+        name,
+      };
+    }
+  } catch {
+    // ignore
+  }
+  return undefined;
+}
+
+export function parseLocationsFromQuery(query: string): {
+  from: GeocoderFeature | undefined;
+  to: GeocoderFeature | undefined;
+} {
+  const fromMatch = query.match(FROM_PATTERN)?.[0];
+  const toMatch = query.match(TO_PATTERN)?.[0];
+  return {
+    from: fromMatch
+      ? (() => {
+          const l = parseLocationFromMatch(fromMatch);
+          return l ? locationToFeature(l) : undefined;
+        })()
+      : undefined,
+    to: toMatch
+      ? (() => {
+          const l = parseLocationFromMatch(toMatch);
+          return l ? locationToFeature(l) : undefined;
+        })()
+      : undefined,
+  };
+}
+
+export function patchQueryLocation(
+  query: string,
+  field: 'from' | 'to',
+  loc: VariablesLocation,
+): string {
+  const pattern = field === 'from' ? FROM_PATTERN : TO_PATTERN;
+  const replacement = `${field}: ${locationToGraphQL(loc)}`;
+  return query.replace(pattern, replacement);
+}
+
+/**
+ * Removes any existing `pageCursor` from the query and injects the given one as
+ * the first argument of the `trip(...)` call.
+ */
+export function injectPageCursor(query: string, cursor: string): string {
+  const withoutCursor = query.replace(/\s*pageCursor:\s*"[^"]*"\n?/, '');
+  return withoutCursor.replace(
+    /trip\s*\(/,
+    `trip(\n    pageCursor: "${cursor}"`,
+  );
+}
+
+// Mirrors the assistant's initial search behaviour: keep following
+// `nextPageCursor` until we have collected enough trip patterns, or we have
+// made too many attempts. See page-modules/assistant/client/journey-planner.
+export const WANTED_TRIP_PATTERNS = 8;
+export const MAX_SEARCH_ATTEMPTS = 5;
+
+export const DEFAULT_FROM: VariablesLocation = {
+  place: 'NSR:StopPlace:41613',
+  coordinates: { latitude: 63.431034, longitude: 10.392007 },
+  name: 'Prinsens gate',
+};
+
+export const DEFAULT_TO: VariablesLocation = {
+  place: 'NSR:StopPlace:42625',
+  coordinates: { latitude: 63.435085, longitude: 10.457026 },
+  name: 'Strindheim',
+};
+
+export function buildDefaultInlinedQuery(fragments: string): string {
+  return `{
+  trip(
+    from: ${locationToGraphQL(DEFAULT_FROM)}
+    to: ${locationToGraphQL(DEFAULT_TO)}
+    arriveBy: false
+    numTripPatterns: 3
+    waitReluctance: 1
+    walkReluctance: 4
+    transferPenalty: 10
+    searchWindow: 120
+    includeRealtimeCancellations: true
+    includePlannedCancellations: true
+  ) {
+    nextPageCursor
+    previousPageCursor
+    metadata {
+      searchWindowUsed
+    }
+    tripPatterns {
+      ...tripPatternWithDetails
+    }
+  }
+}
+
+${fragments}`;
+}
+
+export type FareZone = { id: string; name?: string };
+// The base leg shape — all the fields the zone/ticket helpers read live here.
+// (Array methods like .slice()/.map() on the extended trip legs resolve to this
+// base type, so typing against it keeps the helpers assignable from both.)
+type TripLeg = LegWithDetailsFragment;
+
+function collectFareZones(legs: TripLeg[]): FareZone[] {
+  const zones: FareZone[] = [];
+  const seen = new Set<string>();
+
+  for (const leg of legs) {
+    for (const place of [leg.fromPlace, leg.toPlace]) {
+      for (const zone of place?.quay?.tariffZones ?? []) {
+        if (
+          zone?.id &&
+          zone.id.includes(`${currentOrg.toUpperCase()}:FareZone`) &&
+          !seen.has(zone.id)
+        ) {
+          seen.add(zone.id);
+          zones.push({ id: zone.id, name: zone.name ?? undefined });
+        }
+      }
+    }
+  }
+
+  return zones;
+}
+
+/**
+ * Collects the unique fare zones (ids containing "<ORG>:FareZone") the trip
+ * passes through, in the order they are first encountered, from the quays of
+ * each leg's from/to place. Deduped by zone id.
+ */
+export function getTripPatternZones(
+  tripPattern: ExtendedTripPatternWithDetailsType,
+): FareZone[] {
+  return collectFareZones(tripPattern.legs);
+}
+
+// Tariff rules for the running org (currentOrg is fixed per process). When the
+// org has no tariff config, the calculator produces no ticket plan.
+const ACTIVE_TARIFF: TariffConfig | null = TARIFF_CONFIGS[currentOrg] ?? null;
+
+// All-pairs billed zone count for the active org = shortest connection hops + 1.
+const ACTIVE_ZONE_COUNT: Record<string, Record<string, number>> = (() => {
+  if (!ACTIVE_TARIFF) return {};
+  const conns = ACTIVE_TARIFF.connections;
+  const names = Object.keys(conns);
+  const matrix: Record<string, Record<string, number>> = {};
+  for (const start of names) {
+    const dist: Record<string, number> = { [start]: 0 };
+    const queue = [start];
+    while (queue.length) {
+      const u = queue.shift() as string;
+      for (const v of conns[u]) {
+        if (!(v in dist)) {
+          dist[v] = dist[u] + 1;
+          queue.push(v);
+        }
+      }
+    }
+    matrix[start] = {};
+    for (const n of names) matrix[start][n] = (dist[n] ?? Infinity) + 1;
+  }
+  return matrix;
+})();
+
+function zoneValidityMinutes(zoneCount: number, t: TariffConfig): number {
+  return (
+    t.baseValidityMin + t.extraZoneValidityMin * Math.max(0, zoneCount - 1)
+  );
+}
+
+function singleTicketPriceKr(zoneCount: number, t: TariffConfig): number {
+  return t.singleTicketBaseKr + t.extraZoneKr * Math.max(0, zoneCount - 1);
+}
+
+type PlaceWithZones = {
+  quay?: { tariffZones?: { id: string; name?: string }[] } | null;
+};
+
+function fareZoneIdOfPlace(place: PlaceWithZones | undefined): string | null {
+  return (
+    place?.quay?.tariffZones?.find((z) =>
+      z?.id?.includes(`${currentOrg.toUpperCase()}:FareZone`),
+    )?.id ?? null
+  );
+}
+
+/**
+ * Billed number of zones between two fare zones, via the active org's connection
+ * graph (neighbours = 2 zones, same zone = 1). Returns null when either zone is
+ * unknown, so callers can fall back to counting zones travelled.
+ */
+function zoneCountBetween(
+  fromId: string | null,
+  toId: string | null,
+  t: TariffConfig,
+): number | null {
+  if (!fromId || !toId) return null;
+  const a = t.zoneNames[fromId];
+  const b = t.zoneNames[toId];
+  if (!a || !b) return null;
+  const count = ACTIVE_ZONE_COUNT[a]?.[b];
+  return Number.isFinite(count) ? count : null;
+}
+
+const osloTimeFormatter = new Intl.DateTimeFormat('no-NO', {
+  hour: '2-digit',
+  minute: '2-digit',
+  timeZone: 'Europe/Oslo',
+});
+
+export function formatOsloTime(epochMs: number): string {
+  return osloTimeFormatter.format(epochMs);
+}
+
+function legLabel(leg: TripLeg): string {
+  return leg.line?.publicCode ?? leg.line?.name ?? leg.mode;
+}
+
+export type TicketSegment = {
+  fromZone: string;
+  toZone: string;
+  zoneCount: number;
+  validityMinutes: number;
+  priceKr: number;
+  activatedAtMs: number;
+  expiresAtMs: number;
+  boardings: { timeMs: number; label: string }[];
+};
+
+export type TicketPlan = {
+  tickets: TicketSegment[];
+  singleTotalKr: number;
+  dayTicketKr: number;
+  // True when buying single tickets is no longer worth it (more than two are
+  // needed, or they cost more than a day ticket) and a 24-hour ticket is the
+  // better suggestion.
+  recommendDayTicket: boolean;
+};
+
+/**
+ * Greedily splits a trip into the single tickets a traveller must buy, applying
+ * AtB's rules: a ticket only needs to be valid at boarding, and the billed zone
+ * count between two zones comes from the connection graph (pass-through zones
+ * aren't charged — neighbours are 2 zones).
+ *
+ * Each ticket is activated at a boarding and billed `origin → the destination of
+ * the last leg it actually covers` (not the journey's final zone), so a
+ * force-split trip pays only for the zones ridden on each ticket. A ticket is
+ * extended to the next boarding only while a ticket spanning origin → that
+ * boarding's destination would still be valid at that boarding's time
+ * (`90 + 60·(zones − 1)` min); the first boarding that no longer fits starts the
+ * next ticket. Returns null when the org has no tariff config or the trip has no
+ * transit legs.
+ */
+export function computeTicketPlan(
+  tripPattern: ExtendedTripPatternWithDetailsType,
+): TicketPlan | null {
+  const tariff = ACTIVE_TARIFF;
+  // No tariff config for this org → no ticket plan (rather than wrong numbers).
+  if (!tariff) return null;
+
+  const legs = tripPattern.legs;
+  // Index of each transit leg (a "boarding"); walk legs need no ticket.
+  const boardingLegs = legs
+    .map((leg, index) => ({ leg, index }))
+    .filter(({ leg }) => leg.mode !== Mode.Foot);
+
+  if (boardingLegs.length === 0) return null;
+
+  // Billed zones between two fare zones via the connection graph, falling back
+  // to the literal zones travelled across the covered legs if a zone id can't
+  // be resolved.
+  const billedZones = (
+    fromId: string | null,
+    toId: string | null,
+    fromLegIndex: number,
+    toLegIndex: number,
+  ): number => {
+    const connection = zoneCountBetween(fromId, toId, tariff);
+    if (connection != null) return connection;
+    return Math.max(
+      1,
+      collectFareZones(legs.slice(fromLegIndex, toLegIndex + 1)).length,
+    );
+  };
+
+  const tickets: TicketSegment[] = [];
+  let cursor = 0;
+
+  while (cursor < boardingLegs.length) {
+    const start = boardingLegs[cursor];
+    const originZoneId = fareZoneIdOfPlace(start.leg.fromPlace);
+    const activatedAtMs = new Date(start.leg.expectedStartTime).getTime();
+
+    // Extend to cover the next boarding only while a ticket spanning origin →
+    // that boarding's destination would still be valid at its boarding time.
+    let last = cursor;
+    while (last + 1 < boardingLegs.length) {
+      const next = boardingLegs[last + 1];
+      const candidateDestId = fareZoneIdOfPlace(next.leg.toPlace);
+      const candidateZones = billedZones(
+        originZoneId,
+        candidateDestId,
+        start.index,
+        next.index,
+      );
+      const candidateExpiry =
+        activatedAtMs + zoneValidityMinutes(candidateZones, tariff) * 60_000;
+      if (new Date(next.leg.expectedStartTime).getTime() > candidateExpiry) {
+        break;
+      }
+      last += 1;
+    }
+
+    // The ticket is billed origin → the last leg it actually covers.
+    const lastEntry = boardingLegs[last];
+    const destZoneId = fareZoneIdOfPlace(lastEntry.leg.toPlace);
+    const zoneCount = billedZones(
+      originZoneId,
+      destZoneId,
+      start.index,
+      lastEntry.index,
+    );
+    const validityMinutes = zoneValidityMinutes(zoneCount, tariff);
+    const priceKr = singleTicketPriceKr(zoneCount, tariff);
+    const expiresAtMs = activatedAtMs + validityMinutes * 60_000;
+
+    const covered = collectFareZones(
+      legs.slice(start.index, lastEntry.index + 1),
+    );
+    const boardings = boardingLegs.slice(cursor, last + 1).map((entry) => ({
+      timeMs: new Date(entry.leg.expectedStartTime).getTime(),
+      label: legLabel(entry.leg),
+    }));
+
+    tickets.push({
+      fromZone: originZoneId
+        ? (tariff.zoneNames[originZoneId] ?? originZoneId)
+        : (covered[0]?.name ?? '?'),
+      toZone: destZoneId
+        ? (tariff.zoneNames[destZoneId] ?? destZoneId)
+        : (covered[covered.length - 1]?.name ?? '?'),
+      zoneCount,
+      validityMinutes,
+      priceKr,
+      activatedAtMs,
+      expiresAtMs,
+      boardings,
+    });
+
+    cursor = last + 1;
+  }
+
+  const singleTotalKr = tickets.reduce((sum, t) => sum + t.priceKr, 0);
+
+  // The day ticket is valid in a single zone only, so it can replace the single
+  // tickets just when the whole trip stays within one zone (every ticket is one
+  // zone). It's the better buy once more than `maxSingleTicketsBeforeDayTicket`
+  // single tickets are needed — at 3 the price ties at 150 kr, but the day
+  // ticket is valid 24h instead of 3 × 90 min.
+  const singleZoneTrip = tickets.every((t) => t.zoneCount === 1);
+  const recommendDayTicket =
+    singleZoneTrip &&
+    tickets.length > tariff.maxSingleTicketsBeforeDayTicket;
+
+  return {
+    tickets,
+    singleTotalKr,
+    dayTicketKr: tariff.dayTicketKr,
+    recommendDayTicket,
+  };
+}

--- a/src/page-modules/dev/trip-pattern/utils.ts
+++ b/src/page-modules/dev/trip-pattern/utils.ts
@@ -506,8 +506,7 @@ export function computeTicketPlan(
   // ticket is valid 24h instead of 3 × 90 min.
   const singleZoneTrip = tickets.every((t) => t.zoneCount === 1);
   const recommendDayTicket =
-    singleZoneTrip &&
-    tickets.length > tariff.maxSingleTicketsBeforeDayTicket;
+    singleZoneTrip && tickets.length > tariff.maxSingleTicketsBeforeDayTicket;
 
   return {
     tickets,

--- a/src/pages/dev/trip-pattern.module.css
+++ b/src/pages/dev/trip-pattern.module.css
@@ -129,6 +129,48 @@
   min-width: 0;
 }
 
+.ticketPlan {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-top: 0.25rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.8rem;
+  border-radius: 4px;
+  border: 1px solid var(--color-background-neutral-2-background, #e0e0e0);
+  background: var(--color-background-neutral-1-background, #f5f5f5);
+}
+
+.ticketPlanWarn {
+  border-color: #d9a400;
+  background: #fff8e6;
+}
+
+.ticketPlanHeader {
+  font-weight: 600;
+}
+
+.ticketRow {
+  display: flex;
+  flex-direction: column;
+}
+
+.ticketBoardings,
+.ticketTrigger {
+  color: var(--color-background-neutral-0-foreground, #555);
+  font-size: 0.75rem;
+}
+
+.ticketTrigger {
+  font-style: italic;
+}
+
+.ticketRecommendation {
+  margin-top: 0.25rem;
+  font-weight: 600;
+  color: #8a6d00;
+}
+
 .rawResponse {
   margin-top: 0.5rem;
 }

--- a/src/pages/dev/trip-pattern.module.css
+++ b/src/pages/dev/trip-pattern.module.css
@@ -129,47 +129,6 @@
   min-width: 0;
 }
 
-.ticketPlan {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  margin-top: 0.25rem;
-  padding: 0.5rem 0.75rem;
-  font-size: 0.8rem;
-  border-radius: 4px;
-  border: 1px solid var(--color-background-neutral-2-background, #e0e0e0);
-  background: var(--color-background-neutral-1-background, #f5f5f5);
-}
-
-.ticketPlanWarn {
-  border-color: #d9a400;
-  background: #fff8e6;
-}
-
-.ticketPlanHeader {
-  font-weight: 600;
-}
-
-.ticketRow {
-  display: flex;
-  flex-direction: column;
-}
-
-.ticketBoardings,
-.ticketTrigger {
-  color: var(--color-background-neutral-0-foreground, #555);
-  font-size: 0.75rem;
-}
-
-.ticketTrigger {
-  font-style: italic;
-}
-
-.ticketRecommendation {
-  margin-top: 0.25rem;
-  font-weight: 600;
-  color: #8a6d00;
-}
 
 .rawResponse {
   margin-top: 0.5rem;

--- a/src/pages/dev/trip-pattern.module.css
+++ b/src/pages/dev/trip-pattern.module.css
@@ -129,7 +129,6 @@
   min-width: 0;
 }
 
-
 .rawResponse {
   margin-top: 0.5rem;
 }

--- a/src/pages/dev/trip-pattern.tsx
+++ b/src/pages/dev/trip-pattern.tsx
@@ -12,9 +12,7 @@ import type { GeocoderFeature } from '@atb/modules/geocoder';
 import Search from '@atb/components/search';
 import { TransportModeFilter } from '@atb/modules/transport-mode';
 import { getTransportModeFilter } from '@atb/modules/firebase/transport-mode-filter';
-import type { TransportModeFilterOptionType } from '@atb-as/config-specs';
 import useSWRImmutable from 'swr/immutable';
-import { uniq } from 'lodash';
 import dynamic from 'next/dynamic';
 import style from './trip-pattern.module.css';
 import { currentOrg } from '@atb/modules/org-data';
@@ -25,6 +23,23 @@ import nfk from '../../../orgs/nfk.json';
 import troms from '../../../orgs/troms.json';
 import vkt from '../../../orgs/vkt.json';
 import farte from '../../../orgs/farte.json';
+import {
+  featureToLocation,
+  locationToFeature,
+  patchQueryLocation,
+  buildModesGraphQL,
+  patchQueryModes,
+  patchQueryAuthorities,
+  parseLocationsFromQuery,
+  injectPageCursor,
+  buildDefaultInlinedQuery,
+  computeTicketPlan,
+  formatOsloTime,
+  WANTED_TRIP_PATTERNS,
+  MAX_SEARCH_ATTEMPTS,
+  DEFAULT_FROM,
+  DEFAULT_TO,
+} from '@atb/page-modules/dev/trip-pattern/utils';
 
 const GraphQLEditor = dynamic(() => import('@atb/components/graphql-editor'), {
   ssr: false,
@@ -38,237 +53,6 @@ type DevTripPatternPageProps = WithGlobalData<{
   defaultGqlQuery: string;
   fragments: string;
 }>;
-
-type VariablesLocation = {
-  place: string;
-  coordinates: { latitude: number; longitude: number };
-  name: string;
-};
-
-function featureToLocation(feature: GeocoderFeature): VariablesLocation {
-  return {
-    place: feature.id,
-    coordinates: {
-      latitude: feature.geometry.coordinates[1],
-      longitude: feature.geometry.coordinates[0],
-    },
-    name: feature.name,
-  };
-}
-
-function locationToFeature(loc: VariablesLocation): GeocoderFeature {
-  return {
-    id: loc.place,
-    name: loc.name,
-    locality: null,
-    category: [],
-    layer: 'venue',
-    geometry: {
-      coordinates: [loc.coordinates.longitude, loc.coordinates.latitude],
-    },
-  };
-}
-
-function locationToGraphQL(loc: VariablesLocation): string {
-  return `{
-      place: "${loc.place}"
-      coordinates: {
-        latitude: ${loc.coordinates.latitude}
-        longitude: ${loc.coordinates.longitude}
-      }
-      name: "${loc.name}"
-    }`;
-}
-
-const FROM_PATTERN = /from:\s*\{[\s\S]*?coordinates:\s*\{[\s\S]*?\}[\s\S]*?\}/;
-const TO_PATTERN = /to:\s*\{[\s\S]*?coordinates:\s*\{[\s\S]*?\}[\s\S]*?\}/;
-// Matches the `modes: { ... }` block injected by the transport mode filter.
-// The `transportModes` list is always rendered inline (single line), so the
-// first newline-indented `}` is the closing brace of the modes block.
-const MODES_PATTERN = /\n\s*modes:\s*\{[\s\S]*?\n\s*\}/;
-
-/**
- * Builds the inline GraphQL `modes: { ... }` block from the selected transport
- * mode filter options, mirroring how the assistant maps the filter to the
- * JourneyPlanner `Modes` input (see server/journey-planner/mappers.ts).
- *
- * Returns `null` when no filter should be applied (nothing selected yet, or
- * every option selected — both mean "all modes", same as the assistant).
- */
-function buildModesGraphQL(
-  options: TransportModeFilterOptionType[],
-  filterState: string[] | null,
-): string | null {
-  // `null` means no filter; all options selected is equivalent to no filter.
-  if (!filterState) return null;
-  if (filterState.length === options.length) return null;
-
-  const selectedModes = options
-    .filter((option) => filterState.includes(option.id))
-    .flatMap((option) => option.modes);
-
-  const transportModes = uniq(
-    selectedModes.map((mode) => {
-      const subModes =
-        mode.transportSubModes && mode.transportSubModes.length > 0
-          ? `, transportSubModes: [${mode.transportSubModes.join(', ')}]`
-          : '';
-      return `{ transportMode: ${mode.transportMode}${subModes} }`;
-    }),
-  );
-
-  return `    modes: {
-      accessMode: foot
-      egressMode: foot
-      transportModes: [${transportModes.join(', ')}]
-    }`;
-}
-
-/**
- * Removes any existing `modes` block from the query and, when a block is
- * provided, injects it as the first argument of the `trip(...)` call.
- */
-function patchQueryModes(query: string, modesBlock: string | null): string {
-  const withoutModes = query.replace(MODES_PATTERN, '');
-  if (!modesBlock) return withoutModes;
-  return withoutModes.replace(/trip\s*\(/, `trip(\n${modesBlock}`);
-}
-
-// Matches the single-line `whiteListed: { authorities: [...] }` block injected
-// by the authority toggle, so it can be removed/replaced idempotently.
-const WHITELISTED_AUTHORITIES_PATTERN =
-  /\n\s*whiteListed:\s*\{\s*authorities:[^}]*\}/;
-
-/**
- * Removes any injected authority whitelist and, when an authority id is given,
- * injects `whiteListed: { authorities: [...] }` as the first argument of
- * `trip(...)`. This filters server-side: the JourneyPlanner only returns trips
- * operated by the whitelisted authority — i.e. the ones the sales endpoint can
- * price.
- */
-function patchQueryAuthorities(
-  query: string,
-  authorityId: string | null,
-): string {
-  const without = query.replace(WHITELISTED_AUTHORITIES_PATTERN, '');
-  if (!authorityId) return without;
-  return without.replace(
-    /trip\s*\(/,
-    `trip(\n    whiteListed: { authorities: ["${authorityId}"] }`,
-  );
-}
-
-function parseLocationFromMatch(match: string): VariablesLocation | undefined {
-  try {
-    const place = match.match(/place:\s*"([^"]+)"/)?.[1] ?? '';
-    const lat = match.match(/latitude:\s*([\d.-]+)/)?.[1];
-    const lon = match.match(/longitude:\s*([\d.-]+)/)?.[1];
-    const name = match.match(/name:\s*"([^"]+)"/)?.[1];
-    if (name) {
-      return {
-        place,
-        coordinates: {
-          latitude: lat ? parseFloat(lat) : 0,
-          longitude: lon ? parseFloat(lon) : 0,
-        },
-        name,
-      };
-    }
-  } catch {
-    // ignore
-  }
-  return undefined;
-}
-
-function parseLocationsFromQuery(query: string): {
-  from: GeocoderFeature | undefined;
-  to: GeocoderFeature | undefined;
-} {
-  const fromMatch = query.match(FROM_PATTERN)?.[0];
-  const toMatch = query.match(TO_PATTERN)?.[0];
-  return {
-    from: fromMatch
-      ? (() => {
-          const l = parseLocationFromMatch(fromMatch);
-          return l ? locationToFeature(l) : undefined;
-        })()
-      : undefined,
-    to: toMatch
-      ? (() => {
-          const l = parseLocationFromMatch(toMatch);
-          return l ? locationToFeature(l) : undefined;
-        })()
-      : undefined,
-  };
-}
-
-function patchQueryLocation(
-  query: string,
-  field: 'from' | 'to',
-  loc: VariablesLocation,
-): string {
-  const pattern = field === 'from' ? FROM_PATTERN : TO_PATTERN;
-  const replacement = `${field}: ${locationToGraphQL(loc)}`;
-  return query.replace(pattern, replacement);
-}
-
-/**
- * Removes any existing `pageCursor` from the query and injects the given one as
- * the first argument of the `trip(...)` call.
- */
-function injectPageCursor(query: string, cursor: string): string {
-  const withoutCursor = query.replace(/\s*pageCursor:\s*"[^"]*"\n?/, '');
-  return withoutCursor.replace(
-    /trip\s*\(/,
-    `trip(\n    pageCursor: "${cursor}"`,
-  );
-}
-
-// Mirrors the assistant's initial search behaviour: keep following
-// `nextPageCursor` until we have collected enough trip patterns, or we have
-// made too many attempts. See page-modules/assistant/client/journey-planner.
-const WANTED_TRIP_PATTERNS = 8;
-const MAX_SEARCH_ATTEMPTS = 5;
-
-const DEFAULT_FROM: VariablesLocation = {
-  place: 'NSR:StopPlace:41613',
-  coordinates: { latitude: 63.431034, longitude: 10.392007 },
-  name: 'Prinsens gate',
-};
-
-const DEFAULT_TO: VariablesLocation = {
-  place: 'NSR:StopPlace:42625',
-  coordinates: { latitude: 63.435085, longitude: 10.457026 },
-  name: 'Strindheim',
-};
-
-function buildDefaultInlinedQuery(fragments: string): string {
-  return `{
-  trip(
-    from: ${locationToGraphQL(DEFAULT_FROM)}
-    to: ${locationToGraphQL(DEFAULT_TO)}
-    arriveBy: false
-    numTripPatterns: 3
-    waitReluctance: 1
-    walkReluctance: 4
-    transferPenalty: 10
-    searchWindow: 120
-    includeRealtimeCancellations: true
-    includePlannedCancellations: true
-  ) {
-    nextPageCursor
-    previousPageCursor
-    metadata {
-      searchWindowUsed
-    }
-    tripPatterns {
-      ...tripPatternWithDetails
-    }
-  }
-}
-
-${fragments}`;
-}
 
 // Authorities selectable in the dev config panel, the current org's first.
 const ALL_AUTHORITIES = [atb, nfk, fram, troms, vkt, farte]
@@ -307,6 +91,8 @@ const DevTripPatternPage: NextPage<DevTripPatternPageProps> = (props) => {
   const [authorityFilter, setAuthorityFilter] = useState<string | null>(null);
   // Toggles the per-trip inspector panels in the results.
   const [showInspector, setShowInspector] = useState(false);
+  // Toggles the per-trip ticket-plan / day-ticket recommendation in the results.
+  const [showTicketPlan, setShowTicketPlan] = useState(false);
 
   // Loaded the same way as the assistant layout so the available transport
   // modes match the real travel search filters.
@@ -552,6 +338,14 @@ const DevTripPatternPage: NextPage<DevTripPatternPageProps> = (props) => {
                 onChange={(e) => setShowInspector(e.target.checked)}
               />
             </label>
+            <label className={style.fieldRow}>
+              <span className={style.fieldRowLabel}>Ticket plan</span>
+              <input
+                type="checkbox"
+                checked={showTicketPlan}
+                onChange={(e) => setShowTicketPlan(e.target.checked)}
+              />
+            </label>
           </div>
         </div>
 
@@ -562,11 +356,20 @@ const DevTripPatternPage: NextPage<DevTripPatternPageProps> = (props) => {
                 <span className={style.label}>Trip patterns</span>
                 <div className={style.tripPatterns}>
                   {result.tripPatterns.map((tripPattern, i) => {
+                    const plan = showTicketPlan
+                      ? computeTicketPlan(tripPattern)
+                      : null;
                     return (
                       <div
                         key={`${runCount}-${i}-${tripPattern.compressedQuery}`}
                         className={style.tripPatternRow}
                       >
+                        {showInspector && (
+                          <TripInspector
+                            tripPattern={tripPattern}
+                            delay={i * 0.05}
+                          />
+                        )}
                         <div className={style.tripPatternMain}>
                           <TripPattern
                             tripPattern={tripPattern}
@@ -574,11 +377,59 @@ const DevTripPatternPage: NextPage<DevTripPatternPageProps> = (props) => {
                             index={i}
                           />
                         </div>
-                        {showInspector && (
-                          <TripInspector
-                            tripPattern={tripPattern}
-                            delay={i * 0.05}
-                          />
+                        {showTicketPlan && plan && (
+                          <div
+                            className={`${style.ticketPlan} ${
+                              plan.recommendDayTicket
+                                ? style.ticketPlanWarn
+                                : ''
+                            }`}
+                          >
+                            <span className={style.ticketPlanHeader}>
+                              {plan.tickets.length > 1
+                                ? `${plan.recommendDayTicket ? '⚠ ' : ''}${
+                                    plan.tickets.length
+                                  } single tickets · ${plan.singleTotalKr} kr`
+                                : `1 ticket covers this trip · ${plan.singleTotalKr} kr`}
+                            </span>
+                            {plan.tickets.map((ticket, ti) => (
+                              <div key={ti} className={style.ticketRow}>
+                                <span>
+                                  {`Ticket ${ti + 1}: ${ticket.fromZone}→${
+                                    ticket.toZone
+                                  } · ${ticket.zoneCount} ${
+                                    ticket.zoneCount === 1 ? 'zone' : 'zones'
+                                  } · ${ticket.priceKr} kr · ${ticket.validityMinutes} min · ${formatOsloTime(
+                                    ticket.activatedAtMs,
+                                  )}–${formatOsloTime(ticket.expiresAtMs)}`}
+                                </span>
+                                <span className={style.ticketBoardings}>
+                                  {`covers: ${ticket.boardings
+                                    .map(
+                                      (b) =>
+                                        `${formatOsloTime(b.timeMs)} (${b.label})`,
+                                    )
+                                    .join(', ')}`}
+                                </span>
+                                {ti > 0 && (
+                                  <span className={style.ticketTrigger}>
+                                    {`new ticket — previous expired ${formatOsloTime(
+                                      plan.tickets[ti - 1].expiresAtMs,
+                                    )}`}
+                                  </span>
+                                )}
+                              </div>
+                            ))}
+                            {plan.recommendDayTicket && (
+                              <span className={style.ticketRecommendation}>
+                                {`💡 Buy a 24-hour ticket (${plan.dayTicketKr} kr, valid 24h in zone ${plan.tickets[0].fromZone}) instead — ${
+                                  plan.singleTotalKr > plan.dayTicketKr
+                                    ? `saves ${plan.singleTotalKr - plan.dayTicketKr} kr`
+                                    : 'same price but valid all day'
+                                }`}
+                              </span>
+                            )}
+                          </div>
                         )}
                       </div>
                     );

--- a/src/pages/dev/trip-pattern.tsx
+++ b/src/pages/dev/trip-pattern.tsx
@@ -17,6 +17,7 @@ import dynamic from 'next/dynamic';
 import style from './trip-pattern.module.css';
 import { currentOrg } from '@atb/modules/org-data';
 import { TripInspector } from '@atb/page-modules/dev/trip-inspector';
+import { TicketPlanPanel } from '@atb/page-modules/dev/ticket-plan';
 import atb from '../../../orgs/atb.json';
 import fram from '../../../orgs/fram.json';
 import nfk from '../../../orgs/nfk.json';
@@ -33,8 +34,6 @@ import {
   parseLocationsFromQuery,
   injectPageCursor,
   buildDefaultInlinedQuery,
-  computeTicketPlan,
-  formatOsloTime,
   WANTED_TRIP_PATTERNS,
   MAX_SEARCH_ATTEMPTS,
   DEFAULT_FROM,
@@ -355,85 +354,29 @@ const DevTripPatternPage: NextPage<DevTripPatternPageProps> = (props) => {
               <div className={style.section}>
                 <span className={style.label}>Trip patterns</span>
                 <div className={style.tripPatterns}>
-                  {result.tripPatterns.map((tripPattern, i) => {
-                    const plan = showTicketPlan
-                      ? computeTicketPlan(tripPattern)
-                      : null;
-                    return (
-                      <div
-                        key={`${runCount}-${i}-${tripPattern.compressedQuery}`}
-                        className={style.tripPatternRow}
-                      >
-                        {showInspector && (
-                          <TripInspector
-                            tripPattern={tripPattern}
-                            delay={i * 0.05}
-                          />
-                        )}
-                        <div className={style.tripPatternMain}>
-                          <TripPattern
-                            tripPattern={tripPattern}
-                            delay={i * 0.05}
-                            index={i}
-                          />
-                        </div>
-                        {showTicketPlan && plan && (
-                          <div
-                            className={`${style.ticketPlan} ${
-                              plan.recommendDayTicket
-                                ? style.ticketPlanWarn
-                                : ''
-                            }`}
-                          >
-                            <span className={style.ticketPlanHeader}>
-                              {plan.tickets.length > 1
-                                ? `${plan.recommendDayTicket ? '⚠ ' : ''}${
-                                    plan.tickets.length
-                                  } single tickets · ${plan.singleTotalKr} kr`
-                                : `1 ticket covers this trip · ${plan.singleTotalKr} kr`}
-                            </span>
-                            {plan.tickets.map((ticket, ti) => (
-                              <div key={ti} className={style.ticketRow}>
-                                <span>
-                                  {`Ticket ${ti + 1}: ${ticket.fromZone}→${
-                                    ticket.toZone
-                                  } · ${ticket.zoneCount} ${
-                                    ticket.zoneCount === 1 ? 'zone' : 'zones'
-                                  } · ${ticket.priceKr} kr · ${ticket.validityMinutes} min · ${formatOsloTime(
-                                    ticket.activatedAtMs,
-                                  )}–${formatOsloTime(ticket.expiresAtMs)}`}
-                                </span>
-                                <span className={style.ticketBoardings}>
-                                  {`covers: ${ticket.boardings
-                                    .map(
-                                      (b) =>
-                                        `${formatOsloTime(b.timeMs)} (${b.label})`,
-                                    )
-                                    .join(', ')}`}
-                                </span>
-                                {ti > 0 && (
-                                  <span className={style.ticketTrigger}>
-                                    {`new ticket — previous expired ${formatOsloTime(
-                                      plan.tickets[ti - 1].expiresAtMs,
-                                    )}`}
-                                  </span>
-                                )}
-                              </div>
-                            ))}
-                            {plan.recommendDayTicket && (
-                              <span className={style.ticketRecommendation}>
-                                {`💡 Buy a 24-hour ticket (${plan.dayTicketKr} kr, valid 24h in zone ${plan.tickets[0].fromZone}) instead — ${
-                                  plan.singleTotalKr > plan.dayTicketKr
-                                    ? `saves ${plan.singleTotalKr - plan.dayTicketKr} kr`
-                                    : 'same price but valid all day'
-                                }`}
-                              </span>
-                            )}
-                          </div>
-                        )}
+                  {result.tripPatterns.map((tripPattern, i) => (
+                    <div
+                      key={`${runCount}-${i}-${tripPattern.compressedQuery}`}
+                      className={style.tripPatternRow}
+                    >
+                      {showInspector && (
+                        <TripInspector
+                          tripPattern={tripPattern}
+                          delay={i * 0.05}
+                        />
+                      )}
+                      <div className={style.tripPatternMain}>
+                        <TripPattern
+                          tripPattern={tripPattern}
+                          delay={i * 0.05}
+                          index={i}
+                        />
                       </div>
-                    );
-                  })}
+                      {showTicketPlan && (
+                        <TicketPlanPanel tripPattern={tripPattern} />
+                      )}
+                    </div>
+                  ))}
                 </div>
                 {nextPageCursor && (
                   <button

--- a/src/pages/dev/trip-pattern.tsx
+++ b/src/pages/dev/trip-pattern.tsx
@@ -18,6 +18,8 @@ import style from './trip-pattern.module.css';
 import { currentOrg } from '@atb/modules/org-data';
 import { TripInspector } from '@atb/page-modules/dev/trip-inspector';
 import { TicketPlanPanel } from '@atb/page-modules/dev/ticket-plan';
+import { OwnedTicketsEditor } from '@atb/page-modules/dev/owned-tickets';
+import type { OwnedTicket } from '@atb/page-modules/dev/trip-pattern/utils';
 import atb from '../../../orgs/atb.json';
 import fram from '../../../orgs/fram.json';
 import nfk from '../../../orgs/nfk.json';
@@ -92,6 +94,9 @@ const DevTripPatternPage: NextPage<DevTripPatternPageProps> = (props) => {
   const [showInspector, setShowInspector] = useState(false);
   // Toggles the per-trip ticket-plan / day-ticket recommendation in the results.
   const [showTicketPlan, setShowTicketPlan] = useState(false);
+  // Tickets the traveller already holds; subtracted from every trip's route by
+  // the ticket plan.
+  const [ownedTickets, setOwnedTickets] = useState<OwnedTicket[]>([]);
 
   // Loaded the same way as the assistant layout so the available transport
   // modes match the real travel search filters.
@@ -348,6 +353,18 @@ const DevTripPatternPage: NextPage<DevTripPatternPageProps> = (props) => {
           </div>
         </div>
 
+        {showTicketPlan && (
+          <div className={style.fieldBlock}>
+            <span className={style.subLabel}>Owned tickets</span>
+            <div className={style.fieldPanel}>
+              <OwnedTicketsEditor
+                value={ownedTickets}
+                onChange={setOwnedTickets}
+              />
+            </div>
+          </div>
+        )}
+
         {result && (
           <>
             {result.tripPatterns && result.tripPatterns.length > 0 && (
@@ -373,7 +390,10 @@ const DevTripPatternPage: NextPage<DevTripPatternPageProps> = (props) => {
                         />
                       </div>
                       {showTicketPlan && (
-                        <TicketPlanPanel tripPattern={tripPattern} />
+                        <TicketPlanPanel
+                          tripPattern={tripPattern}
+                          ownedTickets={ownedTickets}
+                        />
                       )}
                     </div>
                   ))}


### PR DESCRIPTION
Dev-mode ticket calculator for the trip-pattern test rig:

- Adds owned ticket simulator, which simulates the ticket a user may have, along with possible zones, single/24h/period ticket, and remaining minutes. For each trip in the results it estimates which/how many tickets a traveller must buy, and whether a 24-hour ticket is the better deal. This supports validating the sales ticket-recommendation system against real journeys. It's shown per-trip behind a new **"Ticket plan"** view toggle (alongside the existing "Inspector" toggle).

- Adds zone connection and pricing rule for AtB.

<img width="904" height="645" alt="image" src="https://github.com/user-attachments/assets/834c28da-243d-410a-a472-172e6e808f8b" />

<img width="893" height="649" alt="image" src="https://github.com/user-attachments/assets/8538098f-7f8f-4c4a-95d0-62c93c60da83" />

