### PR TITLE
docs: document how to enable dev mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,36 @@ To easily change organization, change `NEXT_PUBLIC_PLANNER_ORG_ID` in your
 pnpm refresh-assets
 ```
 
+## Developer mode
+
+Developer mode unlocks the debugging interface at `/dev/trip-pattern`, which
+lets you edit GraphQL queries directly, inspect trip patterns (including fare
+zones), filter by authority and transport mode, and view raw API responses.
+
+There is no UI toggle. It is gated by a browser cookie that you set manually.
+Both the `/dev/trip-pattern` page and the `/api/dev/graphql` endpoint return a
+not-found/forbidden response unless the cookie is present.
+
+The cookie gate works the same in every environment, so dev mode is also
+available in staging and production — set the cookie there and open
+`/dev/trip-pattern` on that environment's URL.
+
+To enable it, set the `dev-mode-enabled` cookie to `true`. The easiest way is to
+run this in your browser's DevTools console (with the app open):
+
+```js
+document.cookie = 'dev-mode-enabled=true; path=/; max-age=31536000';
+```
+
+Then reload and open `https://<host>/dev/trip-pattern` (e.g.
+`http://localhost:3000/dev/trip-pattern` when running locally). To disable it
+again, delete the cookie (e.g. via the Application → Cookies tab in DevTools) or
+expire it:
+
+```js
+document.cookie = 'dev-mode-enabled=; path=/; max-age=0';
+```
+
 ## Release
 
 ### Deploy to staging

--- a/README.md
+++ b/README.md
@@ -54,32 +54,17 @@ pnpm refresh-assets
 ## Developer mode
 
 Developer mode unlocks the debugging interface at `/dev/trip-pattern`, which
-lets you edit GraphQL queries directly, inspect trip patterns (including fare
-zones), filter by authority and transport mode, and view raw API responses.
+lets you edit GraphQL queries directly and see detailed metadata.
 
-There is no UI toggle. It is gated by a browser cookie that you set manually.
-Both the `/dev/trip-pattern` page and the `/api/dev/graphql` endpoint return a
-not-found/forbidden response unless the cookie is present.
-
-The cookie gate works the same in every environment, so dev mode is also
-available in staging and production — set the cookie there and open
-`/dev/trip-pattern` on that environment's URL.
-
-To enable it, set the `dev-mode-enabled` cookie to `true`. The easiest way is to
-run this in your browser's DevTools console (with the app open):
+To enable it, set the `dev-mode-enabled` cookie to `true`. Run this in the
+DevTools console:
 
 ```js
-document.cookie = 'dev-mode-enabled=true; path=/; max-age=31536000';
+document.cookie = 'dev-mode-enabled=true';
 ```
 
-Then reload and open `https://<host>/dev/trip-pattern` (e.g.
-`http://localhost:3000/dev/trip-pattern` when running locally). To disable it
-again, delete the cookie (e.g. via the Application → Cookies tab in DevTools) or
-expire it:
-
-```js
-document.cookie = 'dev-mode-enabled=; path=/; max-age=0';
-```
+Then load `/dev/trip-pattern`. This works in any environment — set the cookie on
+that host to use dev mode in staging or production too.
 
 ## Release
 


### PR DESCRIPTION
## What

Documents the previously-undocumented developer mode, so anyone on the team can find and enable the `/dev/trip-pattern` debugging interface without reading the source.

## Changes

- Add a "Developer mode" section to the README covering what the interface unlocks (GraphQL query editor, trip/fare-zone inspector, authority and transport-mode filters, raw response viewer).
- Explain that there is no UI toggle — it's gated by the `dev-mode-enabled` cookie — and give the DevTools snippets to enable and disable it.
- Note that the cookie gate is environment-agnostic, so dev mode also works in staging and production.